### PR TITLE
fix(search): clear description from dataset index when it's cleared

### DIFF
--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
@@ -72,6 +72,8 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
     final DatasetDocument doc = setUrnDerivedFields(urn);
     if (datasetProperties.hasDescription()) {
       doc.setDescription(datasetProperties.getDescription());
+    } else {
+      doc.setDescription("");
     }
     return doc;
   }

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
@@ -1,0 +1,40 @@
+package com.linkedin.metadata.builders.search;
+
+import com.linkedin.common.FabricType;
+import com.linkedin.common.urn.DataPlatformUrn;
+import com.linkedin.common.urn.DatasetUrn;
+import com.linkedin.dataset.DatasetProperties;
+import com.linkedin.metadata.aspect.DatasetAspect;
+import com.linkedin.metadata.dao.utils.ModelUtils;
+import com.linkedin.metadata.search.DatasetDocument;
+import com.linkedin.metadata.snapshot.DatasetSnapshot;
+import java.util.Collections;
+import java.util.List;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class DatasetIndexBuilderTest {
+
+  @Test
+  public void testDescriptionClearing() {
+    DatasetUrn datasetUrn = new DatasetUrn(new DataPlatformUrn("foo"), "bar", FabricType.PROD);
+
+    DatasetProperties datasetProperties = new DatasetProperties().setDescription("baz");
+    DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
+        Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetProperties)));
+    List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
+    assertEquals(actualDocs.size(), 1);
+    assertEquals(actualDocs.get(0).getUrn(), datasetUrn);
+    assertEquals(actualDocs.get(0).getDescription(), "baz");
+
+    datasetProperties = new DatasetProperties();
+    datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
+        Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetProperties)));
+    actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
+    assertEquals(actualDocs.size(), 1);
+    assertEquals(actualDocs.get(0).getUrn(), datasetUrn);
+    assertEquals(actualDocs.get(0).getDescription(), "");
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/linkedin/datahub/issues/1798

Also verified end-to-end
1. Set the dataset description
2. Make sure it's searchable
3. Clear dataset description
4. Make sure it's unsearchable

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
