### PR TITLE
refactor: move springframework gradle plugin version to top level build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
     classpath 'com.moowork.gradle:gradle-node-plugin:1.3.1'
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.8.1'
+    classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.2.RELEASE'
   }
 }
 

--- a/metadata-jobs/mae-consumer-job/build.gradle
+++ b/metadata-jobs/mae-consumer-job/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.1.2.RELEASE'
+    id 'org.springframework.boot'
     id 'java'
 }
 

--- a/metadata-jobs/mce-consumer-job/build.gradle
+++ b/metadata-jobs/mce-consumer-job/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.1.2.RELEASE'
+    id 'org.springframework.boot'
     id 'java'
 }
 


### PR DESCRIPTION
This will ensure the version of org.springframework.boot plugin is defined at one place which is the top level build.gradle file

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
