### PR TITLE
Add support for customizing topic names via a convention.

### DIFF
--- a/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/StandardTopicConvention.java
+++ b/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/StandardTopicConvention.java
@@ -1,0 +1,73 @@
+package com.linkedin.mxe;
+
+import com.linkedin.common.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import javax.annotation.Nonnull;
+
+
+/**
+ * Convention for standard Kafka topics, and is configurable to use different delimiters.
+ *
+ * <p>By default, uses an underscore (_) as the delimiter.
+ */
+public final class StandardTopicConvention implements TopicConvention {
+  private static final String DEFAULT_DELIMiTER = "_";
+  private static final String METADATA_CHANGE_EVENT = "MetadataChangeEvent";
+  private static final String METADATA_AUDIT_EVENT = "MetadataAuditEvent";
+  private static final String FAILED_METADATA_CHANGE_EVENT = "FailedMetadataChangeEvent";
+  private static final String VERSION_4 = "v4";
+
+  private final String _delimiter;
+
+  /**
+   * Constructs a convention with the given delimiter.
+   *
+   * @param delimiter the delimiter between words in a topic
+   */
+  public StandardTopicConvention(@Nonnull String delimiter) {
+    _delimiter = delimiter;
+  }
+
+  /**
+   * Constructs a convention with the default delimiter of underscore.
+   */
+  public StandardTopicConvention() {
+    this(DEFAULT_DELIMiTER);
+  }
+
+  @Nonnull
+  private String getTopicName(@Nonnull String... parts) {
+    return String.join(_delimiter, parts);
+  }
+
+  @Nonnull
+  @Override
+  public String getMetadataChangeEventTopicName() {
+    return getTopicName(METADATA_CHANGE_EVENT, VERSION_4);
+  }
+
+  @Nonnull
+  @Override
+  public String getMetadataAuditEventTopicName() {
+    return getTopicName(METADATA_AUDIT_EVENT, VERSION_4);
+  }
+
+  @Nonnull
+  @Override
+  public String getFailedMetadataChangeEventTopicName() {
+    return getTopicName(FAILED_METADATA_CHANGE_EVENT, VERSION_4);
+  }
+
+  @Nonnull
+  @Override
+  public String getMetadataAuditEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect) {
+    // v5 is still in development.
+    throw new UnsupportedOperationException("TODO - implement once versions are in annotations.");
+  }
+
+  @Override
+  public String getMetadataAuditEventType(@Nonnull String topicName) {
+    // v5 is still in development.
+    throw new UnsupportedOperationException("TODO - implement once versions are in annotations.");
+  }
+}

--- a/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/TopicConvention.java
+++ b/metadata-events/mxe-registration/src/main/java/com/linkedin/mxe/TopicConvention.java
@@ -1,0 +1,47 @@
+package com.linkedin.mxe;
+
+import com.linkedin.common.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import javax.annotation.Nonnull;
+import org.apache.avro.specific.SpecificRecord;
+
+
+/**
+ * The convention for naming kafka topics.
+ *
+ * <p>Different companies may have different naming conventions or styles for their kafka topics. Namely, companies
+ * should pick _ or . as a delimiter, but not both, as they collide in metric names.
+ */
+public interface TopicConvention {
+  /**
+   * The name of the metadata change event (v4) kafka topic.
+   */
+  @Nonnull
+  String getMetadataChangeEventTopicName();
+
+  /**
+   * The name of the metadata audit event (v4) kafka topic.
+   */
+  @Nonnull
+  String getMetadataAuditEventTopicName();
+
+  /**
+   * The name of the failed metadata change event (v4) kafka topic.
+   */
+  @Nonnull
+  String getFailedMetadataChangeEventTopicName();
+
+  /**
+   * Returns the name of the metadata audit event (v5) kafka topic.
+   *
+   * @param urn the urn of the entity being updated
+   * @param aspect the aspect name being updated
+   */
+  @Nonnull
+  String getMetadataAuditEventTopicName(@Nonnull Urn urn, @Nonnull RecordTemplate aspect);
+
+  /**
+   * Returns the avro class that defines the given MAE v5 topic.
+   */
+  Class<? extends SpecificRecord> getMetadataAuditEventType(@Nonnull String topicName);
+}


### PR DESCRIPTION
Requested by a few people in OS.

Companies probably need to pick _ or . as a delimiter and we hard coded _

TODO to finish the implmentation for v5. For right now v5 is LI only and unfinished. Getting this in for v4 so it is useful to other companies now.

TODO BEFORE SUBMIT - make configurable via spring
TODO BEFORE SUBMIT - decide if this needs to be an internal RB first
TODO BEFORE SUBMIT - see where else we can use this (jobs, where else?)



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
