### PR TITLE
build(gms): rename JettyRunWar task to run

### DIFF
--- a/gms/README.md
+++ b/gms/README.md
@@ -27,7 +27,7 @@ Quickest way to try out `DataHub GMS` is running the [Docker image](../docker/gm
 If you do modify things and want to try it out quickly without building the Docker image, you can also run
 the application directly from command line after a successful [build](#build):
 ```
-./gradlew :gms:war:JettyRunWar
+./gradlew :gms:war:run
 ```
 
 ## Sample API Calls

--- a/gms/war/build.gradle
+++ b/gms/war/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   jetty8 "org.eclipse.jetty:jetty-runner:9.4.18.v20190429"
 }
 
-task JettyRunWar(type: JavaExec) {
+task run(type: JavaExec, dependsOn: build) {
   main = "org.eclipse.jetty.runner.Runner"
   args = [war.archivePath]
   classpath configurations.jetty8


### PR DESCRIPTION
Also make sure the task depends on build so it'll rebuild if needed.
This make it more consistent with other modules such as mce-consumer-job.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
