### PR TITLE
Add workflow to check build and tests on PRs + releases.

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,26 @@
+name: Gradle Build & Test
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  release:
+    types: [published, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Gradle build (and test)
+        run: ./gradlew build

--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -1,5 +1,5 @@
 name: datahub-frontend docker
-on: 
+on:
   push:
     branches:
       - master
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'linkedin/datahub' }}
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -1,5 +1,5 @@
 name: datahub-gms docker
-on: 
+on:
   push:
     branches:
       - master
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'linkedin/datahub' }}
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -1,5 +1,5 @@
 name: datahub-mae-consumer docker
-on: 
+on:
   push:
     branches:
       - master
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'linkedin/datahub' }}
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -1,5 +1,5 @@
 name: datahub-mce-consumer docker
-on: 
+on:
   push:
     branches:
       - master
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'linkedin/datahub' }}
     steps:
       - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1


### PR DESCRIPTION
PRs are setup to skip docs.

Also, only run docker actions on linkedin/datahub (i.e. disable on forks; makes forks nicer since you don't have failing actions).


See it in action in my fork (and it should also show up in this PR?):
- https://github.com/jplaisted/datahub/pull/1
- (test the disabled feature) https://github.com/jplaisted/datahub/pull/2
- (test enabling) https://github.com/jplaisted/datahub/pull/3

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
