### PR TITLE
fix: correct the way to catch the exception

### DIFF
--- a/metadata-ingestion/ldap-etl/requirements.txt
+++ b/metadata-ingestion/ldap-etl/requirements.txt
@@ -1,3 +1,3 @@
 avro-python3==1.8.2
-confluent-kafka==1.4.0
+confluent-kafka[avro]==1.4.0
 python-ldap==3.2.0

--- a/metadata-ingestion/mysql-etl/requirements.txt
+++ b/metadata-ingestion/mysql-etl/requirements.txt
@@ -1,3 +1,3 @@
 avro-python3==1.8.2
-confluent-kafka==1.4.0
+confluent-kafka[avro]==1.4.0
 mysql-connector==2.2.9

--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -97,8 +97,9 @@ def produce_dataset_mce(mce, kafka_config):
     conf = {'bootstrap.servers': kafka_config.bootstrap_server,
             'on_delivery': delivery_report,
             'schema.registry.url': kafka_config.schema_registry}
+    key_schema = avro.loads('{"type": "string"}')
     record_schema = avro.load(kafka_config.avsc_path)
-    producer = AvroProducer(conf, default_value_schema=record_schema)
+    producer = AvroProducer(conf, default_key_schema=key_schema, default_value_schema=record_schema)
 
     producer.produce(topic=kafka_config.kafka_topic, key=mce['proposedSnapshot'][1]['urn'], value=mce)
     producer.flush()

--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -1,6 +1,5 @@
 #! /usr/bin/python
 import time
-from uuid import uuid4
 
 from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
@@ -57,7 +56,8 @@ def build_dataset_mce(platform, dataset_name, columns):
         fields.append({
             "fieldPath": column["name"],
             "nativeDataType": repr(column["type"]),
-            "type": { "type":get_column_type(column["type"]) }
+            "type": { "type":get_column_type(column["type"]) },
+            "description": column["comment"]
         })
 
     schema_metadata = {
@@ -100,7 +100,7 @@ def produce_dataset_mce(mce, kafka_config):
     record_schema = avro.load(kafka_config.avsc_path)
     producer = AvroProducer(conf, default_value_schema=record_schema)
 
-    producer.produce(topic=kafka_config.kafka_topic, key=str(uuid4()), value=mce)
+    producer.produce(topic=kafka_config.kafka_topic, key=mce['proposedSnapshot'][1]['urn'], value=mce)
     producer.flush()
 
 

--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -80,21 +80,26 @@ def build_dataset_mce(platform, dataset_name, columns):
     }
 
 
+def delivery_report(err, msg):
+    """ Called once for each message produced to indicate delivery result.
+        Triggered by poll() or flush(). """
+    if err is not None:
+        print('Message delivery failed: {}'.format(err))
+    else:
+        print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+
 def produce_dataset_mce(mce, kafka_config):
     """
     Produces a MetadataChangeEvent to Kafka
     """
     conf = {'bootstrap.servers': kafka_config.bootstrap_server,
+            'on_delivery': delivery_report,
             'schema.registry.url': kafka_config.schema_registry}
     record_schema = avro.load(kafka_config.avsc_path)
     producer = AvroProducer(conf, default_value_schema=record_schema)
 
-    try:
-        producer.produce(topic=kafka_config.kafka_topic, value=mce)
-        producer.poll(0)
-        print('\n%s has been successfully produced!\n' % mce)
-    except ValueError as e:
-        print('Message serialization failed %s' % e)
+    producer.produce(topic=kafka_config.kafka_topic, value=mce)
     producer.flush()
 
 

--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -1,5 +1,6 @@
 #! /usr/bin/python
 import time
+from uuid import uuid4
 
 from confluent_kafka import avro
 from confluent_kafka.avro import AvroProducer
@@ -99,7 +100,7 @@ def produce_dataset_mce(mce, kafka_config):
     record_schema = avro.load(kafka_config.avsc_path)
     producer = AvroProducer(conf, default_value_schema=record_schema)
 
-    producer.produce(topic=kafka_config.kafka_topic, value=mce)
+    producer.produce(topic=kafka_config.kafka_topic, key=str(uuid4()), value=mce)
     producer.flush()
 
 

--- a/metadata-ingestion/sql-etl/common.txt
+++ b/metadata-ingestion/sql-etl/common.txt
@@ -1,3 +1,3 @@
 avro-python3==1.8.2
-confluent-kafka==1.1.0
+confluent-kafka[avro]==1.4.0
 SQLAlchemy==1.3.17


### PR DESCRIPTION
After verification, the function `producer.produce` will not throw exceptions. The exception will be returned as a callback.

Such as:

```
Message delivery failed: KafkaError{code=INVALID_MSG,val=2,str="Broker: Invalid message"}
```
