### PR TITLE
build(docker): refactor ingestion docker build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This repository contains the complete source code for both DataHub's frontend & 
 5. At this point, you should be able to start DataHub by opening [http://localhost:9001](http://localhost:9001) in your browser. You can sign in using `datahub` as both username and password. However, you'll notice that no data has been ingested yet.
 6. To ingest provided [sample data](https://github.com/linkedin/datahub/blob/master/metadata-ingestion/mce-cli/bootstrap_mce.dat) to DataHub, switch to a new terminal window, `cd` into the cloned `datahub` repo, and run the following command:
     ```
-    docker build -t ingestion -f docker/ingestion/Dockerfile . && cd docker/ingestion && docker-compose up
+    ./docker/ingestion/ingestion.sh
     ```
    After running this, you should be able to see and search sample datasets in DataHub.
 

--- a/docker/ingestion/Dockerfile
+++ b/docker/ingestion/Dockerfile
@@ -1,6 +1,10 @@
 FROM openjdk:8
+
 COPY --from=python:2.7 / /
 COPY . datahub-src
 RUN cd datahub-src && ./gradlew :metadata-events:mxe-schemas:build \
     && cp -r metadata-ingestion/mce-cli . && cd metadata-ingestion/mce-cli \
     && pip install --user -r requirements.txt
+
+CMD cd datahub-src/metadata-ingestion/mce-cli \
+    && python mce_cli.py produce -d bootstrap_mce.dat -b $KAFKA_BOOTSTRAP_SERVER -s $KAFKA_SCHEMAREGISTRY_URL

--- a/docker/ingestion/README.md
+++ b/docker/ingestion/README.md
@@ -3,18 +3,13 @@
 Refer to [DataHub Metadata Ingestion](../../metadata-ingestion/mce-cli) to have a quick understanding of the architecture and 
 responsibility of this service for the DataHub.
 
-## Build
+## Build & Run
 ```
- docker build -t ingestion -f docker/ingestion/Dockerfile .
+cd docker/ingestion && docker-compose up --build
 ```
-This command will build and deploy the image in your local store.
+This command will rebuild the docker image and start a container based on the image.
 
-## Run container
-```
- cd docker/ingestion && docker-compose up
-```
-This command will start the container. If you have the image available in your local store, this image will be used
-for the container otherwise it will build the image from local repository and then start that.
+To start a container using an existing image, run the same command without the `--build` flag.
 
 ### Container configuration
 

--- a/docker/ingestion/docker-compose.yml
+++ b/docker/ingestion/docker-compose.yml
@@ -2,13 +2,15 @@
 version: '3.5'
 services:
   ingestion:
-    image: ingestion
+    image: datahub-ingestion
+    build:
+      context: ../../
+      dockerfile: docker/ingestion/Dockerfile
     hostname: ingestion
     container_name: ingestion
     environment:
       - KAFKA_BOOTSTRAP_SERVER=broker:29092
       - KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
-    command: "bash -c 'cd datahub-src/metadata-ingestion/mce-cli && python mce_cli.py produce -d bootstrap_mce.dat -b broker:29092 -s http://schema-registry:8081'"
 
 networks:
   default:

--- a/docker/ingestion/ingestion.sh
+++ b/docker/ingestion/ingestion.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR && docker-compose -p datahub up --build


### PR DESCRIPTION
- add "build" option to docker-compose file to simplify rebuilding of images
- move command from docker-compose.yml to Dockerfile
- add ingestion.sh script to simplify quickstart instruction and to reduce confusion

Fix https://github.com/linkedin/datahub/issues/1689


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
