### PR TITLE
fix typo and watchman error

### DIFF
--- a/datahub-web/README.md
+++ b/datahub-web/README.md
@@ -40,7 +40,7 @@ Building will run the monorepo test suite and transpile the TypeScript applicati
 ## Developing & Running the web application
 Once [DataHub GMS](../gms) and the [DataHub Frontend](../datahub-frontend) are running you can start [DataHub Web](./) by running:
 ```sh
-datahub> ./gradew emberServe
+datahub> ./gradlew emberServe
 ```
 
 or

--- a/datahub-web/build.gradle
+++ b/datahub-web/build.gradle
@@ -49,7 +49,7 @@ task emberLintHbs(type: YarnTask, dependsOn: emberLintJs) {
 }
 
 task emberServe(type: YarnTask, dependsOn: emberLintHbs) {
-  args = ['workspace', yarnMainProject, 'run', 'start',  '--proxy', 'localhost:9001', '--secure-proxy=false']
+  args = ['workspace', yarnMainProject, 'run', 'start',  '--proxy', 'http://localhost:9001', '--secure-proxy=false']
 }
 
 task emberWorkspaceTest(type: YarnTask, dependsOn: emberLintHbs) {


### PR DESCRIPTION
1. adjust gradew to gradlew for doc
2. watchmman need proxy URL
```
Could not start watchman
Visit https://ember-cli.com/user-guide/#watchman for more info.
You need to include a protocol with the proxy URL.
Try --proxy http://localhost:9001

```