### PR TITLE
fix: update defaults of aspectNames params

### DIFF
--- a/gms/api/src/main/idl/com.linkedin.dataprocess.dataProcesses.restspec.json
+++ b/gms/api/src/main/idl/com.linkedin.dataprocess.dataProcesses.restspec.json
@@ -16,21 +16,21 @@
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     }, {
       "method" : "batch_get",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     }, {
       "method" : "get_all",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       }, {
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.Filter",
@@ -50,7 +50,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       }, {
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.Filter",
@@ -89,7 +89,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
     }, {
@@ -100,7 +100,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "com.linkedin.metadata.snapshot.DataProcessSnapshot"
     }, {

--- a/gms/api/src/main/idl/com.linkedin.dataset.datasets.restspec.json
+++ b/gms/api/src/main/idl/com.linkedin.dataset.datasets.restspec.json
@@ -16,14 +16,14 @@
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     }, {
       "method" : "batch_get",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     } ],
     "finders" : [ {
@@ -34,7 +34,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       }, {
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.Filter",
@@ -73,7 +73,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
     }, {
@@ -108,7 +108,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "com.linkedin.metadata.snapshot.DatasetSnapshot"
     }, {

--- a/gms/api/src/main/idl/com.linkedin.identity.corpGroups.restspec.json
+++ b/gms/api/src/main/idl/com.linkedin.identity.corpGroups.restspec.json
@@ -16,14 +16,14 @@
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     }, {
       "method" : "batch_get",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     } ],
     "finders" : [ {
@@ -34,7 +34,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       }, {
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.Filter",
@@ -73,7 +73,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
     }, {
@@ -84,7 +84,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "com.linkedin.metadata.snapshot.CorpGroupSnapshot"
     }, {

--- a/gms/api/src/main/idl/com.linkedin.identity.corpUsers.restspec.json
+++ b/gms/api/src/main/idl/com.linkedin.identity.corpUsers.restspec.json
@@ -16,21 +16,21 @@
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     }, {
       "method" : "batch_get",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ]
     }, {
       "method" : "get_all",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       }, {
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.Filter",
@@ -50,7 +50,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       }, {
         "name" : "filter",
         "type" : "com.linkedin.metadata.query.Filter",
@@ -89,7 +89,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
     }, {
@@ -100,7 +100,7 @@
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "default" : "[]"
+        "optional" : true
       } ],
       "returns" : "com.linkedin.metadata.snapshot.CorpUserSnapshot"
     }, {

--- a/gms/api/src/main/snapshot/com.linkedin.dataprocess.dataProcesses.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataprocess.dataProcesses.snapshot.json
@@ -429,21 +429,21 @@
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       }, {
         "method" : "batch_get",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       }, {
         "method" : "get_all",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.Filter",
@@ -463,7 +463,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.Filter",
@@ -502,7 +502,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
       }, {
@@ -513,7 +513,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "com.linkedin.metadata.snapshot.DataProcessSnapshot"
       }, {

--- a/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
@@ -1091,14 +1091,14 @@
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       }, {
         "method" : "batch_get",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       } ],
       "finders" : [ {
@@ -1109,7 +1109,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.Filter",
@@ -1148,7 +1148,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
       }, {
@@ -1183,7 +1183,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "com.linkedin.metadata.snapshot.DatasetSnapshot"
       }, {

--- a/gms/api/src/main/snapshot/com.linkedin.identity.corpGroups.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.identity.corpGroups.snapshot.json
@@ -120,7 +120,10 @@
             "items" : "com.linkedin.common.CorpGroupUrn"
           },
           "doc" : "List of groups in this group."
-        } ]
+        } ],
+        "Aspect" : {
+          "EntityUrns" : [ "com.linkedin.common.CorpGroupUrn" ]
+        }
       },
       "doc" : "Information of the corp group",
       "optional" : true
@@ -300,14 +303,14 @@
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       }, {
         "method" : "batch_get",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       } ],
       "finders" : [ {
@@ -318,7 +321,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.Filter",
@@ -357,7 +360,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
       }, {
@@ -368,7 +371,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "com.linkedin.metadata.snapshot.CorpGroupSnapshot"
       }, {

--- a/gms/api/src/main/snapshot/com.linkedin.identity.corpUsers.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.identity.corpUsers.snapshot.json
@@ -117,7 +117,10 @@
           "type" : "string",
           "doc" : "two uppercase letters country code. e.g.  US",
           "optional" : true
-        } ]
+        } ],
+        "Aspect" : {
+          "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ]
+        }
       },
       "doc" : "Information of the corp user",
       "optional" : true
@@ -153,7 +156,10 @@
           "type" : "com.linkedin.common.Url",
           "doc" : "A URL which points to a picture which user wants to set as a profile photo",
           "default" : "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web/packages/data-portal/public/assets/images/default_avatar.png"
-        } ]
+        } ],
+        "Aspect" : {
+          "EntityUrns" : [ "com.linkedin.common.CorpuserUrn" ]
+        }
       },
       "doc" : "Editable information of the corp user",
       "optional" : true
@@ -349,21 +355,21 @@
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       }, {
         "method" : "batch_get",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ]
       }, {
         "method" : "get_all",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.Filter",
@@ -383,7 +389,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         }, {
           "name" : "filter",
           "type" : "com.linkedin.metadata.query.Filter",
@@ -422,7 +428,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "{ \"type\" : \"array\", \"items\" : \"string\" }"
       }, {
@@ -433,7 +439,7 @@
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "default" : "[]"
+          "optional" : true
         } ],
         "returns" : "com.linkedin.metadata.snapshot.CorpUserSnapshot"
       }, {

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataprocess/DataProcesses.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataprocess/DataProcesses.java
@@ -139,7 +139,7 @@ public class DataProcesses extends BaseSearchableEntityResource<
     @Override
     @Nonnull
     public Task<DataProcess> get(@Nonnull ComplexResourceKey<DataProcessKey, EmptyRecord> key,
-                                 @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+                                 @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
         return super.get(key, aspectNames);
     }
 
@@ -148,14 +148,14 @@ public class DataProcesses extends BaseSearchableEntityResource<
     @Nonnull
     public Task<Map<ComplexResourceKey<DataProcessKey, EmptyRecord>, DataProcess>> batchGet(
             @Nonnull Set<ComplexResourceKey<DataProcessKey, EmptyRecord>> keys,
-            @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+            @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
         return super.batchGet(keys, aspectNames);
     }
 
     @RestMethod.GetAll
     @Nonnull
     public Task<List<DataProcess>> getAll(@PagingContextParam @Nonnull PagingContext pagingContext,
-        @QueryParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames,
+        @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
         @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
         @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion) {
         return super.getAll(pagingContext, aspectNames, filter, sortCriterion);
@@ -165,7 +165,7 @@ public class DataProcesses extends BaseSearchableEntityResource<
     @Override
     @Nonnull
     public Task<CollectionResult<DataProcess, SearchResultMetadata>> search(@QueryParam(PARAM_INPUT) @Nonnull String input,
-                                                                            @QueryParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames,
+                                                                            @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
                                                                             @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
                                                                             @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion,
                                                                             @PagingContextParam @Nonnull PagingContext pagingContext) {
@@ -191,7 +191,7 @@ public class DataProcesses extends BaseSearchableEntityResource<
     @Override
     @Nonnull
     public Task<DataProcessSnapshot> getSnapshot(@ActionParam(PARAM_URN) @Nonnull String urnString,
-                                                 @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+                                                 @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
         return super.getSnapshot(urnString, aspectNames);
     }
 
@@ -199,7 +199,7 @@ public class DataProcesses extends BaseSearchableEntityResource<
     @Override
     @Nonnull
     public Task<String[]> backfill(@ActionParam(PARAM_URN) @Nonnull String urnString,
-                                   @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+                                   @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
         return super.backfill(urnString, aspectNames);
     }
 }

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataset/Datasets.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataset/Datasets.java
@@ -173,7 +173,7 @@ public final class Datasets extends BaseBrowsableEntityResource<
   @Override
   @Nonnull
   public Task<Dataset> get(@Nonnull ComplexResourceKey<DatasetKey, EmptyRecord> key,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.get(key, aspectNames);
   }
 
@@ -182,7 +182,7 @@ public final class Datasets extends BaseBrowsableEntityResource<
   @Nonnull
   public Task<Map<ComplexResourceKey<DatasetKey, EmptyRecord>, Dataset>> batchGet(
       @Nonnull Set<ComplexResourceKey<DatasetKey, EmptyRecord>> keys,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.batchGet(keys, aspectNames);
   }
 
@@ -190,7 +190,7 @@ public final class Datasets extends BaseBrowsableEntityResource<
   @Override
   @Nonnull
   public Task<CollectionResult<Dataset, SearchResultMetadata>> search(@QueryParam(PARAM_INPUT) @Nonnull String input,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames,
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
       @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
       @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion,
       @PagingContextParam @Nonnull PagingContext pagingContext) {
@@ -231,14 +231,14 @@ public final class Datasets extends BaseBrowsableEntityResource<
   @Override
   @Nonnull
   public Task<DatasetSnapshot> getSnapshot(@ActionParam(PARAM_URN) @Nonnull String urnString,
-      @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.getSnapshot(urnString, aspectNames);
   }
   @Action(name = ACTION_BACKFILL)
   @Override
   @Nonnull
   public Task<String[]> backfill(@ActionParam(PARAM_URN) @Nonnull String urnString,
-      @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.backfill(urnString, aspectNames);
   }
 }

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpGroups.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpGroups.java
@@ -119,7 +119,7 @@ public final class CorpGroups extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<CorpGroup> get(@Nonnull ComplexResourceKey<CorpGroupKey, EmptyRecord> key,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.get(key, aspectNames);
   }
 
@@ -128,7 +128,7 @@ public final class CorpGroups extends BaseSearchableEntityResource<
   @Nonnull
   public Task<Map<ComplexResourceKey<CorpGroupKey, EmptyRecord>, CorpGroup>> batchGet(
       @Nonnull Set<ComplexResourceKey<CorpGroupKey, EmptyRecord>> keys,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.batchGet(keys, aspectNames);
   }
 
@@ -136,7 +136,7 @@ public final class CorpGroups extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<CollectionResult<CorpGroup, SearchResultMetadata>> search(@QueryParam(PARAM_INPUT) @Nonnull String input,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames,
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
       @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
       @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion,
       @PagingContextParam @Nonnull PagingContext pagingContext) {
@@ -163,7 +163,7 @@ public final class CorpGroups extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<CorpGroupSnapshot> getSnapshot(@ActionParam(PARAM_URN) @Nonnull String urnString,
-      @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.getSnapshot(urnString, aspectNames);
   }
 
@@ -171,7 +171,7 @@ public final class CorpGroups extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<String[]> backfill(@ActionParam(PARAM_URN) @Nonnull String urnString,
-      @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.backfill(urnString, aspectNames);
   }
 }

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpUsers.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpUsers.java
@@ -125,7 +125,7 @@ public final class CorpUsers extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<CorpUser> get(@Nonnull ComplexResourceKey<CorpUserKey, EmptyRecord> key,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.get(key, aspectNames);
   }
 
@@ -134,14 +134,14 @@ public final class CorpUsers extends BaseSearchableEntityResource<
   @Nonnull
   public Task<Map<ComplexResourceKey<CorpUserKey, EmptyRecord>, CorpUser>> batchGet(
       @Nonnull Set<ComplexResourceKey<CorpUserKey, EmptyRecord>> keys,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") String[] aspectNames) {
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.batchGet(keys, aspectNames);
   }
 
   @RestMethod.GetAll
   @Nonnull
   public Task<List<CorpUser>> getAll(@PagingContextParam @Nonnull PagingContext pagingContext,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames,
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
       @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
       @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion) {
     return super.getAll(pagingContext, aspectNames, filter, sortCriterion);
@@ -151,7 +151,7 @@ public final class CorpUsers extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<CollectionResult<CorpUser, SearchResultMetadata>> search(@QueryParam(PARAM_INPUT) @Nonnull String input,
-      @QueryParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames,
+      @QueryParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
       @QueryParam(PARAM_FILTER) @Optional @Nullable Filter filter,
       @QueryParam(PARAM_SORT) @Optional @Nullable SortCriterion sortCriterion,
       @PagingContextParam @Nonnull PagingContext pagingContext) {
@@ -178,7 +178,7 @@ public final class CorpUsers extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<CorpUserSnapshot> getSnapshot(@ActionParam(PARAM_URN) @Nonnull String urnString,
-      @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.getSnapshot(urnString, aspectNames);
   }
 
@@ -186,7 +186,7 @@ public final class CorpUsers extends BaseSearchableEntityResource<
   @Override
   @Nonnull
   public Task<String[]> backfill(@ActionParam(PARAM_URN) @Nonnull String urnString,
-      @ActionParam(PARAM_ASPECTS) @Optional("[]") @Nonnull String[] aspectNames) {
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
     return super.backfill(urnString, aspectNames);
   }
 


### PR DESCRIPTION
The last PR to sync internal code broke the external GMS, as code was now expected aspectNames to be null rather than empty by default. This preventing me logging into DataHub as the corp user request would fail (it assumed I asked for no aspects rather than all aspects).

TESTED: Built locally, launched with docker/dev.sh (so used latest frontend, but whatever). Verified I can now log into DataHub, browse and search for datasets, and view my profile.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
