### PR TITLE
refactor: change the default log location

### DIFF
--- a/datahub-frontend/conf/logback.xml
+++ b/datahub-frontend/conf/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-  <property name="WHZ_LOG_DIR" value="${WHZ_LOG_DIR:- /var/tmp/datahub}"/>
+  <property name="LOG_DIR" value="${LOG_DIR:- /tmp/datahub/logs}"/>
   <timestamp key="bySecond" datePattern="yyyy-MM-dd'_'HH-mm-ss"/>
   <timestamp key="byDate" datePattern="yyyy-MM-dd"/>
 
@@ -10,14 +10,14 @@
   </appender>
 
   <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${WHZ_LOG_DIR}/datahub-frontend-${bySecond}.log</file>
+    <file>${LOG_DIR}/datahub-frontend-${bySecond}.log</file>
     <append>true</append>
     <encoder>
       <pattern>%d{HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
       <maxIndex>10</maxIndex>
-      <FileNamePattern>${WHZ_LOG_DIR}/${byDate}.log.%i</FileNamePattern>
+      <FileNamePattern>${LOG_DIR}/${byDate}.log.%i</FileNamePattern>
     </rollingPolicy>
     <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
       <MaxFileSize>20MB</MaxFileSize>

--- a/gms/war/src/main/resources/logback.xml
+++ b/gms/war/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="LOG_DIR" value="${LOG_DIR:- /local/logs}"/>
+    <property name="LOG_DIR" value="${LOG_DIR:- /tmp/datahub/logs}"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/metadata-jobs/mae-consumer-job/src/main/resources/logback.xml
+++ b/metadata-jobs/mae-consumer-job/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="LOG_DIR" value="${LOG_DIR:- /local/logs}"/>
+    <property name="LOG_DIR" value="${LOG_DIR:- /tmp/datahub/logs}"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/metadata-jobs/mce-consumer-job/src/main/resources/logback.xml
+++ b/metadata-jobs/mce-consumer-job/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="LOG_DIR" value="${LOG_DIR:- /local/logs}"/>
+    <property name="LOG_DIR" value="${LOG_DIR:- /tmp/datahub/logs}"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
The original location (/local/log) is not a commonly writable location on Mac & Linux.
The new default location also matches the default data location for docker containers.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
