### PR TITLE
[fix] Fix NPE while loading picture link

### DIFF
--- a/datahub-dao/src/main/java/com/linkedin/datahub/util/CorpUserUtil.java
+++ b/datahub-dao/src/main/java/com/linkedin/datahub/util/CorpUserUtil.java
@@ -64,8 +64,12 @@ public class CorpUserUtil {
         UserEntity user = new UserEntity();
         user.setCategory("person");
         user.setLabel(corpUser.getUsername());
-        user.setDisplayName(corpUser.getInfo().getDisplayName());
-        user.setPictureLink(corpUser.getEditableInfo().getPictureLink().toString());
+        if (corpUser.hasInfo()) {
+            user.setDisplayName(corpUser.getInfo().getDisplayName());
+        }
+        if (corpUser.hasEditableInfo() && corpUser.getEditableInfo().hasPictureLink()) {
+            user.setPictureLink(corpUser.getEditableInfo().getPictureLink().toString());
+        }
         return user;
     }
 }


### PR DESCRIPTION
Tested on DataHub UI. Ownership tab earlier would throw an error since http://localhost:9001/api/v1/party/entities throws Null pointer exception when picture link is not provided in `CorpUserEditableInfo` aspect. Now it doesn't throw an error.
## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
