### PR TITLE
fix: remove helm container commands

### DIFF
--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -31,7 +31,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "-c" ,"java -jar jetty-runner-9.4.20.v20190813.jar gms.war"]
           ports:
             - name: http
               containerPort: 8080

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          command: ["/bin/sh", "-c" ,"./mae-consumer-job/bin/mae-consumer-job"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: KAFKA_BOOTSTRAP_SERVER

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -31,7 +31,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "-c" ,"./mce-consumer-job/bin/mce-consumer-job"]
           env:
             - name: KAFKA_BOOTSTRAP_SERVER
               valueFrom:


### PR DESCRIPTION
Some of the current helm container commands are not compatible with the latest
docker images. Instead, rely on CMD in the docker images.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
