### PR TITLE
fix: elasticsearch not starting on Mac

### DIFF
--- a/docker/quickstart/quickstart.sh
+++ b/docker/quickstart/quickstart.sh
@@ -5,6 +5,6 @@ mkdir -p ${DATA_STORAGE_FOLDER}
 
 # https://discuss.elastic.co/t/elastic-elasticsearch-docker-not-assigning-permissions-to-data-directory-on-run/65812/4
 mkdir -p ${DATA_STORAGE_FOLDER}/elasticsearch
-sudo chown 1000:1000 ${DATA_STORAGE_FOLDER}/elasticsearch
+sudo chmod 777 ${DATA_STORAGE_FOLDER}/elasticsearch
 
 docker-compose pull && docker-compose up --build


### PR DESCRIPTION
The `chown 1000:1000` trick mentioned in https://discuss.elastic.co/t/elastic-elasticsearch-docker-not-assigning-permissions-to-data-directory-on-run/65812/4 only works on Linux. Make the directory world writeable instead so that it works on both Mac & Linux.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
