### PR TITLE
feat: Enable Failed Metadata Change Event for MCE Processor

### DIFF
--- a/docker/kafka/docker-compose.yml
+++ b/docker/kafka/docker-compose.yml
@@ -39,7 +39,8 @@ services:
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
                        cub kafka-ready -b broker:29092 1 60 && \
                        kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic MetadataAuditEvent && \
-                       kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic MetadataChangeEvent'"
+                       kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic MetadataChangeEvent && \
+                       kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic FailedMetadataChangeEvent'"
     environment:
       # The following settings are listed here only to satisfy the image's requirements.
       # We override the image's `command` anyways, hence this container will not start a broker.

--- a/docker/quickstart/docker-compose.yml
+++ b/docker/quickstart/docker-compose.yml
@@ -54,7 +54,8 @@ services:
     command: "bash -c 'echo Waiting for Kafka to be ready... && \
                        cub kafka-ready -b broker:29092 1 60 && \
                        kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic MetadataAuditEvent && \
-                       kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic MetadataChangeEvent'"
+                       kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic MetadataChangeEvent && \
+                       kafka-topics --create --if-not-exists --zookeeper zookeeper:2181 --partitions 1 --replication-factor 1 --topic FailedMetadataChangeEvent'"
     environment:
       # The following settings are listed here only to satisfy the image's requirements.
       # We override the image's `command` anyways, hence this container will not start a broker.

--- a/metadata-events/mxe-utils-avro-1.7/src/main/java/com/linkedin/metadata/EventUtils.java
+++ b/metadata-events/mxe-utils-avro-1.7/src/main/java/com/linkedin/metadata/EventUtils.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.linkedin.data.avro.DataTranslator;
 import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.mxe.FailedMetadataChangeEvent;
 import com.linkedin.mxe.MetadataAuditEvent;
 import com.linkedin.mxe.MetadataChangeEvent;
 import java.io.ByteArrayInputStream;
@@ -35,9 +36,14 @@ public class EventUtils {
   private static final Schema ORIGINAL_MAE_AVRO_SCHEMA =
       getAvroSchemaFromResource("avro/com/linkedin/mxe/MetadataAuditEvent.avsc");
 
+  private static final Schema ORIGINAL_FAILED_MCE_AVRO_SCHEMA =
+      getAvroSchemaFromResource("avro/com/linkedin/mxe/FailedMetadataChangeEvent.avsc");
+
   private static final Schema RENAMED_MCE_AVRO_SCHEMA = com.linkedin.pegasus2avro.mxe.MetadataChangeEvent.SCHEMA$;
 
   private static final Schema RENAMED_MAE_AVRO_SCHEMA = com.linkedin.pegasus2avro.mxe.MetadataAuditEvent.SCHEMA$;
+
+  private static final Schema RENAMED_FAILED_MCE_AVRO_SCHEMA = com.linkedin.pegasus2avro.mxe.FailedMetadataChangeEvent.SCHEMA$;
 
   private EventUtils() {
     // Util class
@@ -106,6 +112,20 @@ public class EventUtils {
         DataTranslator.dataMapToGenericRecord(event.data(), event.schema(), ORIGINAL_MCE_AVRO_SCHEMA);
     return renameSchemaNamespace(original, ORIGINAL_MCE_AVRO_SCHEMA, RENAMED_MCE_AVRO_SCHEMA);
   }
+
+    /**
+     * Converts a Pegasus Failed MCE into the equivalent Avro model as a {@link GenericRecord}.
+     *
+     * @param failedMetadataChangeEvent the Pegasus {@link FailedMetadataChangeEvent} model
+     * @return the Avro model with com.linkedin.pegasus2avro.mxe namesapce
+     * @throws IOException if the conversion fails
+     */
+    @Nonnull
+    public static GenericRecord pegasusToAvroFailedMCE(@Nonnull FailedMetadataChangeEvent failedMetadataChangeEvent) throws IOException {
+        GenericRecord original =
+            DataTranslator.dataMapToGenericRecord(failedMetadataChangeEvent.data(), failedMetadataChangeEvent.schema(), ORIGINAL_FAILED_MCE_AVRO_SCHEMA);
+        return renameSchemaNamespace(original, ORIGINAL_FAILED_MCE_AVRO_SCHEMA, RENAMED_FAILED_MCE_AVRO_SCHEMA);
+    }
 
   /**
    * Converts original MXE into a renamed namespace

--- a/metadata-events/mxe-utils-avro-1.7/src/test/java/com/linkedin/metadata/EventUtilsTests.java
+++ b/metadata-events/mxe-utils-avro-1.7/src/test/java/com/linkedin/metadata/EventUtilsTests.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.mxe.FailedMetadataChangeEvent;
 import com.linkedin.mxe.MetadataAuditEvent;
 import com.linkedin.mxe.MetadataChangeEvent;
 import java.io.IOException;
@@ -63,6 +64,17 @@ public class EventUtilsTests {
 
         assertEquals(record.getSchema(), com.linkedin.pegasus2avro.mxe.MetadataChangeEvent.SCHEMA$);
         assertNotNull(record.get("proposedSnapshot"));
+    }
+
+    @Test
+    public void testPegasusToAvroFailedMCE() throws IOException {
+        FailedMetadataChangeEvent event = recordTemplateFromResource("test-pegasus2avro-fmce.json", FailedMetadataChangeEvent.class);
+
+        GenericRecord record = EventUtils.pegasusToAvroFailedMCE(event);
+
+        assertEquals(record.getSchema(), com.linkedin.pegasus2avro.mxe.FailedMetadataChangeEvent.SCHEMA$);
+        assertNotNull(record.get("error"));
+        assertNotNull(record.get("metadataChangeEvent"));
     }
 
     private GenericRecord genericRecordFromResource(String resourcePath, Schema schema) throws IOException {

--- a/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-pegasus2avro-fmce.json
+++ b/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-pegasus2avro-fmce.json
@@ -1,23 +1,26 @@
 {
-    "auditHeader": null,
     "metadataChangeEvent": {
         "proposedSnapshot": {
-            "com.linkedin.metadata.snapshot.MetricSnapshot": {
-                "urn": "urn:li:metric:(foo,bar)",
+            "com.linkedin.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,baz)",
                 "aspects": [
                     {
                         "com.linkedin.common.Ownership": {
                             "owners": [
                                 {
-                                    "owner": "urn:li:corpuser:foo",
+                                    "owner": "urn:li:corpuser:foobar",
                                     "type": "DEVELOPER"
                                 }
-                            ]
+                            ],
+                            "lastModified": {
+                                "time": 0,
+                                "actor": "urn:li:corpuser:foobar"
+                            }
                         }
                     }
                 ]
             }
         }
     },
-    "error": ""
+    "error": "Test"
 }

--- a/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-pegasus2avro-fmce.json
+++ b/metadata-events/mxe-utils-avro-1.7/src/test/resources/test-pegasus2avro-fmce.json
@@ -1,0 +1,23 @@
+{
+    "auditHeader": null,
+    "metadataChangeEvent": {
+        "proposedSnapshot": {
+            "com.linkedin.metadata.snapshot.MetricSnapshot": {
+                "urn": "urn:li:metric:(foo,bar)",
+                "aspects": [
+                    {
+                        "com.linkedin.common.Ownership": {
+                            "owners": [
+                                {
+                                    "owner": "urn:li:corpuser:foo",
+                                    "type": "DEVELOPER"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "error": ""
+}

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceStreamTask.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceStreamTask.java
@@ -9,13 +9,24 @@ import com.linkedin.metadata.dao.utils.ModelUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.restli.DefaultRestliClientFactory;
 import com.linkedin.metadata.snapshot.Snapshot;
+import com.linkedin.mxe.FailedMetadataChangeEvent;
+import com.linkedin.mxe.MetadataChangeEvent;
 import com.linkedin.mxe.Topics;
 import com.linkedin.restli.client.Client;
 import com.linkedin.util.Configuration;
+
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerializer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -23,18 +34,21 @@ import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.kstream.KStream;
 
 import javax.annotation.Nonnull;
+
+import java.io.IOException;
 import java.util.Properties;
 
 
 @Slf4j
 public class MceStreamTask {
 
-  private static final String DEFAULT_KAFKA_TOPIC_NAME = Topics.METADATA_CHANGE_EVENT;
+  private static final String DEFAULT_MCE_KAFKA_TOPIC_NAME = Topics.METADATA_CHANGE_EVENT;
+  private static final String DEFAULT_FMCE_KAFKA_TOPIC_NAME = Topics.FAILED_METADATA_CHANGE_EVENT;
   private static final String DEFAULT_GMS_HOST = "localhost";
   private static final String DEFAULT_GMS_PORT = "8080";
   private static final String DEFAULT_KAFKA_BOOTSTRAP_SERVER = "localhost:9092";
   private static final String DEFAULT_KAFKA_SCHEMAREGISTRY_URL = "http://localhost:8081";
-
+  private static KafkaProducer<String, GenericRecord> producer;
   private static BaseRemoteWriterDAO _remoteWriterDAO;
 
   public static void main(final String[] args) {
@@ -48,6 +62,13 @@ public class MceStreamTask {
 
     // Configure the Streams application.
     final Properties streamsConfiguration = getStreamsConfiguration();
+
+    // Configure the Kakfa Producer for sending Failed MCE
+    final Properties producerProperties = getProducerProperties();
+
+    // Define the Producer for Sending Failed MCE Events
+    producer = new KafkaProducer<>(producerProperties);
+
 
     // Define the processing topology of the Streams application.
     final StreamsBuilder builder = new StreamsBuilder();
@@ -93,6 +114,25 @@ public class MceStreamTask {
     return streamsConfiguration;
   }
 
+    /**
+     * KafkaProducer Properties to produce FailedMetadataChangeEvent
+     *
+     * @return Properties producerConfig
+     */
+  static Properties getProducerProperties() {
+      final Properties producerConfig = new Properties();
+
+      producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+          Configuration.getEnvironmentVariable("KAFKA_BOOTSTRAP_SERVER", DEFAULT_KAFKA_BOOTSTRAP_SERVER));
+      producerConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+          Configuration.getEnvironmentVariable("KAFKA_SCHEMAREGISTRY_URL", DEFAULT_KAFKA_SCHEMAREGISTRY_URL));
+      producerConfig.put(ProducerConfig.CLIENT_ID_CONFIG, "failed-mce-producer");
+      producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+      producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, GenericAvroSerializer.class);
+
+      return producerConfig;
+  }
+
   /**
    * Define the processing topology for job.
    *
@@ -101,10 +141,10 @@ public class MceStreamTask {
   static void createProcessingTopology(final StreamsBuilder builder) {
     // Construct a `KStream` from the input topic.
     // The default key and value serdes will be used.
-    final KStream<String, GenericData.Record> messages = builder.stream(
-            Configuration.getEnvironmentVariable("KAFKA_TOPIC_NAME", DEFAULT_KAFKA_TOPIC_NAME)
+     KStream<String, GenericData.Record> messages = builder.stream(
+            Configuration.getEnvironmentVariable("KAFKA_TOPIC_NAME", DEFAULT_MCE_KAFKA_TOPIC_NAME)
     );
-    messages.foreach((k, v) -> processSingleMCE(v));
+     messages.foreach((k, v) -> processSingleMCE(v));
   }
 
   /**
@@ -114,17 +154,50 @@ public class MceStreamTask {
    */
   static void processSingleMCE(final GenericData.Record record) {
     log.debug("Got MCE");
-
+    com.linkedin.mxe.MetadataChangeEvent event = new MetadataChangeEvent();
     try {
-      final com.linkedin.mxe.MetadataChangeEvent event = EventUtils.avroToPegasusMCE(record);
+        event = EventUtils.avroToPegasusMCE(record);
 
-      if (event.hasProposedSnapshot()) {
-        processProposedSnapshot(event.getProposedSnapshot());
-      }
+        if (event.hasProposedSnapshot()) {
+            processProposedSnapshot(event.getProposedSnapshot());
+        }
     } catch (Throwable throwable) {
-      log.error("MCE Processor Error", throwable);
-      log.error("Message: {}", record);
+        log.error("MCE Processor Error", throwable);
+        log.error("Message: {}", record);
+        sendFailedMCE(event, throwable);
     }
+  }
+
+    /**
+     * Sending Failed MCE Event to Kafka Topic
+     * @param event
+     * @param throwable
+     */
+    private static void sendFailedMCE(MetadataChangeEvent event, Throwable throwable) {
+        FailedMetadataChangeEvent failedMetadataChangeEvent = createFailedMCEEvent(event, throwable);
+        try {
+            GenericRecord genericFailedMCERecord = EventUtils.pegasusToAvroFailedMCE(failedMetadataChangeEvent);
+            log.debug("FailedMetadataChangeEvent:"+failedMetadataChangeEvent);
+            producer.send(new ProducerRecord<>(
+                Configuration.getEnvironmentVariable("FAILED_MCE_KAFKA_TOPIC_NAME", DEFAULT_FMCE_KAFKA_TOPIC_NAME),
+                genericFailedMCERecord));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Populate a FailedMetadataChangeEvent from a MCE
+     * @param event
+     * @param throwable
+     * @return FailedMetadataChangeEvent
+     */
+  @Nonnull
+  private static FailedMetadataChangeEvent createFailedMCEEvent(@Nonnull MetadataChangeEvent event, @Nonnull Throwable throwable) {
+      FailedMetadataChangeEvent fmce = new FailedMetadataChangeEvent();
+      fmce.setError(ExceptionUtils.getStackTrace(throwable));
+      fmce.setMetadataChangeEvent(event);
+      return fmce;
   }
 
   static void processProposedSnapshot(@Nonnull Snapshot snapshotUnion) {

--- a/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceStreamTask.java
+++ b/metadata-jobs/mce-consumer-job/src/main/java/com/linkedin/metadata/kafka/MceStreamTask.java
@@ -141,7 +141,7 @@ public class MceStreamTask {
   static void createProcessingTopology(final StreamsBuilder builder) {
     // Construct a `KStream` from the input topic.
     // The default key and value serdes will be used.
-     KStream<String, GenericData.Record> messages = builder.stream(
+     final KStream<String, GenericData.Record> messages = builder.stream(
             Configuration.getEnvironmentVariable("KAFKA_TOPIC_NAME", DEFAULT_MCE_KAFKA_TOPIC_NAME)
     );
      messages.foreach((k, v) -> processSingleMCE(v));
@@ -173,10 +173,10 @@ public class MceStreamTask {
      * @param event
      * @param throwable
      */
-    private static void sendFailedMCE(MetadataChangeEvent event, Throwable throwable) {
-        FailedMetadataChangeEvent failedMetadataChangeEvent = createFailedMCEEvent(event, throwable);
+    private static void sendFailedMCE(@Nonnull MetadataChangeEvent event, @Nonnull Throwable throwable) {
+        final FailedMetadataChangeEvent failedMetadataChangeEvent = createFailedMCEEvent(event, throwable);
         try {
-            GenericRecord genericFailedMCERecord = EventUtils.pegasusToAvroFailedMCE(failedMetadataChangeEvent);
+            final GenericRecord genericFailedMCERecord = EventUtils.pegasusToAvroFailedMCE(failedMetadataChangeEvent);
             log.debug("FailedMetadataChangeEvent:"+failedMetadataChangeEvent);
             producer.send(new ProducerRecord<>(
                 Configuration.getEnvironmentVariable("FAILED_MCE_KAFKA_TOPIC_NAME", DEFAULT_FMCE_KAFKA_TOPIC_NAME),
@@ -194,7 +194,7 @@ public class MceStreamTask {
      */
   @Nonnull
   private static FailedMetadataChangeEvent createFailedMCEEvent(@Nonnull MetadataChangeEvent event, @Nonnull Throwable throwable) {
-      FailedMetadataChangeEvent fmce = new FailedMetadataChangeEvent();
+      final FailedMetadataChangeEvent fmce = new FailedMetadataChangeEvent();
       fmce.setError(ExceptionUtils.getStackTrace(throwable));
       fmce.setMetadataChangeEvent(event);
       return fmce;


### PR DESCRIPTION
No Failed MCE was sent when a MCE was rejected by the system
- Added FailedMetadataChangeEvent kafka topic
- Created FailedMCE event from the MCE record
- Added Kafka Producer to send FailedMCE to the FailedMetadataChangeEvent Topic