### PR TITLE
init nix-python script for unify haskell and python script

### DIFF
--- a/contrib/metadata-ingestion/README.md
+++ b/contrib/metadata-ingestion/README.md
@@ -13,11 +13,12 @@ i split the ingestion procedure to two part: [datahub-producer] and different [m
 - [X] datahub-producer load json avro data.
 - [X] add lineage-hive generator
 - [X] add dataset-jdbc generator[include [mysql, mssql, postgresql, oracle] driver]
+- [*] add lineage-oracle generator
+- [*] support haskell and python version
 - [ ] enhance dataset-jdbc generator [hive-driver]
 - [ ] enhance lineage-jdbc generator to lazy iterator mode.
-- [ ] add lineage-oracle generator
-- [ ] enchance avro parser to show error information 
 
+- [ ] enchance avro parser to show error information 
 
 
 ## Quickstart
@@ -31,18 +32,30 @@ i split the ingestion procedure to two part: [datahub-producer] and different [m
   nix-channel --update nixpkgs
 ```
 
-2. load json data to datahub
+2. [optional] you can download specified dependency in advanced, or it will automatically download at run time.
 
 ```
+  nix-shell bin/[datahub-producer].hs.nix
+  nix-shell bin/[datahub-producer].py.nix
+  ...
+```
+
+3. load json data to datahub
+
+```
+    # haskell
     cat sample/mce.json.dat | bin/datahub-producer.hs config
+    
+    # python
+    bin/datahub-producer.py produce -d sample/bootstrap_mce.dat
 ```
 
-3. parse hive sql to  datahub
+4. parse hive sql to  datahub
 ```
     ls sample/hive_*.sql | bin/lineage_hive_generator.hs | bin/datahub-producer.hs config
 ```
 
-4. load jdbc schema(mysql, mssql, postgresql, oracle) to datahub
+5. load jdbc schema(mysql, mssql, postgresql, oracle) to datahub
 ```
     bin/dataset-jdbc-generator.hs | bin/datahub-producer.hs config
 ```

--- a/contrib/metadata-ingestion/bin/datahub-producer.py
+++ b/contrib/metadata-ingestion/bin/datahub-producer.py
@@ -1,0 +1,109 @@
+#! /usr/bin/env nix-shell
+#! nix-shell datahub-producer.py.nix -i python
+import argparse
+from confluent_kafka import avro
+
+topic = "MetadataChangeEvent"
+
+class MetadataChangeEvent(object):
+
+    def __init__(self, avro_event=None):
+        self.value = avro_event
+
+def produce(conf, data_file, schema_record):
+    """
+        Produce MetadataChangeEvent records
+    """
+    from confluent_kafka.avro import AvroProducer
+    import ast
+
+    producer = AvroProducer(conf, default_value_schema=avro.load(schema_record))
+
+    print("Producing MetadataChangeEvent records to topic {}. ^c to exit.".format(topic))
+
+    with open(data_file) as fp:
+        cnt = 0
+        while True:
+            sample = fp.readline()
+            cnt += 1
+            if not sample:
+                break
+            try:
+                content = ast.literal_eval(sample.strip())
+                producer.produce(topic=topic, value=content)
+                producer.poll(0)
+                print("  MCE{}: {}".format(cnt, sample))
+            except KeyboardInterrupt:
+                break
+            except ValueError as e:
+                print ("Message serialization failed {}".format(e))
+                continue
+
+    print("Flushing records...")
+    producer.flush()
+
+
+def consume(conf):
+    """
+        Consume MetadataChangeEvent records
+    """
+    from confluent_kafka.avro import AvroConsumer
+    from confluent_kafka.avro.serializer import SerializerError
+
+    print("Consuming MetadataChangeEvent records from topic {} with group {}. ^c to exit.".format(topic, conf["group.id"]))
+
+    c = AvroConsumer(conf, reader_value_schema=record_schema)
+    c.subscribe([topic])
+
+    while True:
+        try:
+            msg = c.poll(1)
+
+            # There were no messages on the queue, continue polling
+            if msg is None:
+                continue
+
+            if msg.error():
+                print("Consumer error: {}".format(msg.error()))
+                continue
+
+            record = MetadataChangeEvent(msg.value())
+            print("avro_event: {}\n\t".format(record.value))
+        except SerializerError as e:
+            # Report malformed record, discard results, continue polling
+            print("Message deserialization failed {}".format(e))
+            continue
+        except KeyboardInterrupt:
+            break
+
+    print("Shutting down consumer..")
+    c.close()
+
+
+def main(args):
+    # Handle common configs
+    conf = {'bootstrap.servers': args.bootstrap_servers,
+            'schema.registry.url': args.schema_registry}
+
+    if args.mode == "produce":
+        produce(conf, args.data_file, args.schema_record)
+    else:
+        # Fallback to earliest to ensure all messages are consumed
+        conf['group.id'] = topic
+        conf['auto.offset.reset'] = "earliest"
+        consume(conf)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Client for producing/consuming MetadataChangeEvent")
+    parser.add_argument('-b', dest="bootstrap_servers",
+                        default="localhost:9092", help="Kafka broker(s) (localhost[:port])")
+    parser.add_argument('-s', dest="schema_registry",
+                        default="http://localhost:8081", help="Schema Registry (http(s)://localhost[:port]")
+    parser.add_argument('mode', choices=['produce', 'consume'],
+                        help="Execution mode (produce | consume)")
+    parser.add_argument('-l', dest="schema_record", default="../../metadata-events/mxe-schemas/src/renamed/avro/com/linkedin/mxe/MetadataChangeEvent.avsc",
+                        help="Avro schema record; required if running 'producer' mode")
+    parser.add_argument('-d', dest="data_file", default="bootstrap_mce.dat",
+                        help="MCE data file; required if running 'producer' mode")
+    main(parser.parse_args())

--- a/contrib/metadata-ingestion/bin/datahub-producer.py.nix
+++ b/contrib/metadata-ingestion/bin/datahub-producer.py.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> {} ;
+mkShell {
+  buildInputs = [
+    python38
+  ] ++ (with python38Packages ;[
+    confluent-kafka
+    requests
+    # avro-python3
+    avro3k
+  ]) ;
+}

--- a/contrib/metadata-ingestion/bin/datahub-producer.py.nix
+++ b/contrib/metadata-ingestion/bin/datahub-producer.py.nix
@@ -1,11 +1,32 @@
 with import <nixpkgs> {} ;
+let
+  avro-python3-1_8 = python3Packages.buildPythonPackage rec {
+      pname = "avro-python3" ;
+      version = "1.8.2" ;
+
+      src = python3Packages.fetchPypi {
+        inherit pname version ;
+        sha256 = "f82cf0d66189600b1e6b442f650ad5aca6c189576723dcbf6f9ce096eab81bd6" ;
+      } ;
+      doCheck = false;
+  } ;
+  avro-python3-1_7 = python3Packages.buildPythonPackage rec {
+      pname = "avro-python3" ;
+      version = "1.7.7" ;
+
+      src = python3Packages.fetchPypi {
+        inherit pname version ;
+        sha256 = "b0a738e7a2b4bbe63029262fa1cd7c08a572341d267d543a08853e526356c1ea" ;
+      } ;
+      doCheck = false;
+  } ;
+
+in
 mkShell {
-  buildInputs = [
-    python38
-  ] ++ (with python38Packages ;[
+  buildInputs = (with python3Packages ;[
+    python
     confluent-kafka
     requests
-    # avro-python3
-    avro3k
+    avro-python3-1_8
   ]) ;
 }

--- a/contrib/metadata-ingestion/sample/bootstrap_mce.dat
+++ b/contrib/metadata-ingestion/sample/bootstrap_mce.dat
@@ -1,0 +1,1 @@
+../../../metadata-ingestion/mce-cli/bootstrap_mce.dat


### PR DESCRIPTION
plan to support haskell and python at the same time.
the dependency is manage by nix as nix can support all language library and binary file.