### PR TITLE
bug: Fix docker actions.

### DIFF
--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -6,32 +6,65 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-frontend.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
   release:
     types: [published, edited]
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'linkedin/datahub' }}
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
     steps:
       - uses: actions/checkout@v2
       - id: tag
         run: |
-          TAG=$(echo ${GITHUB_REF} | sed -e 's/refs\/heads\/master/latest/g' | sed -e 's/refs\/tags\///g')
+          echo "GITHUB_REF: $GITHUB_REF"
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' | sed -e 's,refs/tags/,,g' | sed -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  build-and-publish-dockerhub:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
         env:
           DOCKER_BUILDKIT: 1
         with:
-          dockerfile: ./docker/frontend/Dockerfile
+          dockerfile: ./docker/datahub-frontend/Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: linkedin/datahub-frontend
-          tags: ${{ steps.tag.outputs.tag }}
+          tags: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}
+  build-and-publish-github:
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: VaultVulp/gp-docker-action@1.1.6
+        env:
+          DOCKER_BUILDKIT: 1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/frontend/Dockerfile
+          dockerfile: ./docker/datahub-frontend/Dockerfile
           image-name: datahub-frontend
-          image-tag: ${{ steps.tag.outputs.tag }}
+          image-tag: ${{ needs.setup.outputs.tag }}

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -6,32 +6,65 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-gms.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
   release:
     types: [published, edited]
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'linkedin/datahub' }}
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
     steps:
       - uses: actions/checkout@v2
       - id: tag
         run: |
-          TAG=$(echo ${GITHUB_REF} | sed -e 's/refs\/heads\/master/latest/g' | sed -e 's/refs\/tags\///g')
+          echo "GITHUB_REF: $GITHUB_REF"
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' | sed -e 's,refs/tags/,,g' | sed -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  build-and-publish-dockerhub:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
         env:
           DOCKER_BUILDKIT: 1
         with:
-          dockerfile: ./docker/gms/Dockerfile
+          dockerfile: ./docker/datahub-gms/Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: linkedin/datahub-gms
-          tags: ${{ steps.tag.outputs.tag }}
+          tags: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}
+  build-and-publish-github:
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: VaultVulp/gp-docker-action@1.1.6
+        env:
+          DOCKER_BUILDKIT: 1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/gms/Dockerfile
+          dockerfile: ./docker/datahub-gms/Dockerfile
           image-name: datahub-gms
-          image-tag: ${{ steps.tag.outputs.tag }}
+          image-tag: ${{ needs.setup.outputs.tag }}

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -6,32 +6,65 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-mae-consumer.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
   release:
     types: [published, edited]
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'linkedin/datahub' }}
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
     steps:
       - uses: actions/checkout@v2
       - id: tag
         run: |
-          TAG=$(echo ${GITHUB_REF} | sed -e 's/refs\/heads\/master/latest/g' | sed -e 's/refs\/tags\///g')
+          echo "GITHUB_REF: $GITHUB_REF"
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' | sed -e 's,refs/tags/,,g' | sed -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  build-and-publish-dockerhub:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
         env:
           DOCKER_BUILDKIT: 1
         with:
-          dockerfile: ./docker/mae-consumer/Dockerfile
+          dockerfile: ./docker/datahub-mae-consumer/Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: linkedin/datahub-mae-consumer
-          tags: ${{ steps.tag.outputs.tag }}
+          tags: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}
+  build-and-publish-github:
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: VaultVulp/gp-docker-action@1.1.6
+        env:
+          DOCKER_BUILDKIT: 1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/mae-consumer/Dockerfile
+          dockerfile: ./docker/datahub-mae-consumer/Dockerfile
           image-name: datahub-mae-consumer
-          image-tag: ${{ steps.tag.outputs.tag }}
+          image-tag: ${{ needs.setup.outputs.tag }}

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -6,32 +6,65 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-mce-consumer.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
   release:
     types: [published, edited]
 
 jobs:
-  build:
+  setup:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'linkedin/datahub' }}
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
     steps:
       - uses: actions/checkout@v2
       - id: tag
         run: |
-          TAG=$(echo ${GITHUB_REF} | sed -e 's/refs\/heads\/master/latest/g' | sed -e 's/refs\/tags\///g')
+          echo "GITHUB_REF: $GITHUB_REF"
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' | sed -e 's,refs/tags/,,g' | sed -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  build-and-publish-dockerhub:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: docker/build-push-action@v1
         env:
           DOCKER_BUILDKIT: 1
         with:
-          dockerfile: ./docker/mce-consumer/Dockerfile
+          dockerfile: ./docker/datahub-mce-consumer/Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: linkedin/datahub-mce-consumer
-          tags: ${{ steps.tag.outputs.tag }}
+          tags: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}
+  build-and-publish-github:
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
       - uses: VaultVulp/gp-docker-action@1.1.6
+        env:
+          DOCKER_BUILDKIT: 1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/mce-consumer/Dockerfile
+          dockerfile: ./docker/datahub-mce-consumer/Dockerfile
           image-name: datahub-mce-consumer
-          image-tag: ${{ steps.tag.outputs.tag }}
+          image-tag: ${{ needs.setup.outputs.tag }}


### PR DESCRIPTION
We renamed directories in docker/ which broke the actions.

Also try to refactor the action files a little so that we can run (but not publish) these images on pull requests that change the docker/ dir as an extra check. Note this only seems to be supported by the dockerhub plugin; the github plugin doesn't support this (so that will be an issue when we move to it only).



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
