### PR TITLE
build(node): replace broken & unmaintained gradle node plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   buildscript.repositories.addAll(project.repositories)
   dependencies {
     classpath 'com.linkedin.pegasus:gradle-plugins:' + pegasusVersion
-    classpath 'com.moowork.gradle:gradle-node-plugin:1.3.1'
+    classpath 'com.github.node-gradle:gradle-node-plugin:2.2.4'
     classpath 'com.commercehub.gradle.plugin:gradle-avro-plugin:0.8.1'
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.2.RELEASE'
   }

--- a/datahub-web/build.gradle
+++ b/datahub-web/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'distribution'
-apply plugin: 'com.moowork.node'
+apply plugin: 'com.github.node-gradle.node'
 
 node {
   // Version of node to use.


### PR DESCRIPTION
Looks like the current node gradle plugin is already broken: https://github.com/linkedin/datahub/pull/1837/checks?check_run_id=1047367684

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
