### PR TITLE
build: bypass testing datahub-web when running idea gradle task

### DIFF
--- a/datahub-web/build.gradle
+++ b/datahub-web/build.gradle
@@ -85,6 +85,8 @@ distZip {
   from 'packages/data-portal/dist'
 }
 
-artifacts {
-  assets distZip
+if (!gradle.startParameter.taskNames.any { it in ["idea"] }) {
+  artifacts {
+    assets distZip
+  }
 }


### PR DESCRIPTION
This significantly speeds up `gradlew idea`