### PR TITLE
metadata-models 72.0.8 -> 80.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # Pegasus & Avro
 **/src/mainGenerated*
 **/src/testGenerated*
+metadata-events/mxe-registration/src/main/resources/**/*.avsc
 
 # Java
 .java-version

--- a/metadata-dao-impl/ebean-dao/gma-create-all.sql
+++ b/metadata-dao-impl/ebean-dao/gma-create-all.sql
@@ -15,3 +15,18 @@ create table metadata_aspect (
   constraint pk_metadata_aspect primary key (urn,aspect,version)
 );
 
+create table metadata_index (
+  id                            bigint auto_increment not null,
+  urn                           varchar(500) not null,
+  aspect                        varchar(200) not null,
+  path                          varchar(200) not null,
+  longval                       bigint,
+  stringval                     varchar(500),
+  doubleval                     double,
+  constraint pk_metadata_index primary key (id)
+);
+
+create index idx_long_val on metadata_index (aspect,path,longval,urn);
+create index idx_string_val on metadata_index (aspect,path,stringval,urn);
+create index idx_double_val on metadata_index (aspect,path,doubleval,urn);
+create index idx_urn on metadata_index (urn);

--- a/metadata-dao-impl/ebean-dao/gma-drop-all.sql
+++ b/metadata-dao-impl/ebean-dao/gma-drop-all.sql
@@ -2,3 +2,9 @@ drop table if exists metadata_id;
 
 drop table if exists metadata_aspect;
 
+drop table if exists metadata_index;
+
+drop index if exists idx_long_val;
+drop index if exists idx_string_val;
+drop index if exists idx_double_val;
+drop index if exists idx_urn;

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataIndex.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataIndex.java
@@ -1,0 +1,78 @@
+package com.linkedin.metadata.dao;
+
+import io.ebean.annotation.Index;
+import io.ebean.Model;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+// define composite indexes
+@Index(name = "idx_long_val", columnNames = {
+    EbeanMetadataIndex.ASPECT_COLUMN,
+    EbeanMetadataIndex.PATH_COLUMN,
+    EbeanMetadataIndex.LONG_COLUMN,
+    EbeanMetadataIndex.URN_COLUMN
+})
+@Index(name = "idx_string_val", columnNames = {
+    EbeanMetadataIndex.ASPECT_COLUMN,
+    EbeanMetadataIndex.PATH_COLUMN,
+    EbeanMetadataIndex.STRING_COLUMN,
+    EbeanMetadataIndex.URN_COLUMN
+})
+@Index(name = "idx_double_val", columnNames = {
+    EbeanMetadataIndex.ASPECT_COLUMN,
+    EbeanMetadataIndex.PATH_COLUMN,
+    EbeanMetadataIndex.DOUBLE_COLUMN,
+    EbeanMetadataIndex.URN_COLUMN
+})
+@Entity
+@Table(name = "metadata_index")
+public class EbeanMetadataIndex extends Model {
+
+  public static final long serialVersionUID = 1L;
+
+  private static final String ID_COLUMN = "id";
+  public static final String URN_COLUMN = "urn";
+  public static final String ASPECT_COLUMN = "aspect";
+  public static final String PATH_COLUMN = "path";
+  public static final String LONG_COLUMN = "longVal";
+  public static final String STRING_COLUMN = "stringVal";
+  public static final String DOUBLE_COLUMN = "doubleVal";
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = ID_COLUMN)
+  protected long id;
+
+  @NonNull
+  @Index(name = "idx_urn")
+  @Column(name = URN_COLUMN, length = 500, nullable = false)
+  protected String urn;
+
+  @NonNull
+  @Column(name = ASPECT_COLUMN, length = 200, nullable = false)
+  protected String aspect;
+
+  @NonNull
+  @Column(name = PATH_COLUMN, length = 200, nullable = false)
+  protected String path;
+
+  @Column(name = LONG_COLUMN)
+  protected Long longVal;
+
+  @Column(name = STRING_COLUMN, length = 500)
+  protected String stringVal;
+
+  @Column(name = DOUBLE_COLUMN)
+  protected Double doubleVal;
+
+}

--- a/metadata-dao-impl/ebean-dao/src/main/resources/gma-create-all.sql
+++ b/metadata-dao-impl/ebean-dao/src/main/resources/gma-create-all.sql
@@ -15,3 +15,18 @@ create table metadata_id (
   constraint uq_metadata_id_namespace_id unique (namespace,id)
 );
 
+create table metadata_index (
+  id                            bigint auto_increment not null,
+  urn                           varchar(500) not null,
+  aspect                        varchar(200) not null,
+  path                          varchar(200) not null,
+  longval                       bigint,
+  stringval                     varchar(500),
+  doubleval                     double,
+  constraint pk_metadata_index primary key (id)
+);
+
+create index idx_long_val on metadata_index (aspect,path,longval,urn);
+create index idx_string_val on metadata_index (aspect,path,stringval,urn);
+create index idx_double_val on metadata_index (aspect,path,doubleval,urn);
+create index idx_urn on metadata_index (urn);

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
@@ -18,10 +18,10 @@ public class ESUtils {
   private static final String DEFAULT_SEARCH_RESULTS_SORT_BY_FIELD = "urn";
 
   /*
-  * TODO: we might need to extend this list if need be, below link has the complete list
-  * https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html
-  * */
-  private static final char[] ELASTICSEARCH_REGEXP_RESERVED_CHARACTERS = {'*'};
+   * Refer to https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html for list of reserved
+   * characters in an Elasticsearch regular expression.
+   */
+  private static final String ELASTICSEARCH_REGEXP_RESERVED_CHARACTERS = "?+*|{}[]()";
 
   private ESUtils() {
 
@@ -81,7 +81,7 @@ public class ESUtils {
    */
   @Nonnull
   public static String escapeReservedCharacters(@Nonnull String input) {
-    for (char reservedChar : ELASTICSEARCH_REGEXP_RESERVED_CHARACTERS) {
+    for (char reservedChar : ELASTICSEARCH_REGEXP_RESERVED_CHARACTERS.toCharArray()) {
       input = input.replace(String.valueOf(reservedChar), "\\" + reservedChar);
     }
     return input;

--- a/metadata-dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/ESUtilsTest.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/ESUtilsTest.java
@@ -39,5 +39,7 @@ public class ESUtilsTest {
   public void testEscapeReservedCharacters() {
     assertEquals(escapeReservedCharacters("foobar"), "foobar");
     assertEquals(escapeReservedCharacters("**"), "\\*\\*");
+    assertEquals(escapeReservedCharacters("()"), "\\(\\)");
+    assertEquals(escapeReservedCharacters("{}"), "\\{\\}");
   }
 }

--- a/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
+++ b/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
@@ -8,14 +8,17 @@ import com.linkedin.metadata.query.CriterionArray;
 import com.linkedin.metadata.query.Filter;
 import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.ClassUtils;
 import org.neo4j.driver.types.Node;
+import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.*;
@@ -163,6 +166,25 @@ public class Neo4jUtil {
 
     final String className = node.labels().iterator().next();
     return RecordUtils.toRecordTemplate(className, new DataMap(node.asMap()));
+  }
+
+  /**
+   * Converts path segment (field:value map) list of {@link RecordTemplate}s of nodes & edges
+   *
+   * @param segment The segment of a path containing nodes & edges
+   * @return List<RecordTemplate>
+   */
+  @Nonnull
+  public static List<RecordTemplate> pathSegmentToRecordList(@Nonnull Path.Segment segment) {
+    final Node startNode = segment.start();
+    final Node endNode = segment.end();
+    final Relationship edge = segment.relationship();
+
+    return Arrays.asList(
+        nodeToEntity(startNode),
+        edgeToRelationship(startNode, endNode, edge),
+        nodeToEntity(endNode)
+    );
   }
 
   /**

--- a/metadata-dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jQueryDAOTest.java
+++ b/metadata-dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jQueryDAOTest.java
@@ -511,17 +511,17 @@ public class Neo4jQueryDAOTest {
     // Get reports roll-up - 2 levels
     Filter sourceFilter = newFilter("urn", urn1.toString());
     RelationshipFilter relationshipFilter = createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING);
-    List<List<RecordTemplate>> nodesInPath = _dao.getPathsToAllNodesTraversed(EntityFoo.class, sourceFilter, null,
+    List<List<RecordTemplate>> paths = _dao.getTraversedPaths(EntityFoo.class, sourceFilter, null,
         EMPTY_FILTER, RelationshipFoo.class, relationshipFilter, 1, 2, -1, -1);
-    assertEquals(nodesInPath.size(), 5);
-    assertEquals(nodesInPath.stream().filter(l -> l.size() == 2).collect(Collectors.toList()).size(), 2);
-    assertEquals(nodesInPath.stream().filter(l -> l.size() == 3).collect(Collectors.toList()).size(), 3);
+    assertEquals(paths.size(), 5);
+    assertEquals(paths.stream().filter(l -> l.size() == 3).collect(Collectors.toList()).size(), 2);
+    assertEquals(paths.stream().filter(l -> l.size() == 5).collect(Collectors.toList()).size(), 3);
 
     // Get reports roll-up - 1 level
-    nodesInPath = _dao.getPathsToAllNodesTraversed(EntityFoo.class, sourceFilter, null,
+    paths = _dao.getTraversedPaths(EntityFoo.class, sourceFilter, null,
         EMPTY_FILTER, RelationshipFoo.class, relationshipFilter, 1, 1, -1, -1);
-    assertEquals(nodesInPath.size(), 2);
-    assertEquals(nodesInPath.stream().filter(l -> l.size() == 2).collect(Collectors.toList()).size(), 2);
-    assertEquals(nodesInPath.stream().filter(l -> l.size() == 3).collect(Collectors.toList()).size(), 0);
+    assertEquals(paths.size(), 2);
+    assertEquals(paths.stream().filter(l -> l.size() == 3).collect(Collectors.toList()).size(), 2);
+    assertEquals(paths.stream().filter(l -> l.size() == 5).collect(Collectors.toList()).size(), 0);
   }
 }

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
@@ -18,7 +18,8 @@ public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate,
   protected final Class<SNAPSHOT> _snapshotClass;
   protected final Class<ASPECT_UNION> _aspectUnionClass;
 
-  public BaseMetadataEventProducer(@Nonnull Class<SNAPSHOT> snapshotClass, @Nonnull Class<ASPECT_UNION> aspectUnionClass) {
+  public BaseMetadataEventProducer(@Nonnull Class<SNAPSHOT> snapshotClass,
+      @Nonnull Class<ASPECT_UNION> aspectUnionClass) {
     ModelUtils.validateSnapshotAspect(snapshotClass, aspectUnionClass);
     _snapshotClass = snapshotClass;
     _aspectUnionClass = aspectUnionClass;
@@ -43,5 +44,15 @@ public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate,
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}
    */
   public abstract <ASPECT extends RecordTemplate> void produceMetadataAuditEvent(@Nonnull URN urn,
+      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue);
+
+  /**
+   * Produces an aspect specific Metadata Audit Event (MAE) after a metadata aspect is updated for an entity.
+   *
+   * @param urn {@link Urn} of the entity
+   * @param oldValue the value prior to the update, or null if there's none.
+   * @param newValue the value after the update
+   */
+  public abstract <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
       @Nullable ASPECT oldValue, @Nonnull ASPECT newValue);
 }

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducer.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducer.java
@@ -29,4 +29,10 @@ public class DummyMetadataEventProducer<URN extends Urn>
       @Nonnull ASPECT newValue) {
     // Do nothing
   }
+
+  @Override
+  public <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
+      @Nullable ASPECT oldValue, @Nonnull ASPECT newValue) {
+    // Do nothing
+  }
 }

--- a/metadata-dao/src/test/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducerTest.java
+++ b/metadata-dao/src/test/java/com/linkedin/metadata/dao/producer/DummyMetadataEventProducerTest.java
@@ -18,5 +18,6 @@ public class DummyMetadataEventProducerTest {
     AspectFoo newValue = new AspectFoo().setValue("new");
 
     producer.produceMetadataAuditEvent(urn, oldValue, newValue);
+    producer.produceAspectSpecificMetadataAuditEvent(urn, oldValue, newValue);
   }
 }

--- a/metadata-dao/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/metadata-dao/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -139,9 +139,7 @@ public class ModelUtilsTest {
   public void testGetUrnFromRelationship() {
     FooUrn expectedSource = makeFooUrn(1);
     BarUrn expectedDestination = makeBarUrn(1);
-    RelationshipFoo relationship = new RelationshipFoo()
-        .setSource(expectedSource)
-        .setDestination(expectedDestination);
+    RelationshipFoo relationship = new RelationshipFoo().setSource(expectedSource).setDestination(expectedDestination);
 
     Urn sourceUrn = ModelUtils.getSourceUrnFromRelationship(relationship);
     Urn destinationUrn = ModelUtils.getDestinationUrnFromRelationship(relationship);
@@ -228,7 +226,6 @@ public class ModelUtilsTest {
     assertEquals(ModelUtils.urnClassForEntity(EntityBar.class), BarUrn.class);
   }
 
-
   @Test
   public void testUrnClassForSnapshot() {
     assertEquals(ModelUtils.urnClassForSnapshot(EntitySnapshot.class), Urn.class);
@@ -267,5 +264,13 @@ public class ModelUtilsTest {
     RelationshipUnion relationshipUnion = ModelUtils.newRelationshipUnion(RelationshipUnion.class, foo);
 
     assertEquals(relationshipUnion.getRelationshipFoo(), foo);
+  }
+
+  @Test
+  public void testGetMAETopicName() throws URISyntaxException {
+    FooUrn urn = new FooUrn(1);
+    AspectFoo foo = new AspectFoo().setValue("foo");
+
+    assertEquals(ModelUtils.getAspectSpecificMAETopicName(urn, foo), "METADATA_AUDIT_EVENT_FOO_ASPECTFOO");
   }
 }

--- a/metadata-events/mxe-registration/build.gradle
+++ b/metadata-events/mxe-registration/build.gradle
@@ -1,1 +1,34 @@
 apply plugin: 'java'
+
+configurations {
+  avroOriginal
+}
+
+dependencies {
+  compile project(':metadata-events:mxe-avro-1.7')
+  compile project(':metadata-models')
+  compile spec.product.pegasus.dataAvro1_6
+
+  testCompile project(':metadata-dao')
+  testCompile project(':metadata-testing:metadata-test-utils')
+
+  avroOriginal project(path: ':metadata-models', configuration: 'avroSchema')
+}
+
+// copy original MXE avro schema from metadata-models to resources
+task copyOriginalMXESchemas(type: Copy) {
+  dependsOn configurations.avroOriginal
+
+  from { // use of closure defers evaluation until execution time
+    configurations.avroOriginal.collect { zipTree(it) }
+  }
+  into("src/main/resources/")
+  include("avro/com/linkedin/mxe/")
+}
+
+compileJava.dependsOn copyOriginalMXESchemas
+processResources.dependsOn copyOriginalMXESchemas
+
+clean {
+  project.delete("src/main/resources/avro")
+}

--- a/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/Configs.java
+++ b/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/Configs.java
@@ -1,0 +1,77 @@
+package com.linkedin.mxe;
+
+import com.linkedin.pegasus2avro.mxe.FailedMetadataChangeEvent;
+import com.linkedin.pegasus2avro.mxe.MetadataAuditEvent;
+import com.linkedin.pegasus2avro.mxe.MetadataChangeEvent;
+import com.linkedin.pegasus2avro.mxe.MetadataGraphEvent;
+import com.linkedin.pegasus2avro.mxe.MetadataSearchEvent;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificRecord;
+
+
+public class Configs {
+
+  public static final Map<String, String> FABRIC_SCHEMA_REGISTRY_MAP =
+      Collections.unmodifiableMap(new HashMap<String, String>() {
+        {
+          put("ei", "http://1.schemaregistry.ei4.atd.int.linkedin.com:10252");
+          put("corp", "http://1.schemaregistry.corp-lca1.atd.corp.linkedin.com:10252");
+        }
+      });
+
+  public static final Map<String, Schema> TOPIC_SCHEMA_MAP = Collections.unmodifiableMap(new HashMap<String, Schema>() {
+    {
+      put(Topics.METADATA_AUDIT_EVENT, MetadataAuditEvent.SCHEMA$);
+      put(Topics.METADATA_CHANGE_EVENT, MetadataChangeEvent.SCHEMA$);
+      put(Topics.FAILED_METADATA_CHANGE_EVENT, FailedMetadataChangeEvent.SCHEMA$);
+      put(Topics.METADATA_GRAPH_EVENT, MetadataGraphEvent.SCHEMA$);
+      put(Topics.METADATA_SEARCH_EVENT, MetadataSearchEvent.SCHEMA$);
+
+      put(Topics.DEV_METADATA_AUDIT_EVENT, MetadataAuditEvent.SCHEMA$);
+      put(Topics.DEV_METADATA_CHANGE_EVENT, MetadataChangeEvent.SCHEMA$);
+      put(Topics.DEV_FAILED_METADATA_CHANGE_EVENT, FailedMetadataChangeEvent.SCHEMA$);
+    }
+  });
+
+  public static final Map<String, Class<? extends SpecificRecord>> TOPIC_SCHEMA_CLASS_MAP =
+      Collections.unmodifiableMap(new HashMap<String, Class<? extends SpecificRecord>>() {
+        {
+          // Aspect-specific MCE topic to schema.
+          // CorpGroupUrn
+          put(Topics.METADATA_AUDIT_EVENT_CORPGROUP_CORPGROUPINFO,
+              com.linkedin.pegasus2avro.mxe.corpGroup.corpGroupInfo.MetadataAuditEvent.class);
+          // CorpUserUrn
+          put(Topics.METADATA_AUDIT_EVENT_CORPUSER_CORPUSERINFO,
+              com.linkedin.pegasus2avro.mxe.corpuser.corpUserInfo.MetadataAuditEvent.class);
+          put(Topics.METADATA_AUDIT_EVENT_CORPUSER_CORPUSEREDITABLEINFO,
+              com.linkedin.pegasus2avro.mxe.corpuser.corpUserEditableInfo.MetadataAuditEvent.class);
+
+          // Aspect-specific MCE topic to schema.
+          // CorpGroupUrn
+          put(Topics.METADATA_CHANGE_EVENT_CORPGROUP_CORPGROUPINFO,
+              com.linkedin.pegasus2avro.mxe.corpGroup.corpGroupInfo.MetadataChangeEvent.class);
+          // CorpUserUrn
+          put(Topics.METADATA_CHANGE_EVENT_CORPUSER_CORPUSERINFO,
+              com.linkedin.pegasus2avro.mxe.corpuser.corpUserInfo.MetadataChangeEvent.class);
+          put(Topics.METADATA_CHANGE_EVENT_CORPUSER_CORPUSEREDITABLEINFO,
+              com.linkedin.pegasus2avro.mxe.corpuser.corpUserEditableInfo.MetadataChangeEvent.class);
+
+          // Aspect-specific FMCE topic to schema.
+          // CorpGroupUrn
+          put(Topics.FAILED_METADATA_CHANGE_EVENT_CORPGROUP_CORPGROUPINFO,
+              com.linkedin.pegasus2avro.mxe.corpGroup.corpGroupInfo.FailedMetadataChangeEvent.class);
+          // CorpUserUrn
+          put(Topics.FAILED_METADATA_CHANGE_EVENT_CORPUSER_CORPUSERINFO,
+              com.linkedin.pegasus2avro.mxe.corpuser.corpUserInfo.FailedMetadataChangeEvent.class);
+          put(Topics.FAILED_METADATA_CHANGE_EVENT_CORPUSER_CORPUSEREDITABLEINFO,
+              com.linkedin.pegasus2avro.mxe.corpuser.corpUserEditableInfo.FailedMetadataChangeEvent.class);
+        }
+      });
+
+  private Configs() {
+    // Util class
+  }
+}

--- a/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/Topics.java
+++ b/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/Topics.java
@@ -1,11 +1,56 @@
 package com.linkedin.mxe;
 
 public class Topics {
-  public static final String METADATA_AUDIT_EVENT = "MetadataAuditEvent";
-  public static final String METADATA_CHANGE_EVENT = "MetadataChangeEvent";
-  public static final String FAILED_METADATA_CHANGE_EVENT = "FailedMetadataChangeEvent";
-  public static final String METADATA_GRAPH_EVENT = "MetadataGraphEvent";
-  public static final String METADATA_SEARCH_EVENT = "MetadataSearchEvent";
+  public static final String METADATA_AUDIT_EVENT = "MetadataAuditEvent_v4";
+  public static final String METADATA_CHANGE_EVENT = "MetadataChangeEvent_v4";
+  public static final String FAILED_METADATA_CHANGE_EVENT = "FailedMetadataChangeEvent_v4";
+  public static final String METADATA_GRAPH_EVENT = "MetadataGraphEvent_v4";
+  public static final String METADATA_SEARCH_EVENT = "MetadataSearchEvent_v4";
+
+  public static final String DEV_METADATA_AUDIT_EVENT = "MetadataAuditEvent_v4_dev";
+  public static final String DEV_METADATA_CHANGE_EVENT = "MetadataChangeEvent_v4_dev";
+  public static final String DEV_FAILED_METADATA_CHANGE_EVENT = "FailedMetadataChangeEvent_v4_dev";
+
+  /**
+   *  aspect-specific MAE topics.
+   *  format : METADATA_AUDIT_EVENT_<URN>_<ASPECT>
+   */
+  // MAE topics for CorpGroup entity.
+  public static final String METADATA_AUDIT_EVENT_CORPGROUP_CORPGROUPINFO =
+      "MetadataAuditEvent_CorpGroup_CorpGroupInfo_v1";
+
+  // MAE topics for CorpUser entity.
+  public static final String METADATA_AUDIT_EVENT_CORPUSER_CORPUSEREDITABLEINFO =
+      "MetadataAuditEvent_CorpUser_CorpUserEditableInfo_v2";
+  public static final String METADATA_AUDIT_EVENT_CORPUSER_CORPUSERINFO = "MetadataAuditEvent_CorpUser_CorpUserInfo_v2";
+
+  /**
+   *  aspect-specific MCE topics.
+   *  format : METADATA_CHANGE_EVENT_<URN>_<ASPECT>
+   */
+  // MCE topics for CorpGroup entity.
+  public static final String METADATA_CHANGE_EVENT_CORPGROUP_CORPGROUPINFO =
+      "MetadataChangeEvent_CorpGroup_CorpGroupInfo_v1";
+
+  // MCE topics for CorpUser entity.
+  public static final String METADATA_CHANGE_EVENT_CORPUSER_CORPUSEREDITABLEINFO =
+      "MetadataChangeEvent_CorpUser_CorpUserEditableInfo_v1";
+  public static final String METADATA_CHANGE_EVENT_CORPUSER_CORPUSERINFO =
+      "MetadataChangeEvent_CorpUser_CorpUserInfo_v1";
+
+  /**
+   *  aspect-specific FMCE topics.
+   *  format : FAILED_METADATA_CHANGE_EVENT_<URN>_<ASPECT>
+   */
+  // FMCE topics for CorpGroup entity.
+  public static final String FAILED_METADATA_CHANGE_EVENT_CORPGROUP_CORPGROUPINFO =
+      "FailedMetadataChangeEvent_CorpGroup_CorpGroupInfo_v1";
+
+  // FMCE topics for CorpUser entity.
+  public static final String FAILED_METADATA_CHANGE_EVENT_CORPUSER_CORPUSEREDITABLEINFO =
+      "FailedMetadataChangeEvent_CorpUser_CorpUserEditableInfo_v1";
+  public static final String FAILED_METADATA_CHANGE_EVENT_CORPUSER_CORPUSERINFO =
+      "FailedMetadataChangeEvent_CorpUser_CorpUserInfo_v1";
 
   private Topics() {
     // Util class

--- a/metadata-events/mxe-utils-avro-1.7/src/main/java/com/linkedin/metadata/EventUtils.java
+++ b/metadata-events/mxe-utils-avro-1.7/src/main/java/com/linkedin/metadata/EventUtils.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.linkedin.data.avro.DataTranslator;
 import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.mxe.FailedMetadataChangeEvent;
 import com.linkedin.mxe.MetadataAuditEvent;
 import com.linkedin.mxe.MetadataChangeEvent;
@@ -22,6 +23,7 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificRecord;
 
 
 public class EventUtils {
@@ -114,6 +116,24 @@ public class EventUtils {
   }
 
   /**
+   * Converts a Pegasus aspect specific MXE into the equivalent Avro model as a {@link GenericRecord}.
+   *
+   * @param event the Pegasus aspect specific MXE model
+   * @return the Avro model with com.linkedin.pegasus2avro.mxe namesapce
+   * @throws IOException if the conversion fails
+   */
+
+  @Nonnull
+  public static <MXE extends GenericRecord, T extends SpecificRecord> MXE pegasusToAvroAspectSpecificMXE(
+      @Nonnull Class<T> clazz, @Nonnull RecordTemplate event)
+      throws NoSuchFieldException, IOException, IllegalAccessException {
+    final Schema newSchema = (Schema) clazz.getField("SCHEMA$").get(null);
+    final Schema originalSchema = getAvroSchemaFromResource(getAvroResourcePath(clazz));
+    final GenericRecord original = DataTranslator.dataMapToGenericRecord(event.data(), event.schema(), originalSchema);
+    return (MXE) renameSchemaNamespace(original, originalSchema, newSchema);
+  }
+
+  /**
    * Converts a Pegasus Failed MCE into the equivalent Avro model as a {@link GenericRecord}.
    *
    * @param failedMetadataChangeEvent the Pegasus {@link FailedMetadataChangeEvent} model
@@ -169,5 +189,19 @@ public class EventUtils {
         return reader.read(null, decoder);
       }
     }
+  }
+
+  /**
+   * Get Pegasus class from Avro class.
+   * @param clazz the aspect specific MXE avro class
+   * @return the Pegasus aspect specific MXE class
+   * @throws Exception
+   */
+  public static Class<?> getPegasusClass(@Nonnull Class<?> clazz) throws ClassNotFoundException {
+    return Class.forName(clazz.getCanonicalName().replace(".pegasus2avro", ""));
+  }
+
+  private static String getAvroResourcePath(@Nonnull Class<?> clazz) {
+    return String.format("avro/%s.avsc", clazz.getCanonicalName().replace(".pegasus2avro", "").replace(".", "/"));
   }
 }

--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/EventSchemaComposer.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/EventSchemaComposer.java
@@ -58,6 +58,10 @@ public class EventSchemaComposer extends RythmGenerator {
     // generate FMCE
     writeToFile(new File(directory, FAILED_METADATA_CHANGE_EVENT + PDL_SUFFIX),
         renderToString(eventSpec, entityUrn, namespace, EVENT_TEMPLATES.get(FAILED_METADATA_CHANGE_EVENT)));
+
+    // generate MAE
+    writeToFile(new File(directory, METADATA_AUDIT_EVENT + PDL_SUFFIX),
+        renderToString(eventSpec, entityUrn, namespace, EVENT_TEMPLATES.get(METADATA_AUDIT_EVENT)));
   }
 
   @Nonnull

--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorConstants.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/SchemaGeneratorConstants.java
@@ -19,12 +19,14 @@ public class SchemaGeneratorConstants {
   // used in EventSchemaComposer
   static final String FAILED_METADATA_CHANGE_EVENT = "FailedMetadataChangeEvent";
   static final String FAILED_METADATA_CHANGE_EVENT_PREFIX = "Failed";
+  static final String METADATA_AUDIT_EVENT = "MetadataAuditEvent";
   static final String METADATA_CHANGE_EVENT = "MetadataChangeEvent";
   static final String PDL_SUFFIX = ".pdl";
   static final Map<String, String> EVENT_TEMPLATES = Collections.unmodifiableMap(new HashMap<String, String>() {
     {
-      put(METADATA_CHANGE_EVENT, "MetadataChangeEvent.rythm");
       put(FAILED_METADATA_CHANGE_EVENT, "FailedMetadataChangeEvent.rythm");
+      put(METADATA_AUDIT_EVENT, "MetadataAuditEvent.rythm");
+      put(METADATA_CHANGE_EVENT, "MetadataChangeEvent.rythm");
     }
   });
 }

--- a/metadata-models-generator/src/main/resources/MetadataAuditEvent.rythm
+++ b/metadata-models-generator/src/main/resources/MetadataAuditEvent.rythm
@@ -1,0 +1,36 @@
+@import com.linkedin.metadata.generator.EventSpec;
+@import com.linkedin.metadata.generator.SchemaGeneratorUtil;
+@args String entityUrn, String nameSpace EventSpec eventSpec
+@assign (entityName) {@SchemaGeneratorUtil.getEntityName(entityUrn)}
+namespace com.linkedin.mxe@(nameSpace)
+
+import com.linkedin.avro2pegasus.events.KafkaAuditHeader
+import @entityUrn
+import @eventSpec.getFullValueType()
+
+/**
+ * MetadataAuditEvent for the @(entityName)Urn with @(eventSpec.getValueType()) aspect.
+ */
+@@MetadataAuditEvent
+record MetadataAuditEvent {
+
+  /**
+   * Kafka audit header for the MetadataAuditEvent.
+   */
+  auditHeader: optional KafkaAuditHeader
+
+  /**
+   * @(entityName)Urn as the key for the MetadataAuditEvent.
+   */
+  urn: @(entityName)Urn
+
+  /**
+   * Aspect of the @eventSpec.getValueType() before the update.
+   */
+  oldValue: optional @eventSpec.getValueType()
+
+  /**
+   * Aspect of the @eventSpec.getValueType() after the update.
+   */
+  newValue: @eventSpec.getValueType()
+}

--- a/metadata-models-generator/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
+++ b/metadata-models-generator/src/test/java/com/linkedin/metadata/generator/TestEventSchemaComposer.java
@@ -45,6 +45,21 @@ public class TestEventSchemaComposer {
             + TEST_GENERATED_PDL)));
   }
 
+  @Test
+  public void testMAESchemaRender() throws Exception {
+    final String testMAE =
+        GENERATED_MXE_PATH + TEST_NAMESPACE + File.separator + METADATA_AUDIT_EVENT + PDL_SUFFIX;
+    final File metadataAuditEventBar = new File(testMAE);
+
+    populateEvents();
+
+    assertTrue(metadataAuditEventBar.exists());
+    assertEquals(IOUtils.toString(new FileInputStream(testMAE)), IOUtils.toString(this.getClass()
+        .getClassLoader()
+        .getResourceAsStream(
+            "com/linkedin/mxe" + TEST_NAMESPACE + File.separator + METADATA_AUDIT_EVENT + PDL_SUFFIX)));
+  }
+
   private void populateEvents() throws Exception {
     SchemaAnnotationRetriever schemaAnnotationRetriever =
         new SchemaAnnotationRetriever(TEST_METADATA_MODELS_RESOLVED_PATH);

--- a/metadata-models-generator/src/test/resources/com/linkedin/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
+++ b/metadata-models-generator/src/test/resources/com/linkedin/mxe/bar/annotatedAspectBar/MetadataAuditEvent.pdl
@@ -1,0 +1,32 @@
+namespace com.linkedin.mxe.bar.annotatedAspectBar
+
+import com.linkedin.avro2pegasus.events.KafkaAuditHeader
+import com.linkedin.testing.BarUrn
+import com.linkedin.testing.AnnotatedAspectBar
+
+/**
+ * MetadataAuditEvent for the BarUrn with AnnotatedAspectBar aspect.
+ */
+@MetadataAuditEvent
+record MetadataAuditEvent {
+
+  /**
+   * Kafka audit header for the MetadataAuditEvent.
+   */
+  auditHeader: optional KafkaAuditHeader
+
+  /**
+   * BarUrn as the key for the MetadataAuditEvent.
+   */
+  urn: BarUrn
+
+  /**
+   * Aspect of the AnnotatedAspectBar before the update.
+   */
+  oldValue: optional AnnotatedAspectBar
+
+  /**
+   * Aspect of the AnnotatedAspectBar after the update.
+   */
+  newValue: AnnotatedAspectBar
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpGroupInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpGroupInfo.pdl
@@ -7,6 +7,7 @@ import com.linkedin.common.EmailAddress
 /**
  * group of corpUser, it may contains nested group
  */
+@Aspect.EntityUrns = [ "com.linkedin.common.CorpGroupUrn" ]
 record CorpGroupInfo {
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserEditableInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserEditableInfo.pdl
@@ -5,6 +5,7 @@ import com.linkedin.common.Url
 /**
  * Linkedin corp user information that can be edited from UI
  */
+@Aspect.EntityUrns = [ "com.linkedin.common.CorpuserUrn" ]
 record CorpUserEditableInfo {
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserInfo.pdl
@@ -6,6 +6,7 @@ import com.linkedin.common.EmailAddress
 /**
  * Linkedin corp user information
  */
+@Aspect.EntityUrns = [ "com.linkedin.common.CorpuserUrn" ]
 record CorpUserInfo {
 
   /**

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseBrowsableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseBrowsableClient.java
@@ -1,0 +1,51 @@
+package com.linkedin.metadata.restli;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.BrowseResult;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.Client;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Base client that all entities supporting browse as well as search should implement in their respective restli MPs
+ * @param <VALUE> the client's value type
+ * @param <URN> urn type of the entity
+ */
+public abstract class BaseBrowsableClient<VALUE extends RecordTemplate, URN extends Urn> extends BaseSearchableClient<VALUE> {
+
+  public BaseBrowsableClient(@Nonnull Client restliClient) {
+    super(restliClient);
+  }
+
+  /**
+   * Browse method that the client extending this class must implement. Returns {@link BrowseResult} containing list of groups/entities
+   * that match given browse request
+   *
+   * @param inputPath Path to be browsed
+   * @param requestFilters Request map with fields and values to be applied as filters to the browse query
+   * @param from Start index of the first entity located in path
+   * @param size The max number of entities contained in the response
+   * @return {@link BrowseResult} containing list of groups/entities
+   * @throws RemoteInvocationException when the rest.li request fails
+   */
+  @Nonnull
+  public abstract BrowseResult browse(@Nonnull String inputPath, @Nullable Map<String, String> requestFilters, int from, int size)
+      throws RemoteInvocationException;
+
+  /**
+   * Returns a list of paths for a given urn
+   *
+   * @param urn Urn of the entity
+   * @return all paths that are related to the urn
+   * @throws RemoteInvocationException when the rest.li request fails
+   */
+  @Nonnull
+  public StringArray getBrowsePaths(@Nonnull URN urn) throws RemoteInvocationException {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
+
+}

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSearchableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSearchableClient.java
@@ -1,0 +1,65 @@
+package com.linkedin.metadata.restli;
+
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.Client;
+import com.linkedin.restli.common.CollectionResponse;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Base client that all entities supporting search should implement in their respective restli MPs
+ * @param <VALUE> the client's value type
+ */
+public abstract class BaseSearchableClient<VALUE extends RecordTemplate> extends BaseClient {
+
+  public BaseSearchableClient(@Nonnull Client restliClient) {
+    super(restliClient);
+  }
+
+  /**
+   * Search method that the client inheriting this class must implement. Returns {@link CollectionResponse} containing list of aspects
+   *
+   * @param input Input query
+   * @param aspectNames List of aspects to be returned in the VALUE model
+   * @param requestFilters Request map with fields and values to be applied as filters to the search query
+   * @param sortCriterion {@link SortCriterion} to be applied to search results
+   * @param start Start of the page
+   * @param count Number of search results to return
+   * @return {@link CollectionResponse} of VALUE for the records that satisfy the given search query
+   * @throws RemoteInvocationException when the rest.li request fails
+   */
+  @Nonnull
+  public abstract CollectionResponse<VALUE> search(@Nonnull String input, @Nonnull StringArray aspectNames, @Nullable Map<String, String> requestFilters,
+      @Nullable SortCriterion sortCriterion, int start, int count) throws RemoteInvocationException;
+
+  /**
+   * Similar to {@link #search(String, StringArray, Map, SortCriterion, int, int)} with empty list for aspect names, meaning all aspects will be returned
+   */
+  @Nonnull
+  public CollectionResponse<VALUE> search(@Nonnull String input, @Nullable Map<String, String> requestFilters,
+      @Nullable SortCriterion sortCriterion, int start, int count) throws RemoteInvocationException {
+    return search(input, new StringArray(), requestFilters, sortCriterion, start, count);
+  }
+
+  /**
+   * Autocomplete method that the client will override only if they need this capability. It returns {@link AutoCompleteResult} containing list of suggestions.
+   *
+   * @param query Input query
+   * @param field Field against which the query needs autocompletion
+   * @param requestFilters Request map with fields and values to be applied as filters to the autocomplete query
+   * @param limit Number of suggestions returned
+   * @return {@link AutoCompleteResult} containing list of suggestions as strings
+   * @throws RemoteInvocationException when the rest.li request fails
+   */
+  @Nonnull
+  public AutoCompleteResult autocomplete(@Nonnull String query, @Nullable String field,
+      @Nullable Map<String, String> requestFilters, int limit) throws RemoteInvocationException {
+    throw new UnsupportedOperationException("Not implemented yet.");
+  }
+
+}

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BrowsableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BrowsableClient.java
@@ -11,6 +11,8 @@ import javax.annotation.Nullable;
 
 /**
  * Interface which all entities supporting browse should implement in their respective restli MPs
+ *
+ * @deprecated Use {@link BaseBrowsableClient} instead
  */
 public interface BrowsableClient<URN extends Urn> {
 

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/SearchableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/SearchableClient.java
@@ -13,6 +13,8 @@ import javax.annotation.Nullable;
 /**
  * Interface that all entities that support search and autocomplete should implement in their respective restli MPs
  * @param <VALUE> the client's value type
+ *
+ * @deprecated Use {@link BaseSearchableClient} instead
  */
 public interface SearchableClient<VALUE extends RecordTemplate> {
 

--- a/metadata-restli-resource/src/test/java/com/linkedin/metadata/restli/BaseBrowsableClientTest.java
+++ b/metadata-restli-resource/src/test/java/com/linkedin/metadata/restli/BaseBrowsableClientTest.java
@@ -1,0 +1,72 @@
+package com.linkedin.metadata.restli;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.BrowseResult;
+import com.linkedin.metadata.query.BrowseResultEntityArray;
+import com.linkedin.metadata.query.BrowseResultMetadata;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.Client;
+import com.linkedin.restli.common.CollectionMetadata;
+import com.linkedin.restli.common.CollectionResponse;
+import com.linkedin.testing.EntityValue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+public class BaseBrowsableClientTest {
+
+  private Client _mockRestClient;
+
+  public static class TestBrowsableClient extends BaseBrowsableClient<EntityValue, Urn> {
+
+    public TestBrowsableClient(@Nonnull Client restliClient) {
+      super(restliClient);
+    }
+
+    @Override
+    @Nonnull
+    public BrowseResult browse(@Nonnull String inputPath, @Nullable Map<String, String> requestFilters, int from, int size) throws RemoteInvocationException {
+      BrowseResultMetadata browseResultMetadata = new BrowseResultMetadata().setTotalNumEntities(100);
+      return new BrowseResult().setEntities(new BrowseResultEntityArray()).setFrom(0).setPageSize(10).setMetadata(browseResultMetadata).setNumEntities(8);
+    }
+
+    @Override
+    @Nonnull
+    public StringArray getBrowsePaths(@Nonnull Urn urn) throws RemoteInvocationException {
+      return new StringArray(Arrays.asList("/root/path1", "/root/path2", "/root/path3"));
+    }
+
+    @Override
+    @Nonnull
+    public CollectionResponse<EntityValue> search(@Nonnull String input, @Nonnull StringArray aspectNames, @Nullable Map<String, String> requestFilters,
+        @Nullable SortCriterion sortCriterion, int start, int count) throws RemoteInvocationException {
+      CollectionResponse<EntityValue> collectionResponse = new CollectionResponse<>(EntityValue.class);
+      collectionResponse.setPaging(new CollectionMetadata().setTotal(200));
+      return collectionResponse;
+    }
+  }
+
+  @BeforeMethod
+  public void setup() {
+    _mockRestClient = mock(Client.class);
+  }
+
+  @Test
+  public void testClient() throws RemoteInvocationException {
+    TestBrowsableClient testBrowsableClient = new TestBrowsableClient(_mockRestClient);
+    assertEquals(testBrowsableClient.search("test", new StringArray(), new HashMap<>(), null, 0,
+        10).getPaging().getTotal().intValue(), 200);
+    assertEquals(testBrowsableClient.browse("/root", null, 0, 10).getNumEntities().intValue(), 8);
+    assertEquals(testBrowsableClient.browse("/root", null, 0, 10).getPageSize().intValue(), 10);
+  }
+
+}

--- a/metadata-restli-resource/src/test/java/com/linkedin/metadata/restli/BaseSearchableClientTest.java
+++ b/metadata-restli-resource/src/test/java/com/linkedin/metadata/restli/BaseSearchableClientTest.java
@@ -1,0 +1,51 @@
+package com.linkedin.metadata.restli;
+
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.Client;
+import com.linkedin.restli.common.CollectionMetadata;
+import com.linkedin.restli.common.CollectionResponse;
+import com.linkedin.testing.EntityValue;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+public class BaseSearchableClientTest {
+
+  private Client _mockRestClient;
+
+  public static class TestSearchableClient extends BaseSearchableClient<EntityValue> {
+
+    public TestSearchableClient(@Nonnull Client restliClient) {
+      super(restliClient);
+    }
+
+    @Override
+    @Nonnull
+    public CollectionResponse<EntityValue> search(@Nonnull String input, @Nonnull StringArray aspectNames, @Nullable Map<String, String> requestFilters,
+        @Nullable SortCriterion sortCriterion, int start, int count) throws RemoteInvocationException {
+      CollectionResponse<EntityValue> collectionResponse = new CollectionResponse<>(EntityValue.class);
+      collectionResponse.setPaging(new CollectionMetadata().setTotal(100));
+      return collectionResponse;
+    }
+  }
+
+  @BeforeMethod
+  public void setup() {
+    _mockRestClient = mock(Client.class);
+  }
+
+  @Test
+  public void testClient() throws RemoteInvocationException {
+    TestSearchableClient testSearchableClient = new TestSearchableClient(_mockRestClient);
+    assertEquals(testSearchableClient.search("test", new StringArray(), new HashMap<>(), null, 0,
+        10).getPaging().getTotal().intValue(), 100);
+  }
+}

--- a/metadata-testing/metadata-test-models/src/main/pegasus/com/linkedin/testing/RelationshipFoo.pdl
+++ b/metadata-testing/metadata-test-models/src/main/pegasus/com/linkedin/testing/RelationshipFoo.pdl
@@ -12,17 +12,22 @@ import com.linkedin.common.Urn
 record RelationshipFoo {
 
   /**
-   * For unit tests
+   * Urn of the source entity
    */
   source: Urn
 
   /**
-   * For unit tests
+   * Urn of the destination entity
    */
   destination: Urn
 
   /**
-   * Attribute for the relationship, for unit tests
+   * Type attribute of the relationship
    */
   type: optional string
+
+  /**
+   * Integer field as a relationship attribute
+   */
+  intField: optional int
 }


### PR DESCRIPTION
Convert getNodesInTraversedPath to getSubgraph to return complete view of the subgraph (nodes+edges)
Deprecate BrowsableClient/SearchableClient
Register all aspect specific MAE topics under corp-identity-gms
Add base searchable and browsable client
Emit Aspect Specific MAE only if there is a diff 
Register corpGroup MXE_v5
Enable mxe-util-avro-1.7
Enable the AspectSpecificMAE emission configurable.
Produce AspectSpecificMAE in KafkaMetadataEventProducer
Add DAO for metadata_index table
Adding complete set of reserved characters to escape for browse query
Add Urn in MAE_v5
Refactor avroToPegasusAspectSpecificMCE to generic method
Remove validations on the base client. A better way of validating the models is using DataTemplateUtil.areEqual()
Register CorpUser MAE_v5
Render the MAE_v5

MP_VERSION=metadata-models:80.0.0
MP_VERSION=wherehows-samza:1.0.56

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
