### PR TITLE
fix: add missing neo4j.host helm var

### DIFF
--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/configmap.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/configmap.yaml
@@ -12,4 +12,5 @@ data:
   kafka.schemaregistry.url: "{{ .Values.global.kafka.schemaregistry.url }}"
   elasticsearch.host: "{{ .Values.global.elasticsearch.host }}"
   elasticsearch.port: "{{ .Values.global.elasticsearch.port }}"
+  neo4j.host: "{{ .Values.global.neo4j.host }}"
   neo4j.uri: "{{ .Values.global.neo4j.uri }}"

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -81,6 +81,11 @@ spec:
                 configMapKeyRef:
                   name: {{ include "datahub-gms.fullname" . }}-configmap
                   key: elasticsearch.port
+            - name: NEO4J_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "datahub-gms.fullname" . }}-configmap
+                  key: neo4j.host
             - name: NEO4J_URI
               valueFrom:
                 configMapKeyRef:

--- a/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
@@ -82,6 +82,7 @@ global:
       url: "http://schema-registry:8081"
 
   neo4j:
+    host: "neo4j:7474"
     uri: "bolt://neo4j"
     username: "neo4j"
     password: "datahub"

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -52,6 +52,11 @@ spec:
                 configMapKeyRef:
                   name: datahub-gms-deployment-configmap
                   key: elasticsearch.port
+            - name: NEO4J_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: datahub-gms-deployment-configmap
+                  key: neo4j.host
             - name: NEO4J_URI
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
The new var is needed by the recently added docker start.sh scripts

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
