### PR TITLE
feat(models): add models for Social functions

### DIFF
--- a/metadata-models/src/main/pegasus/com/linkedin/common/Follow.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Follow.pdl
@@ -1,0 +1,12 @@
+namespace com.linkedin.common
+
+/**
+ * Follow information of an entity.
+ */
+record Follow {
+
+  /**
+   * List of followers of an entity.
+   */
+  followers: array[FollowAction]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/common/FollowAction.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/FollowAction.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.common
+
+/**
+ * Follow Action of an entity.
+ */
+record FollowAction {
+
+  /**
+   * Follower (User or a Group) of an entity
+   */
+  follower: FollowerType
+
+  /**
+   * Audit stamp containing who last modified the record and when.
+   */
+  lastModified: optional AuditStamp
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/common/FollowerType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/FollowerType.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.common
+
+/**
+ * A union of all supported follower types
+ */
+typeref FollowerType = union[
+  corpUser: CorpuserUrn,
+  corpGroup: CorpGroupUrn
+]

--- a/metadata-models/src/main/pegasus/com/linkedin/common/LikeAction.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/LikeAction.pdl
@@ -1,0 +1,17 @@
+namespace com.linkedin.common
+
+/**
+ * Like Action on a data entity.
+ */
+record LikeAction {
+
+  /**
+   * Corp user liking a data entity
+   */
+  likedBy: CorpuserUrn
+
+  /**
+   * Audit stamp containing who last modified the record and when. Impersonator here is the social application where the user has performed the action.
+   */
+  lastModified: optional AuditStamp
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Likes.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Likes.pdl
@@ -1,0 +1,12 @@
+namespace com.linkedin.common
+
+/**
+ * Corp users that have liked this entity. This is primarily for counting users who have liked the entity, also to provide personalized search experience.
+ */
+record Likes {
+
+  /**
+   * List of social actions associated with the likes of a data entity.
+   */
+  actions: array[LikeAction]
+}


### PR DESCRIPTION
Add metadata models for Likes and Follow of an entity. These social functions solve the following pain points
1. There are few signals attached to data entities that tell me if the entity has been used by anyone else - Likes
2. There is no standard or transparent way to signal data entity owners that other users have a business need or interest in their data entity - Follow

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
