### PR TITLE
fix(Docker): Fixing 'dockerize not found' issue while starting datahub-gms container using quickstart

### DIFF
--- a/docker/gms/Dockerfile
+++ b/docker/gms/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Kerem Sahin ksahin@linkedin.com
 ENV DOCKERIZE_VERSION v0.6.1
 RUN apk --no-cache add curl tar \
     && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.20.v20190813/jetty-runner-9.4.20.v20190813.jar --output jetty-runner-9.4.20.v20190813.jar \
-    && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar xvz
+    && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
 COPY --from=builder /gms.war .
 


### PR DESCRIPTION
Getting `sh: dockerize: not found` from datahub-gms container while running quickstart. Copying dockerize to /usr/local/bin while extracting it to resolve the issue.

Built Docker image locally & tested by running quickstart docker-compose without pulling from latest. Confirmed that datahub-gms starts as expected.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
