### PR TITLE
metadata-models 93.0.13 -> 94.0.0:

### DIFF
--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/graph/relationship/BaseRelationshipBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/graph/relationship/BaseRelationshipBuilder.java
@@ -16,7 +16,7 @@ public abstract class BaseRelationshipBuilder<ASPECT extends RecordTemplate> {
   }
 
   /**
-   * Returns the aspect class this {@link BaseRelationshipBuilder} supports
+   * Returns the aspect class this {@link BaseRelationshipBuilder} supports.
    */
   @Nonnull
   public Class<ASPECT> supportedAspectClass() {
@@ -24,7 +24,7 @@ public abstract class BaseRelationshipBuilder<ASPECT extends RecordTemplate> {
   }
 
   /**
-   * Returns a list of corresponding relationship updates for the given metadata aspect
+   * Returns a list of corresponding relationship updates for the given metadata aspect.
    */
   @Nonnull
   public abstract <URN extends Urn> List<GraphBuilder.RelationshipUpdates> buildRelationships(@Nonnull URN urn,

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/BaseIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/BaseIndexBuilder.java
@@ -9,7 +9,7 @@ import javax.annotation.Nullable;
 
 
 /**
- * Base class for populating documents from a metadata snapshot
+ * Base class for populating documents from a metadata snapshot.
  *
  * @param <DOCUMENT> the type of document that will be populated and returned
  */
@@ -18,7 +18,7 @@ public abstract class BaseIndexBuilder<DOCUMENT extends RecordTemplate> {
   final List<Class<? extends RecordTemplate>> _snapshotsInterested;
 
   /**
-   * Constructor
+   * Constructor.
    *
    * @param snapshotsInterested List of metadata snapshot classes the document index builder is interested in
    * @param documentClass class of DOCUMENT that should have a valid schema
@@ -31,13 +31,13 @@ public abstract class BaseIndexBuilder<DOCUMENT extends RecordTemplate> {
   /**
    * Constructs documents to update from a metadata snapshot
    *
-   * <p> Given a metadata snapshot containing a list of metadata aspects, this function returns list of documents.
+   * <p>Given a metadata snapshot containing a list of metadata aspects, this function returns list of documents.
    *
-   * <p> Each document is obtained from parsing a metadata aspect from the metadata snapshot that is relevant to
+   * <p>Each document is obtained from parsing a metadata aspect from the metadata snapshot that is relevant to
    * the document index builder that inherits this class.
    *
-   * Each document index builder that inherits from this class, should subscribe to the metadata snapshots it is interested
-   * in by calling the constructor of this class with the list of metadata snapshot classes
+   * <p>Each document index builder that inherits from this class, should subscribe to the metadata snapshots it is
+   * interested in by calling the constructor of this class with the list of metadata snapshot classes
    *
    * @param snapshot Metadata snapshot from which document has to be parsed
    * @return list of documents obtained from various aspects inside a metadata snapshot

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/CorpUserInfoIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/CorpUserInfoIndexBuilder.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.builders.search;
 
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.identity.CorpUserEditableInfo;
 import com.linkedin.identity.CorpUserInfo;
 import com.linkedin.metadata.search.CorpUserInfoDocument;
@@ -33,7 +34,8 @@ public class CorpUserInfoIndexBuilder extends BaseIndexBuilder<CorpUserInfoDocum
         .setFullName(fullName)
         .setTitle(title)
         .setActive(corpUserInfo.isActive())
-        .setManagerLdap(managerLdap);
+        .setManagerLdap(managerLdap)
+        .setEmails(new StringArray(corpUserInfo.getEmail()));
   }
 
   @Nonnull

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/SnapshotProcessor.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/SnapshotProcessor.java
@@ -15,9 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 
 
 /**
- * This class holds method for taking a snapshot to generate relevant documents
+ * This class holds method for taking a snapshot to generate relevant documents.
  */
-
 @Slf4j
 public final class SnapshotProcessor {
 
@@ -25,7 +24,7 @@ public final class SnapshotProcessor {
   private final Set<? extends BaseIndexBuilder> _registeredBuilders;
 
   /**
-   * Constructor
+   * Constructor.
    *
    * @param registerdBuilders Set of document index builders who are interested in parsing metadata snapshot
    */
@@ -53,16 +52,16 @@ public final class SnapshotProcessor {
   /**
    * Constructs documents to update from a snapshot.
    *
-   * <p> Given a snapshot which is a union of metadata snapshot types, this function returns list of documents to update
+   * <p>Given a snapshot which is a union of metadata snapshot types, this function returns list of documents to update
    * from parsing non-empty metadata aspects.
    *
-   * <p> A given metadata snapshot type will contain metadata aspects, each such aspect could be used by multiple
+   * <p>A given metadata snapshot type will contain metadata aspects, each such aspect could be used by multiple
    * document index builders to construct a document.
    *
-   * <p> Each document index builder will subscribe to certain snapshot types whose aspects they are interested in, by
+   * <p>Each document index builder will subscribe to certain snapshot types whose aspects they are interested in, by
    * providing the list of snapshot types in function snapshotsInterested()
    *
-   * <p> Each document index builder will parse relevant aspects from a metadata snapshot type it has subscribed to and
+   * <p>Each document index builder will parse relevant aspects from a metadata snapshot type it has subscribed to and
    * return documents to update.
    *
    * @param snapshot Snapshot from which the document needs to be parsed

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/CorpUserInfoIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/CorpUserInfoIndexBuilderTest.java
@@ -29,6 +29,7 @@ public class CorpUserInfoIndexBuilderTest {
     assertEquals(actualDocs.size(), 1);
     assertEquals(actualDocs.get(0).getUrn(), corpuserUrn);
     assertEquals(actualDocs.get(0).getTitle(), "fooBarEng");
+    assertEquals(actualDocs.get(0).getEmails().get(0), corpUserInfo.getEmail());
     assertTrue(actualDocs.get(0).isActive());
 
     CorpUserEditableInfo corpUserEditableInfo1 = new CorpUserEditableInfo().setAboutMe("An Engineer")

--- a/metadata-dao-impl/ebean-dao/gma-create-all.sql
+++ b/metadata-dao-impl/ebean-dao/gma-create-all.sql
@@ -1,9 +1,3 @@
-create table metadata_id (
-  namespace                     varchar(255) not null,
-  id                            bigint not null,
-  constraint uq_metadata_id_namespace_id unique (namespace,id)
-);
-
 create table metadata_aspect (
   urn                           varchar(500) not null,
   aspect                        varchar(200) not null,
@@ -13,6 +7,12 @@ create table metadata_aspect (
   createdby                     varchar(255) not null,
   createdfor                    varchar(255),
   constraint pk_metadata_aspect primary key (urn,aspect,version)
+);
+
+create table metadata_id (
+  namespace                     varchar(255) not null,
+  id                            bigint not null,
+  constraint uq_metadata_id_namespace_id unique (namespace,id)
 );
 
 create table metadata_index (

--- a/metadata-dao-impl/ebean-dao/gma-drop-all.sql
+++ b/metadata-dao-impl/ebean-dao/gma-drop-all.sql
@@ -1,6 +1,6 @@
-drop table if exists metadata_id;
-
 drop table if exists metadata_aspect;
+
+drop table if exists metadata_id;
 
 drop table if exists metadata_index;
 

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanLocalDAO.java
@@ -24,21 +24,24 @@ import io.ebean.EbeanServer;
 import io.ebean.EbeanServerFactory;
 import io.ebean.ExpressionList;
 import io.ebean.PagedList;
+import io.ebean.Query;
 import io.ebean.Transaction;
 import io.ebean.config.ServerConfig;
 import io.ebean.datasource.DataSourceConfig;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.persistence.RollbackException;
@@ -58,6 +61,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   private static final String EBEAN_INDEX_PACKAGE = EbeanMetadataIndex.class.getPackage().getName();
 
   protected final EbeanServer _server;
+  protected final Class<URN> _urnClass;
 
   @Value
   static class GMAIndexPair {
@@ -66,29 +70,33 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Constructor for EbeanLocalDAO
+   * Constructor for EbeanLocalDAO.
    *
    * @param aspectUnionClass containing union of all supported aspects. Must be a valid aspect union defined in com.linkedin.metadata.aspect
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
    * @param serverConfig {@link ServerConfig} that defines the configuration of EbeanServer instances
+   * @param urnClass Class of the entity URN
    */
   public EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
-      @Nonnull ServerConfig serverConfig) {
+      @Nonnull ServerConfig serverConfig, @Nonnull Class<URN> urnClass) {
     super(aspectUnionClass, producer);
     _server = createServer(serverConfig);
+    _urnClass = urnClass;
   }
 
   /**
-   * Constructor for EbeanLocalDAO
+   * Constructor for EbeanLocalDAO.
    *
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
    * @param serverConfig {@link ServerConfig} that defines the configuration of EbeanServer instances
    * @param storageConfig {@link LocalDAOStorageConfig} containing storage config of full list of supported aspects
+   * @param urnClass Class of the entity URN
    */
   public EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull ServerConfig serverConfig,
-      @Nonnull LocalDAOStorageConfig storageConfig) {
+      @Nonnull LocalDAOStorageConfig storageConfig, @Nonnull Class<URN> urnClass) {
     super(producer, storageConfig);
     _server = createServer(serverConfig);
+    _urnClass = urnClass;
   }
 
   @Nonnull
@@ -105,15 +113,18 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   // For testing purpose
   EbeanLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer,
-      @Nonnull EbeanServer server) {
+      @Nonnull EbeanServer server, @Nonnull Class<URN> urnClass) {
     super(aspectUnionClass, producer);
     _server = server;
+    _urnClass = urnClass;
   }
 
   // For testing purpose
-  EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server, @Nonnull LocalDAOStorageConfig storageConfig) {
+  EbeanLocalDAO(@Nonnull BaseMetadataEventProducer producer, @Nonnull EbeanServer server, @Nonnull LocalDAOStorageConfig storageConfig,
+      @Nonnull Class<URN> urnClass) {
     super(producer, storageConfig);
     _server = server;
+    _urnClass = urnClass;
   }
 
   /**
@@ -205,15 +216,15 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Override
-  protected <ASPECT extends RecordTemplate> void saveToLocalSecondaryIndex(@Nonnull URN urn,
+  protected <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn,
       @Nonnull ASPECT newValue, long version) {
 
     // Process and save URN
     // Only do this with the first version of each aspect
     if (version == FIRST_VERSION) {
-      processAndSaveUrnToLocalSecondaryIndex(urn);
+      updateUrnInLocalIndex(urn);
     }
-    processAndSaveAspectToLocalSecondaryIndex(urn, newValue);
+    updateAspectInLocalIndex(urn, newValue);
   }
 
   @Override
@@ -253,7 +264,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     }
   }
 
-  protected long saveSingleRecordToLocalSecondaryIndex(@Nonnull URN urn, @Nonnull String aspect,
+  protected long saveSingleRecordToLocalIndex(@Nonnull URN urn, @Nonnull String aspect,
       @Nonnull String path, @Nonnull Object value) {
 
     final EbeanMetadataIndex record = new EbeanMetadataIndex()
@@ -277,21 +288,41 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
     return Collections.unmodifiableMap(new HashMap<>(_storageConfig.getAspectStorageConfigMap()));
   }
 
-  protected void processAndSaveUrnToLocalSecondaryIndex(@Nonnull URN urn) {
-    if (existsInLocalSecondaryIndex(urn)) {
+  private void updateUrnInLocalIndex(@Nonnull URN urn) {
+    if (existsInLocalIndex(urn)) {
       return;
     }
 
     final Map<String, Object> pathValueMap = getUrnPathExtractor(urn.getClass()).extractPaths(urn);
     pathValueMap.forEach(
-        (path, value) -> saveSingleRecordToLocalSecondaryIndex(urn, urn.getClass().getCanonicalName(), path, value)
+        (path, value) -> saveSingleRecordToLocalIndex(urn, urn.getClass().getCanonicalName(), path, value)
     );
   }
 
-  // TODO: Will be implemented later
-  protected <ASPECT extends RecordTemplate> void processAndSaveAspectToLocalSecondaryIndex(@Nonnull URN urn,
-      @Nullable ASPECT newValue) {
+  private <ASPECT extends RecordTemplate> void updateAspectInLocalIndex(@Nonnull URN urn, @Nonnull ASPECT newValue) {
 
+    if (!_storageConfig.getAspectStorageConfigMap().containsKey(newValue.getClass())
+        || _storageConfig.getAspectStorageConfigMap().get(newValue.getClass()) == null
+    ) {
+      return;
+    }
+    // step1: remove all rows from the index table corresponding to <urn, aspect> pair
+    _server.find(EbeanMetadataIndex.class)
+        .where()
+        .eq(URN_COLUMN, urn.toString())
+        .eq(ASPECT_COLUMN, ModelUtils.getAspectName(newValue.getClass()))
+        .delete();
+
+    // step2: add fields of the aspect that need to be indexed
+    final Map<String, LocalDAOStorageConfig.PathStorageConfig> pathStorageConfigMap =
+        _storageConfig.getAspectStorageConfigMap().get(newValue.getClass()).getPathStorageConfigMap();
+
+    pathStorageConfigMap.keySet()
+        .stream()
+        .filter(path -> pathStorageConfigMap.get(path).isStrongConsistentSecondaryIndex())
+        .collect(Collectors.toMap(Function.identity(), path -> RecordUtils.getFieldValue(newValue, path)))
+        .forEach((k, v) -> v.ifPresent(
+            value -> saveSingleRecordToLocalIndex(urn, newValue.getClass().getCanonicalName(), k, value)));
   }
 
   @Override
@@ -350,7 +381,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
             .map(record -> toRecordTemplate(key.getAspectClass(), record))));
   }
 
-  public boolean existsInLocalSecondaryIndex(@Nonnull URN urn) {
+  public boolean existsInLocalIndex(@Nonnull URN urn) {
     return _server.find(EbeanMetadataIndex.class)
         .where().eq(URN_COLUMN, urn.toString())
         .exists();
@@ -376,7 +407,8 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
-   * Checks if an {@link AspectKey} and a {@link PrimaryKey} for Ebean are equivalent
+   * Checks if an {@link AspectKey} and a {@link PrimaryKey} for Ebean are equivalent.
+   *
    * @param aspectKey Urn needs to do a ignore case match
    */
   private boolean matchKeys(@Nonnull AspectKey<URN, ? extends RecordTemplate> aspectKey, @Nonnull PrimaryKey pk) {
@@ -409,7 +441,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
 
   @Override
   @Nonnull
-  public <ASPECT extends RecordTemplate> ListResult<Urn> listUrns(@Nonnull Class<ASPECT> aspectClass, int start,
+  public <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull Class<ASPECT> aspectClass, int start,
       int pageSize) {
 
     checkValidAspect(aspectClass);
@@ -425,7 +457,7 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
         .asc(URN_COLUMN)
         .findPagedList();
 
-    final List<Urn> urns = pagedList.getList().stream().map(EbeanLocalDAO::extractUrn).collect(Collectors.toList());
+    final List<URN> urns = pagedList.getList().stream().map(entry -> getUrn(entry.getKey().getUrn())).collect(Collectors.toList());
     return toListResult(urns, null, pagedList, start);
   }
 
@@ -487,22 +519,13 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   @Nonnull
-  private static Urn extractUrn(@Nonnull String urn) {
+  URN getUrn(@Nonnull String urn) {
     try {
-      return new Urn(urn);
-    } catch (URISyntaxException e) {
-      throw new ModelConversionException("Invalid URN: " + urn);
+      final Method getUrn = _urnClass.getMethod("createFromString", String.class);
+      return _urnClass.cast(getUrn.invoke(null, urn));
+    } catch (NoSuchMethodException |  IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalArgumentException("URN Conversion error ", e);
     }
-  }
-
-  @Nonnull
-  private static Urn extractUrn(@Nonnull EbeanMetadataAspect aspect) {
-    return extractUrn(aspect.getKey().getUrn());
-  }
-
-  @Nonnull
-  private static Urn extractUrn(@Nonnull EbeanMetadataIndex index) {
-    return extractUrn(index.getUrn());
   }
 
   @Nonnull
@@ -588,10 +611,10 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
       object = indexValue.getDouble();
       return new GMAIndexPair(EbeanMetadataIndex.DOUBLE_COLUMN, object);
     } else if (indexValue.isFloat()) {
-      object = indexValue.getFloat();
+      object = (indexValue.getFloat()).doubleValue();
       return new GMAIndexPair(EbeanMetadataIndex.DOUBLE_COLUMN, object);
     } else if (indexValue.isInt()) {
-      object = indexValue.getInt();
+      object = Long.valueOf(indexValue.getInt());
       return new GMAIndexPair(EbeanMetadataIndex.LONG_COLUMN, object);
     } else if (indexValue.isLong()) {
       object = indexValue.getLong();
@@ -605,10 +628,63 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
   }
 
   /**
+   * Sets the values of parameters in metadata index query based on its position, values obtained from
+   * {@link IndexCriterionArray} and last urn.
+   *
+   * @param indexCriterionArray {@link IndexCriterionArray} whose values will be used to set parameters in metadata
+   *                                                       index query based on its position
+   * @param indexQuery {@link Query} whose ordered parameters need to be set, based on it's position
+   * @param lastUrn String representation of the urn whose value is used to set the last urn parameter in index query
+   */
+  private static void setParameters(@Nonnull IndexCriterionArray indexCriterionArray, @Nonnull Query<EbeanMetadataIndex> indexQuery,
+      @Nonnull String lastUrn) {
+    indexQuery.setParameter(1, lastUrn);
+    int pos = 2;
+    for (IndexCriterion criterion : indexCriterionArray) {
+      indexQuery.setParameter(pos++, criterion.getAspect());
+      if (criterion.hasPathParams()) {
+        indexQuery.setParameter(pos++, criterion.getPathParams().getPath());
+        indexQuery.setParameter(pos++, getGMAIndexPair(criterion.getPathParams().getValue()).value);
+      }
+    }
+  }
+
+  /**
+   * Constructs SQL query that contains positioned parameters (with `?`), based on whether {@link IndexCriterion} of
+   * a given condition has field `pathParams`.
+   *
+   * @param indexCriterionArray {@link IndexCriterionArray} used to construct the SQL query
+   * @return String representation of SQL query
+   */
+  @Nonnull
+  private static String constructSQLQuery(@Nonnull IndexCriterionArray indexCriterionArray) {
+    String selectClause = "SELECT DISTINCT(t0.urn) FROM metadata_index t0";
+    selectClause += IntStream.range(1, indexCriterionArray.size()).mapToObj(i -> " INNER JOIN metadata_index " + "t"
+        + i + " ON t0.urn = " + "t" + i + ".urn").collect(Collectors.joining(""));
+    final StringBuilder whereClause = new StringBuilder("WHERE t0.urn > ?");
+    IntStream.range(0, indexCriterionArray.size()).forEach(i -> {
+      final IndexCriterion criterion = indexCriterionArray.get(i);
+      whereClause.append(" AND t").append(i).append(".aspect = ?");
+      if (criterion.hasPathParams()) {
+        whereClause.append(" AND t").append(i).append(".path = ?").append(" AND t").append(i).append(".")
+            .append(getGMAIndexPair(criterion.getPathParams().getValue()).valueType).append(" = ?");
+      }
+    });
+    return selectClause + " " + whereClause;
+  }
+
+  void addEntityTypeFilter(@Nonnull IndexFilter indexFilter) {
+    if (indexFilter.getCriteria().stream().noneMatch(x -> x.getAspect().equals(_urnClass.getCanonicalName()))) {
+      indexFilter.getCriteria().add(new IndexCriterion().setAspect(_urnClass.getCanonicalName()));
+    }
+  }
+
+  /**
    * Returns list of urns from strongly consistent secondary index that satisfy the given filter conditions.
-   * Results are sorted in increasing alphabetical order of urn.
-   * NOTE: Currently this works for only one filter condition
-   * TODO: Extend the support for multiple filter conditions
+   *
+   * <p>Results are sorted in increasing alphabetical order of urn.
+   *
+   * <p>NOTE: Currently this works for upto 10 filter conditions.
    *
    * @param indexFilter {@link IndexFilter} containing filter conditions to be applied
    * @param lastUrn last urn of the previous fetched page. This eliminates the need to use offset which
@@ -618,40 +694,32 @@ public class EbeanLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends Urn>
    */
   @Override
   @Nonnull
-  public ListResult<Urn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
+  public ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize) {
     if (!isLocalSecondaryIndexEnabled()) {
-      throw new UnsupportedOperationException("Local secondary index isn't supported by EbeanLocalDAO");
+      throw new UnsupportedOperationException("Local secondary index isn't supported");
     }
     final IndexCriterionArray indexCriterionArray = indexFilter.getCriteria();
     if (indexCriterionArray.size() == 0) {
       throw new UnsupportedOperationException("Empty Index Filter is not supported by EbeanLocalDAO");
     }
-    if (indexCriterionArray.size() > 1) {
-      throw new UnsupportedOperationException("Currently only one filter condition is supported by EbeanLocalDAO");
+    if (indexCriterionArray.size() > 10) {
+      throw new UnsupportedOperationException("Currently more than 10 filter conditions is not supported by EbeanLocalDAO");
     }
 
-    final IndexCriterion criterion = indexCriterionArray.get(0);
-    ExpressionList<EbeanMetadataIndex> expressionList = _server.find(EbeanMetadataIndex.class)
-        .setDistinct(true)
-        .select(EbeanMetadataIndex.URN_COLUMN)
-        .where()
-        .gt(EbeanMetadataIndex.URN_COLUMN, lastUrn == null ? "" : lastUrn.toString())
-        .eq(EbeanMetadataIndex.ASPECT_COLUMN, criterion.getAspect());
-    if (criterion.hasPathParams()) {
-      final GMAIndexPair gmaIndexPair = getGMAIndexPair(criterion.getPathParams().getValue());
-      expressionList = expressionList
-          .eq(EbeanMetadataIndex.PATH_COLUMN, criterion.getPathParams().getPath())
-          .eq(gmaIndexPair.valueType, gmaIndexPair.value);
-    }
-    final PagedList<EbeanMetadataIndex> pagedList =  expressionList
+    addEntityTypeFilter(indexFilter);
+
+    final Query<EbeanMetadataIndex> query = _server.findNative(EbeanMetadataIndex.class, constructSQLQuery(indexCriterionArray));
+    setParameters(indexCriterionArray, query, lastUrn == null ? "" : lastUrn.toString());
+
+    final PagedList<EbeanMetadataIndex> pagedList = query
         .orderBy()
         .asc(EbeanMetadataIndex.URN_COLUMN)
         .setMaxRows(pageSize)
         .findPagedList();
-    final List<Urn> urns = pagedList.getList()
+
+    final List<URN> urns = pagedList.getList()
         .stream()
-        .map(EbeanLocalDAO::extractUrn)
-        .filter(Objects::nonNull)
+        .map(entry -> getUrn(entry.getUrn()))
         .collect(Collectors.toList());
     return toListResult(urns, null, pagedList, null);
   }

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataAspect.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataAspect.java
@@ -17,6 +17,9 @@ import lombok.NonNull;
 import lombok.Setter;
 
 
+/**
+ * Schema definition for the metadata aspect table.
+ */
 @Getter
 @Setter
 @Entity
@@ -35,6 +38,9 @@ public class EbeanMetadataAspect extends Model {
   public static final String CREATED_BY_COLUMN = "createdBy";
   public static final String CREATED_FOR_COLUMN = "createdFor";
 
+  /**
+   * Key for an aspect in the table.
+   */
   @Embeddable
   @Getter
   @AllArgsConstructor

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataId.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataId.java
@@ -12,6 +12,9 @@ import lombok.NonNull;
 import lombok.Setter;
 
 
+/**
+ * Unique ID for a piece of metadata stored in MySQL.
+ */
 @Getter
 @Setter
 @AllArgsConstructor

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataIndex.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/EbeanMetadataIndex.java
@@ -14,6 +14,9 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 
 
+/**
+ * Index definition for MySQL metadata.
+ */
 @Getter
 @Setter
 // define composite indexes

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/ImmutableLocalDAO.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/ImmutableLocalDAO.java
@@ -38,29 +38,29 @@ public class ImmutableLocalDAO<ASPECT_UNION extends UnionTemplate, URN extends U
   private static final String GMA_CREATE_ALL_SQL = "gma-create-all.sql";
 
   /**
-   * Constructs an {@link ImmutableLocalDAO} from a hard-coded URN-Aspect map
+   * Constructs an {@link ImmutableLocalDAO} from a hard-coded URN-Aspect map.
    */
   public ImmutableLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass,
-      @Nonnull Map<URN, ? extends RecordTemplate> urnAspectMap) {
+      @Nonnull Map<URN, ? extends RecordTemplate> urnAspectMap, @Nonnull Class<URN> urnClass) {
 
     super(aspectUnionClass, new DummyMetadataEventProducer(),
-        createProductionH2ServerConfig(aspectUnionClass.getCanonicalName()));
+        createProductionH2ServerConfig(aspectUnionClass.getCanonicalName()), urnClass);
     _server.execute(Ebean.createSqlUpdate(readSQLfromFile(GMA_CREATE_ALL_SQL)));
     urnAspectMap.forEach((key, value) -> super.save(key, value, DUMMY_AUDIT_STAMP, LATEST_VERSION, true));
   }
 
   // For testing purpose
   public ImmutableLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass,
-      @Nonnull Map<URN, ? extends RecordTemplate> urnAspectMap, boolean ddlGenerate) {
+      @Nonnull Map<URN, ? extends RecordTemplate> urnAspectMap, boolean ddlGenerate, @Nonnull Class<URN> urnClass) {
 
-    super(aspectUnionClass, new DummyMetadataEventProducer(), createTestingH2ServerConfig());
+    super(aspectUnionClass, new DummyMetadataEventProducer(), createTestingH2ServerConfig(), urnClass);
     urnAspectMap.forEach((key, value) -> super.save(key, value, DUMMY_AUDIT_STAMP, LATEST_VERSION, true));
   }
 
   /**
    * Loads a map of URN to aspect values from an {@link InputStream}.
    *
-   * The InputStream is expected to contain a JSON map where the keys are a specific type of URN and values are a
+   * <p>The InputStream is expected to contain a JSON map where the keys are a specific type of URN and values are a
    * specific type of metadata aspect.
    */
   @Nonnull

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/DatasetUrnPathExtractor.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/DatasetUrnPathExtractor.java
@@ -7,6 +7,9 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 
+/**
+ * Maps schema paths to values for DatasetUrns.
+ */
 public class DatasetUrnPathExtractor implements UrnPathExtractor<DatasetUrn> {
   @Override
   public Map<String, Object> extractPaths(@Nonnull DatasetUrn urn) {

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/RegisteredUrnPathExtractors.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/RegisteredUrnPathExtractors.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 /**
  * A class that holds all the registered {@link UrnPathExtractor}s.
  *
- * Register new type of urn path extractors by adding them to {@link #REGISTERED_URN_PATH_EXTRACTORS}.
+ * <p>Register new type of urn path extractors by adding them to {@link #REGISTERED_URN_PATH_EXTRACTORS}.
  */
 public class RegisteredUrnPathExtractors {
 

--- a/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/UrnPathExtractor.java
+++ b/metadata-dao-impl/ebean-dao/src/main/java/com/linkedin/metadata/dao/utils/UrnPathExtractor.java
@@ -5,6 +5,9 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 
+/**
+ * Given an urn, extracts a map of schema key to value.
+ */
 public interface UrnPathExtractor<URN extends Urn> {
   @Nonnull
   Map<String, Object> extractPaths(@Nonnull URN urn);

--- a/metadata-dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
+++ b/metadata-dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/EbeanLocalDAOTest.java
@@ -7,6 +7,7 @@ import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.dao.equality.AlwaysFalseEqualityTester;
 import com.linkedin.metadata.dao.equality.DefaultEqualityTester;
 import com.linkedin.metadata.dao.exception.InvalidMetadataType;
@@ -28,7 +29,9 @@ import com.linkedin.metadata.query.IndexPathParams;
 import com.linkedin.metadata.query.IndexValue;
 import com.linkedin.metadata.query.ListResultMetadata;
 import com.linkedin.testing.AspectBar;
+import com.linkedin.testing.AspectBaz;
 import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.AspectFooEvolved;
 import com.linkedin.testing.AspectInvalid;
 import com.linkedin.testing.EntityAspectUnion;
 import com.linkedin.testing.urn.BarUrn;
@@ -41,6 +44,7 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -49,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.persistence.RollbackException;
 import org.mockito.InOrder;
 import org.testng.annotations.BeforeClass;
@@ -84,18 +89,18 @@ public class EbeanLocalDAOTest {
 
   @Test(expectedExceptions = InvalidMetadataType.class)
   public void testMetadataAspectCheck() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
 
-    dao.add(makeUrn(1), new AspectInvalid().setValue("invalid"), _dummyAuditStamp);
+    dao.add(makeFooUrn(1), new AspectInvalid().setValue("invalid"), _dummyAuditStamp);
   }
 
   @Test
   public void testAddOne() {
     Clock mockClock = mock(Clock.class);
     when(mockClock.millis()).thenReturn(1234L);
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     dao.setClock(mockClock);
-    Urn urn = makeUrn(1);
+    FooUrn urn = makeFooUrn(1);
     String aspectName = ModelUtils.getAspectName(AspectFoo.class);
     AspectFoo expected = new AspectFoo().setValue("foo");
     CorpuserUrn actor = new CorpuserUrn("actor");
@@ -122,8 +127,8 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testAddTwo() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
     String aspectName = ModelUtils.getAspectName(AspectFoo.class);
     AspectFoo v1 = new AspectFoo().setValue("foo");
     AspectFoo v0 = new AspectFoo().setValue("bar");
@@ -147,9 +152,9 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testDefaultEqualityTester() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     dao.setEqualityTester(AspectFoo.class, DefaultEqualityTester.<AspectFoo>newInstance());
-    Urn urn = makeUrn(1);
+    FooUrn urn = makeFooUrn(1);
     String aspectName = ModelUtils.getAspectName(AspectFoo.class);
     AspectFoo foo = new AspectFoo().setValue("foo");
     AspectFoo bar = new AspectFoo().setValue("bar");
@@ -178,9 +183,9 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testAlwaysFalseEqualityTester() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     dao.setEqualityTester(AspectFoo.class, AlwaysFalseEqualityTester.<AspectFoo>newInstance());
-    Urn urn = makeUrn(1);
+    FooUrn urn = makeFooUrn(1);
     String aspectName = ModelUtils.getAspectName(AspectFoo.class);
     AspectFoo foo1 = new AspectFoo().setValue("foo");
     AspectFoo foo2 = new AspectFoo().setValue("foo");
@@ -203,9 +208,9 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testVersionBasedRetention() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     dao.setRetention(AspectFoo.class, new VersionBasedRetention(2));
-    Urn urn = makeUrn(1);
+    FooUrn urn = makeFooUrn(1);
     String aspectName = ModelUtils.getAspectName(AspectFoo.class);
     AspectFoo v0 = new AspectFoo().setValue("baz");
     AspectFoo v1 = new AspectFoo().setValue("bar");
@@ -229,10 +234,10 @@ public class EbeanLocalDAOTest {
         .thenReturn(20L) // v2 age check
         .thenReturn(120L); // v3 age check
 
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     dao.setClock(mockClock);
     dao.setRetention(AspectFoo.class, new TimeBasedRetention(100));
-    Urn urn = makeUrn(1);
+    FooUrn urn = makeFooUrn(1);
     String aspectName = ModelUtils.getAspectName(AspectFoo.class);
     AspectFoo v0 = new AspectFoo().setValue("baz");
     AspectFoo v1 = new AspectFoo().setValue("bar");
@@ -254,9 +259,9 @@ public class EbeanLocalDAOTest {
     when(server.beginTransaction()).thenReturn(mockTransaction);
     when(server.find(any(), any())).thenReturn(null);
     doThrow(RollbackException.class).doNothing().when(server).insert(any(EbeanMetadataAspect.class));
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, server, FooUrn.class);
 
-    dao.add(makeUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
+    dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
   }
 
   @Test(expectedExceptions = RetryLimitReached.class)
@@ -266,15 +271,15 @@ public class EbeanLocalDAOTest {
     when(server.beginTransaction()).thenReturn(mockTransaction);
     when(server.find(any(), any())).thenReturn(null);
     doThrow(RollbackException.class).when(server).insert(any(EbeanMetadataAspect.class));
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, server, FooUrn.class);
 
-    dao.add(makeUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
+    dao.add(makeFooUrn(1), new AspectFoo().setValue("foo"), _dummyAuditStamp);
   }
 
   @Test
   public void testGetNonExisting() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
 
     Optional<AspectFoo> foo = dao.get(AspectFoo.class, urn);
 
@@ -283,7 +288,7 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testGetCapsSensitivity() {
-    final EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    final EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, Urn.class);
     final Urn urnCaps = makeUrn("Dataset");
     final Urn urnLower = makeUrn("dataset");
 
@@ -306,8 +311,8 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testGetLatestVersion() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
     AspectFoo v0 = new AspectFoo().setValue("foo");
     addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, v0);
     AspectFoo v1 = new AspectFoo().setValue("bar");
@@ -321,8 +326,8 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testGetSpecificVersion() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
     AspectFoo v0 = new AspectFoo().setValue("foo");
     addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, v0);
     AspectFoo v1 = new AspectFoo().setValue("bar");
@@ -336,8 +341,8 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testGetMultipleAspects() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
     AspectFoo fooV0 = new AspectFoo().setValue("foo");
     addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, fooV0);
     AspectFoo fooV1 = new AspectFoo().setValue("bar");
@@ -355,22 +360,22 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testGetMultipleAspectsForMultipleUrns() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
 
     // urn1 has both foo & bar
-    Urn urn1 = makeUrn(1);
+    FooUrn urn1 = makeFooUrn(1);
     AspectFoo foo1 = new AspectFoo().setValue("foo1");
     addMetadata(urn1, AspectFoo.class.getCanonicalName(), 0, foo1);
     AspectBar bar1 = new AspectBar().setValue("bar1");
     addMetadata(urn1, AspectBar.class.getCanonicalName(), 0, bar1);
 
     // urn2 has only foo
-    Urn urn2 = makeUrn(2);
+    FooUrn urn2 = makeFooUrn(2);
     AspectFoo foo2 = new AspectFoo().setValue("foo2");
     addMetadata(urn2, AspectFoo.class.getCanonicalName(), 0, foo2);
 
     // urn3 has nothing
-    Urn urn3 = makeUrn(3);
+    FooUrn urn3 = makeFooUrn(3);
 
     Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> result =
         dao.get(ImmutableSet.of(AspectFoo.class, AspectBar.class), ImmutableSet.of(urn1, urn2, urn3));
@@ -386,8 +391,8 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testBackfill() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
 
     AspectFoo expected = new AspectFoo().setValue("foo");
     addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, expected);
@@ -402,25 +407,20 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testLocalSecondaryIndexBackfill() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
 
     FooUrn urn = makeFooUrn(1);
     AspectFoo expected = new AspectFoo().setValue("foo");
     addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, expected);
 
-    // Check if backfilled: _writeToLocalSecondary = false and _backfillLocalSecondaryIndex = false
+    // Check if backfilled: _writeToLocalSecondary = false
     dao.backfill(AspectFoo.class, urn);
-    assertEquals(getAllRecordsFromLocalSecondaryIndex(urn).size(), 0);
+    assertEquals(getAllRecordsFromLocalIndex(urn).size(), 0);
 
-    // Check if backfilled: _writeToLocalSecondary = true and _backfillLocalSecondaryIndex = false
+    // Check if backfilled: _writeToLocalSecondary = true
     dao.enableLocalSecondaryIndex(true);
     dao.backfill(AspectFoo.class, urn);
-    assertEquals(getAllRecordsFromLocalSecondaryIndex(urn).size(), 0);
-
-    // Check if backfilled: _writeToLocalSecondary = true and _backfillLocalSecondaryIndex = true
-    dao.setBackfillLocalSecondaryIndex(true);
-    dao.backfill(AspectFoo.class, urn);
-    List<EbeanMetadataIndex> fooRecords = getAllRecordsFromLocalSecondaryIndex(urn);
+    List<EbeanMetadataIndex> fooRecords = getAllRecordsFromLocalIndex(urn);
     assertEquals(fooRecords.size(), 1);
     EbeanMetadataIndex fooRecord = fooRecords.get(0);
     assertEquals(fooRecord.getUrn(), urn.toString());
@@ -430,11 +430,11 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
-  public void testBatchBackfill() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    List<Urn> urns = ImmutableList.of(makeUrn(1), makeUrn(2), makeUrn(3));
+  public void testBackfillWithUrns() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    List<FooUrn> urns = ImmutableList.of(makeFooUrn(1), makeFooUrn(2), makeFooUrn(3));
 
-    Map<Urn, Map<Class<? extends RecordTemplate>, RecordTemplate>> aspects = new HashMap<>();
+    Map<FooUrn, Map<Class<? extends RecordTemplate>, RecordTemplate>> aspects = new HashMap<>();
 
     urns.forEach(urn -> {
       AspectFoo aspectFoo = new AspectFoo().setValue("foo");
@@ -445,31 +445,30 @@ public class EbeanLocalDAOTest {
     });
 
     // Backfill single aspect for set of urns
-    Map<Urn, Optional<AspectFoo>> backfilledAspects1 = dao.backfill(AspectFoo.class, new HashSet<>(urns));
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
+        dao.backfill(Collections.singleton(AspectFoo.class), new HashSet<>(urns));
     for (Urn urn: urns) {
       RecordTemplate aspect = aspects.get(urn).get(AspectFoo.class);
-      assertEquals(backfilledAspects1.get(urn).get(), aspect);
+      assertEquals(backfilledAspects.get(urn).get(AspectFoo.class).get(), aspect);
       verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
     }
     clearInvocations(_mockProducer);
 
     // Backfill set of aspects for a single urn
-    Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> backfilledAspects2 =
-        dao.backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), urns.get(0));
+    backfilledAspects = dao.backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), Collections.singleton(urns.get(0)));
     for (Class<? extends RecordTemplate> clazz: aspects.get(urns.get(0)).keySet()) {
       RecordTemplate aspect = aspects.get(urns.get(0)).get(clazz);
-      assertEquals(backfilledAspects2.get(clazz).get(), aspect);
+      assertEquals(backfilledAspects.get(urns.get(0)).get(clazz).get(), aspect);
       verify(_mockProducer, times(1)).produceMetadataAuditEvent(urns.get(0), aspect, aspect);
     }
     clearInvocations(_mockProducer);
 
     // Backfill set of aspects for set of urns
-    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects3 =
-        dao.backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), new HashSet<>(urns));
+    backfilledAspects = dao.backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), new HashSet<>(urns));
     for (Urn urn: urns) {
       for (Class<? extends RecordTemplate> clazz: aspects.get(urn).keySet()) {
         RecordTemplate aspect = aspects.get(urn).get(clazz);
-        assertEquals(backfilledAspects3.get(urn).get(clazz).get(), aspect);
+        assertEquals(backfilledAspects.get(urn).get(clazz).get(), aspect);
         verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
       }
     }
@@ -477,9 +476,70 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
+  public void testBackfillUsingSCSI() {
+    LocalDAOStorageConfig storageConfig = makeLocalDAOStorageConfig(AspectFoo.class, Collections.singletonList("/value"),
+        AspectBar.class, Collections.singletonList("/value"));
+    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, storageConfig, FooUrn.class);
+    dao.enableLocalSecondaryIndex(true);
+
+    List<FooUrn> urns = ImmutableList.of(makeFooUrn(1), makeFooUrn(2), makeFooUrn(3));
+
+    Map<FooUrn, Map<Class<? extends RecordTemplate>, RecordTemplate>> aspects = new HashMap<>();
+
+    urns.forEach(urn -> {
+      AspectFoo aspectFoo = new AspectFoo().setValue("foo");
+      AspectBar aspectBar = new AspectBar().setValue("bar");
+
+      // update metadata_aspects table
+      aspects.put(urn, ImmutableMap.of(AspectFoo.class, aspectFoo, AspectBar.class, aspectBar));
+      addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, aspectFoo);
+      addMetadata(urn, AspectBar.class.getCanonicalName(), 0, aspectBar);
+
+      // only index urn
+      addIndex(urn, FooUrn.class.getCanonicalName(), "/fooId", urn.getId());
+    });
+
+    // Backfill in SCSI_ONLY mode
+    Map<Urn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfilledAspects =
+        dao.backfill(BackfillMode.SCSI_ONLY, Collections.singleton(AspectFoo.class), FooUrn.class, null, 3);
+    for (int index = 0; index < 3; index++) {
+      Urn urn = urns.get(index);
+      RecordTemplate aspect = aspects.get(urn).get(AspectFoo.class);
+      assertEquals(backfilledAspects.get(urn).get(AspectFoo.class).get(), aspect);
+      verify(_mockProducer, times(0)).produceMetadataAuditEvent(urn, aspect, aspect);
+    }
+    IndexFilter indexFilter = new IndexFilter().setCriteria(new IndexCriterionArray(new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName())));
+    assertEquals(dao.listUrns(indexFilter, null, 3).getValues().size(), 3);
+
+    // Backfill in MAE_ONLY mode
+    backfilledAspects = dao.backfill(BackfillMode.MAE_ONLY, Collections.singleton(AspectBar.class), FooUrn.class, null, 3);
+    for (int index = 0; index < 3; index++) {
+      Urn urn = urns.get(index);
+      RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
+      assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
+      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
+    }
+    clearInvocations(_mockProducer);
+
+    indexFilter = new IndexFilter().setCriteria(new IndexCriterionArray(new IndexCriterion().setAspect(AspectBar.class.getCanonicalName())));
+    assertEquals(dao.listUrns(indexFilter, null, 3).getValues().size(), 0);
+
+    // Backfill in BACKFILL_ALL mode
+    backfilledAspects = dao.backfill(BackfillMode.BACKFILL_ALL, ImmutableSet.of(AspectBar.class), FooUrn.class, null, 3);
+    for (int index = 0; index < 3; index++) {
+      Urn urn = urns.get(index);
+      RecordTemplate aspect = aspects.get(urn).get(AspectBar.class);
+      assertEquals(backfilledAspects.get(urn).get(AspectBar.class).get(), aspect);
+      verify(_mockProducer, times(1)).produceMetadataAuditEvent(urn, aspect, aspect);
+    }
+    verifyNoMoreInteractions(_mockProducer);
+    assertEquals(dao.listUrns(indexFilter, null, 3).getValues().size(), 3);
+  }
+
+  @Test
   public void testListVersions() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    Urn urn = makeUrn(1);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
     List<Long> versions = new ArrayList<>();
     for (long i = 0; i < 6; i++) {
       AspectFoo foo = new AspectFoo().setValue("foo" + i);
@@ -517,20 +577,105 @@ public class EbeanLocalDAOTest {
     assertEquals(results.getValues(), new ArrayList<>());
   }
 
+  private static IndexCriterionArray makeIndexCriterionArray(int size) {
+    List<IndexCriterion> criterionArrays = new ArrayList<>();
+    IntStream.range(0, size).forEach(i -> criterionArrays.add(new IndexCriterion().setAspect("aspect" + i)));
+    return new IndexCriterionArray(criterionArrays);
+  }
+
+  @Test
+  void testListUrnsFromIndexManyFilters() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    dao.enableLocalSecondaryIndex(true);
+    FooUrn urn1 = makeFooUrn(1);
+    FooUrn urn2 = makeFooUrn(2);
+    FooUrn urn3 = makeFooUrn(3);
+    String aspect1 = "aspect1" + System.currentTimeMillis();
+    String aspect2 = "aspect2" + System.currentTimeMillis();
+
+    addIndex(urn1, aspect1, "/path1", true); // boolean
+    addIndex(urn1, aspect1, "/path2", 1.534e2); // double
+    addIndex(urn1, aspect1, "/path3", 123.4f); // float
+    addIndex(urn1, aspect2, "/path4", 123); // int
+    addIndex(urn1, aspect2, "/path5", 1234L); // long
+    addIndex(urn1, aspect2, "/path6", "val"); // string
+    addIndex(urn1, FooUrn.class.getCanonicalName(), "/fooId", 1);
+
+    addIndex(urn2, aspect1, "/path1", true); // boolean
+    addIndex(urn2, aspect1, "/path2", 1.534e2); // double
+    addIndex(urn2, FooUrn.class.getCanonicalName(), "/fooId", 2);
+
+    addIndex(urn3, aspect1, "/path1", true); // boolean
+    addIndex(urn3, aspect1, "/path2", 1.534e2); // double
+    addIndex(urn3, aspect1, "/path3", 123.4f); // float
+    addIndex(urn3, aspect2, "/path4", 123); // int
+    addIndex(urn3, aspect2, "/path5", 1234L); // long
+    addIndex(urn3, aspect2, "/path6", "val"); // string
+    addIndex(urn3, FooUrn.class.getCanonicalName(), "/fooId", 3);
+
+    IndexValue indexValue1 = new IndexValue();
+    indexValue1.setBoolean(true);
+    IndexCriterion criterion1 = new IndexCriterion().setAspect(aspect1).setPathParams(new IndexPathParams().setPath("/path1").setValue(indexValue1));
+    IndexValue indexValue2 = new IndexValue();
+    indexValue2.setDouble(1.534e2);
+    IndexCriterion criterion2 = new IndexCriterion().setAspect(aspect1).setPathParams(new IndexPathParams().setPath("/path2").setValue(indexValue2));
+    IndexValue indexValue3 = new IndexValue();
+    indexValue3.setFloat(123.4f);
+    IndexCriterion criterion3 = new IndexCriterion().setAspect(aspect1).setPathParams(new IndexPathParams().setPath("/path3").setValue(indexValue3));
+    IndexValue indexValue4 = new IndexValue();
+    indexValue4.setInt(123);
+    IndexCriterion criterion4 = new IndexCriterion().setAspect(aspect2).setPathParams(new IndexPathParams().setPath("/path4").setValue(indexValue4));
+    IndexValue indexValue5 = new IndexValue();
+    indexValue5.setLong(1234L);
+    IndexCriterion criterion5 = new IndexCriterion().setAspect(aspect2).setPathParams(new IndexPathParams().setPath("/path5").setValue(indexValue5));
+    IndexValue indexValue6 = new IndexValue();
+    indexValue6.setString("val");
+    IndexCriterion criterion6 = new IndexCriterion().setAspect(aspect2).setPathParams(new IndexPathParams().setPath("/path6").setValue(indexValue6));
+
+    // 1. with two filter conditions
+    IndexCriterionArray indexCriterionArray1 = new IndexCriterionArray(Arrays.asList(criterion1, criterion2));
+    final IndexFilter indexFilter1 = new IndexFilter().setCriteria(indexCriterionArray1);
+    ListResult<Urn> urns1 = dao.listUrns(indexFilter1, null, 3);
+
+    assertEquals(urns1.getValues(), Arrays.asList(urn1, urn2, urn3));
+    assertEquals(urns1.getTotalCount(), 3);
+    assertEquals(urns1.getTotalPageCount(), 1);
+    assertEquals(urns1.getPageSize(), 3);
+    assertFalse(urns1.isHavingMore());
+
+    // 2. with two filter conditions, check if LIMIT is working as desired i.e. totalCount is more than the page size
+    ListResult<Urn> urns2 = dao.listUrns(indexFilter1, null, 2);
+    assertEquals(urns2.getValues(), Arrays.asList(urn1, urn2));
+    assertEquals(urns2.getTotalCount(), 3);
+    assertEquals(urns2.getTotalPageCount(), 2);
+    assertEquals(urns2.getPageSize(), 2);
+    assertTrue(urns2.isHavingMore());
+
+    // 3. with six filter conditions covering all different data types that value can take
+    IndexCriterionArray indexCriterionArray3 = new IndexCriterionArray(Arrays.asList(criterion1, criterion2, criterion3, criterion4, criterion5, criterion6));
+    final IndexFilter indexFilter3 = new IndexFilter().setCriteria(indexCriterionArray3);
+    ListResult<Urn> urns3 = dao.listUrns(indexFilter3, urn1, 5);
+    assertEquals(urns3.getValues(), Collections.singletonList(urn3));
+    assertEquals(urns3.getTotalCount(), 1);
+    assertEquals(urns3.getTotalPageCount(), 1);
+    assertEquals(urns3.getPageSize(), 5);
+    assertFalse(urns3.isHavingMore());
+  }
+
   @Test
   public void testListUrns() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     AspectFoo foo = new AspectFoo().setValue("foo");
-    List<Urn> urns = new ArrayList<>();
+    List<FooUrn> urns = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
-      Urn urn = makeUrn(i);
+      FooUrn urn = makeFooUrn(i);
       for (int j = 0; j < 3; j++) {
         addMetadata(urn, AspectFoo.class.getCanonicalName(), j, foo);
       }
       urns.add(urn);
     }
 
-    ListResult<Urn> results = dao.listUrns(AspectFoo.class, 0, 1);
+    ListResult<FooUrn> results = dao.listUrns(AspectFoo.class, 0, 1);
 
     assertTrue(results.isHavingMore());
     assertEquals(results.getNextStart(), 1);
@@ -553,17 +698,52 @@ public class EbeanLocalDAOTest {
     results = dao.listUrns(AspectFoo.class, 0, 5);
     assertEquals(results.getValues().size(), 3);
     assertEquals(results.getValues(), urns.subList(0, 3));
-    assertEquals(results.getValues().get(0), makeUrn(0));
-    assertEquals(results.getValues().get(1), makeUrn(1));
-    assertEquals(results.getValues().get(2), makeUrn(2));
+    assertEquals(results.getValues().get(0), makeFooUrn(0));
+    assertEquals(results.getValues().get(1), makeFooUrn(1));
+    assertEquals(results.getValues().get(2), makeFooUrn(2));
+  }
+
+  @Test
+  public void testGetWithIndexFilter() {
+    LocalDAOStorageConfig storageConfig = makeLocalDAOStorageConfig(AspectFoo.class, Collections.singletonList("/value"));
+    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, storageConfig, FooUrn.class);
+    dao.enableLocalSecondaryIndex(true);
+
+    FooUrn urn = makeFooUrn(1);
+    AspectFoo foo0 = new AspectFoo().setValue("val1");
+    addMetadata(urn, AspectFoo.class.getCanonicalName(), 0, foo0);
+    AspectFoo foo1 = new AspectFoo().setValue("val2");
+    addMetadata(urn, AspectFoo.class.getCanonicalName(), 1, foo1);
+    AspectBar bar0 = new AspectBar().setValue("val1");
+    addMetadata(urn, AspectBar.class.getCanonicalName(), 0, bar0);
+    AspectBar bar1 = new AspectBar().setValue("val2");
+    addMetadata(urn, AspectBar.class.getCanonicalName(), 1, bar1);
+
+    dao.updateLocalIndex(urn, foo0, 0);
+    Set<Class<? extends RecordTemplate>> aspectClasses = ImmutableSet.of(AspectFoo.class, AspectBar.class);
+
+    IndexValue indexValue = new IndexValue();
+    indexValue.setString("val1");
+    IndexCriterion criterion = new IndexCriterion().setAspect(AspectFoo.class.getCanonicalName())
+        .setPathParams(new IndexPathParams().setPath("/value").setValue(indexValue));
+    IndexCriterionArray indexCriterionArray = new IndexCriterionArray(Collections.singletonList(criterion));
+    IndexFilter indexFilter = new IndexFilter().setCriteria(indexCriterionArray);
+
+    Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspectMap = new HashMap<>();
+    aspectMap.put(AspectFoo.class, Optional.of(foo0));
+    aspectMap.put(AspectBar.class, Optional.of(bar0));
+    Map<FooUrn, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> expected = new HashMap<>();
+    expected.put(urn, aspectMap);
+
+    assertEquals(dao.get(aspectClasses, indexFilter, null, 2), expected);
   }
 
   @Test
   public void testList() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     List<AspectFoo> foos = new LinkedList<>();
     for (int i = 0; i < 3; i++) {
-      Urn urn = makeUrn(i);
+      FooUrn urn = makeFooUrn(i);
 
       for (int j = 0; j < 10; j++) {
         AspectFoo foo = new AspectFoo().setValue("foo" + j);
@@ -574,7 +754,7 @@ public class EbeanLocalDAOTest {
       }
     }
 
-    Urn urn0 = makeUrn(0);
+    FooUrn urn0 = makeFooUrn(0);
 
     ListResult<AspectFoo> results = dao.list(AspectFoo.class, urn0, 0, 5);
 
@@ -587,7 +767,7 @@ public class EbeanLocalDAOTest {
 
     assertNotNull(results.getMetadata());
     List<Long> expectedVersions = Arrays.asList(0L, 1L, 2L, 3L, 4L);
-    List<Urn> expectedUrns = Arrays.asList(makeUrn(0), makeUrn(1), makeUrn(2), makeUrn(3), makeUrn(4));
+    List<Urn> expectedUrns = Arrays.asList(makeFooUrn(0), makeFooUrn(1), makeFooUrn(2), makeFooUrn(3), makeFooUrn(4));
     assertVersionMetadata(results.getMetadata(), expectedVersions, expectedUrns, 1234L, new CorpuserUrn("foo"),
         new CorpuserUrn("bar"));
 
@@ -603,19 +783,35 @@ public class EbeanLocalDAOTest {
     assertNotNull(results.getMetadata());
   }
 
+  private static LocalDAOStorageConfig makeLocalDAOStorageConfig(Class<? extends RecordTemplate> aspectClass, List<String> pegasusPaths) {
+    Map<Class<? extends RecordTemplate>, LocalDAOStorageConfig.AspectStorageConfig> aspectStorageConfigMap = new HashMap<>();
+    aspectStorageConfigMap.put(aspectClass, getAspectStorageConfig(pegasusPaths));
+    LocalDAOStorageConfig storageConfig = LocalDAOStorageConfig.builder().aspectStorageConfigMap(aspectStorageConfigMap).build();
+    return storageConfig;
+  }
+
+  private static LocalDAOStorageConfig makeLocalDAOStorageConfig(Class<? extends RecordTemplate> aspectClass1, List<String> pegasusPaths1,
+      Class<? extends RecordTemplate> aspectClass2, List<String> pegasusPaths2) {
+    Map<Class<? extends RecordTemplate>, LocalDAOStorageConfig.AspectStorageConfig> aspectStorageConfigMap = new HashMap<>();
+    aspectStorageConfigMap.put(aspectClass1, getAspectStorageConfig(pegasusPaths1));
+    aspectStorageConfigMap.put(aspectClass2, getAspectStorageConfig(pegasusPaths2));
+    LocalDAOStorageConfig storageConfig = LocalDAOStorageConfig.builder().aspectStorageConfigMap(aspectStorageConfigMap).build();
+    return storageConfig;
+  }
+
+  private static LocalDAOStorageConfig.AspectStorageConfig getAspectStorageConfig(List<String> pegasusPaths) {
+    Map<String, LocalDAOStorageConfig.PathStorageConfig> pathStorageConfigMap = new HashMap<>();
+    pegasusPaths.forEach(path -> pathStorageConfigMap.put(path,
+        LocalDAOStorageConfig.PathStorageConfig.builder().strongConsistentSecondaryIndex(true).build()));
+    return LocalDAOStorageConfig.AspectStorageConfig.builder().pathStorageConfigMap(pathStorageConfigMap).build();
+  }
+
   @Test
   void testStrongConsistentIndexPaths() {
     // construct LocalDAOStorageConfig object
-    LocalDAOStorageConfig.PathStorageConfig pathStorageConfig = LocalDAOStorageConfig.PathStorageConfig.builder().strongConsistentSecondaryIndex(true).build();
-    Map<String, LocalDAOStorageConfig.PathStorageConfig> pathStorageConfigMap = new HashMap<>();
-    pathStorageConfigMap.put("/value", pathStorageConfig);
-    LocalDAOStorageConfig.AspectStorageConfig aspectStorageConfig =
-        LocalDAOStorageConfig.AspectStorageConfig.builder().pathStorageConfigMap(pathStorageConfigMap).build();
-    Map<Class<? extends RecordTemplate>, LocalDAOStorageConfig.AspectStorageConfig> aspectStorageConfigMap = new HashMap<>();
-    aspectStorageConfigMap.put(AspectFoo.class, aspectStorageConfig);
-    LocalDAOStorageConfig storageConfig = LocalDAOStorageConfig.builder().aspectStorageConfigMap(aspectStorageConfigMap).build();
+    LocalDAOStorageConfig storageConfig = makeLocalDAOStorageConfig(AspectFoo.class, Collections.singletonList("/value"));
 
-    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, storageConfig);
+    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, storageConfig, FooUrn.class);
     Map<Class<? extends RecordTemplate>, LocalDAOStorageConfig.AspectStorageConfig> aspectToPaths = dao.getStrongConsistentIndexPaths();
 
     assertNotNull(aspectToPaths);
@@ -627,9 +823,9 @@ public class EbeanLocalDAOTest {
 
   @Test
   public void testListAspectsForAllUrns() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     for (int i = 0; i < 3; i++) {
-      Urn urn = makeUrn(i);
+      FooUrn urn = makeFooUrn(i);
 
       for (int j = 0; j < 10; j++) {
         AspectFoo foo = new AspectFoo().setValue("foo" + i + j);
@@ -646,7 +842,7 @@ public class EbeanLocalDAOTest {
     assertEquals(results.getTotalPageCount(), 2);
 
     assertNotNull(results.getMetadata());
-    assertVersionMetadata(results.getMetadata(), Arrays.asList(0L), Arrays.asList(makeUrn(0)), 1234L,
+    assertVersionMetadata(results.getMetadata(), Arrays.asList(0L), Arrays.asList(makeFooUrn(0)), 1234L,
         new CorpuserUrn("foo"), new CorpuserUrn("bar"));
 
     // Test list latest aspects
@@ -679,7 +875,7 @@ public class EbeanLocalDAOTest {
 
   @Test
   void testNewStringId() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     String id1 = dao.newStringId();
     String id2 = dao.newStringId();
 
@@ -692,7 +888,7 @@ public class EbeanLocalDAOTest {
 
   @Test
   void testNewNumericId() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     long id1 = dao.newNumericId("namespace");
     long id2 = dao.newNumericId("namespace");
     long id3 = dao.newNumericId("another namespace");
@@ -703,13 +899,13 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
-  void testSaveSingleEntryToLocalSecondaryIndex() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+  void testSaveSingleEntryToLocalIndex() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, BarUrn.class);
     BarUrn urn = makeBarUrn(0);
 
     // Test indexing integer typed value
-    long recordId = dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/intFoo", 0);
-    EbeanMetadataIndex record = getRecordFromLocalSecondaryIndex(recordId);
+    long recordId = dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/intFoo", 0);
+    EbeanMetadataIndex record = getRecordFromLocalIndex(recordId);
     assertNotNull(record);
     assertEquals(record.getUrn(), urn.toString());
     assertEquals(record.getAspect(), BarUrn.class.getCanonicalName());
@@ -717,8 +913,8 @@ public class EbeanLocalDAOTest {
     assertEquals(record.getLongVal().longValue(), 0L);
 
     // Test indexing long typed value
-    recordId = dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/longFoo", 1L);
-    record = getRecordFromLocalSecondaryIndex(recordId);
+    recordId = dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/longFoo", 1L);
+    record = getRecordFromLocalIndex(recordId);
     assertNotNull(record);
     assertEquals(record.getUrn(), urn.toString());
     assertEquals(record.getAspect(), BarUrn.class.getCanonicalName());
@@ -726,8 +922,8 @@ public class EbeanLocalDAOTest {
     assertEquals(record.getLongVal().longValue(), 1L);
 
     // Test indexing boolean typed value
-    recordId = dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/boolFoo", true);
-    record = getRecordFromLocalSecondaryIndex(recordId);
+    recordId = dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/boolFoo", true);
+    record = getRecordFromLocalIndex(recordId);
     assertNotNull(record);
     assertEquals(record.getUrn(), urn.toString());
     assertEquals(record.getAspect(), BarUrn.class.getCanonicalName());
@@ -735,8 +931,8 @@ public class EbeanLocalDAOTest {
     assertEquals(record.getStringVal(), "true");
 
     // Test indexing float typed value
-    recordId = dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/floatFoo", 12.34f);
-    record = getRecordFromLocalSecondaryIndex(recordId);
+    recordId = dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/floatFoo", 12.34f);
+    record = getRecordFromLocalIndex(recordId);
     assertNotNull(record);
     assertEquals(record.getUrn(), urn.toString());
     assertEquals(record.getAspect(), BarUrn.class.getCanonicalName());
@@ -744,8 +940,8 @@ public class EbeanLocalDAOTest {
     assertEquals(record.getDoubleVal(), 12.34);
 
     // Test indexing double typed value
-    recordId = dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/doubleFoo", 23.45);
-    record = getRecordFromLocalSecondaryIndex(recordId);
+    recordId = dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/doubleFoo", 23.45);
+    record = getRecordFromLocalIndex(recordId);
     assertNotNull(record);
     assertEquals(record.getUrn(), urn.toString());
     assertEquals(record.getAspect(), BarUrn.class.getCanonicalName());
@@ -753,8 +949,8 @@ public class EbeanLocalDAOTest {
     assertEquals(record.getDoubleVal(), 23.45);
 
     // Test indexing string typed value
-    recordId = dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/stringFoo", "valFoo");
-    record = getRecordFromLocalSecondaryIndex(recordId);
+    recordId = dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/stringFoo", "valFoo");
+    record = getRecordFromLocalIndex(recordId);
     assertNotNull(record);
     assertEquals(record.getUrn(), urn.toString());
     assertEquals(record.getAspect(), BarUrn.class.getCanonicalName());
@@ -763,26 +959,31 @@ public class EbeanLocalDAOTest {
   }
 
   @Test
-  void testExistsInLocalSecondaryIndex() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+  void testExistsInLocalIndex() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, BarUrn.class);
     BarUrn urn = makeBarUrn(0);
 
-    assertFalse(dao.existsInLocalSecondaryIndex(urn));
+    assertFalse(dao.existsInLocalIndex(urn));
 
-    dao.saveSingleRecordToLocalSecondaryIndex(urn, BarUrn.class.getCanonicalName(), "/barId", 0);
-    assertTrue(dao.existsInLocalSecondaryIndex(urn));
+    dao.saveSingleRecordToLocalIndex(urn, BarUrn.class.getCanonicalName(), "/barId", 0);
+    assertTrue(dao.existsInLocalIndex(urn));
   }
 
   @Test
-  void testProcessAndSaveUrnToLocalSecondaryIndex() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+  void testUpdateUrnInLocalIndex() {
+    // only urn will be updated since storage config has not been provided
+    EbeanLocalDAO dao1 = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, BarUrn.class);
+    EbeanLocalDAO dao2 = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, BazUrn.class);
+
     BarUrn barUrn = makeBarUrn(1);
     BazUrn bazUrn = makeBazUrn(2);
+    AspectBar aspectBar = new AspectBar().setValue("val1");
+    AspectBaz aspectBaz = new AspectBaz().setBoolField(true).setLongField(1234L).setStringField("val2");
 
-    dao.processAndSaveUrnToLocalSecondaryIndex(barUrn);
-    dao.processAndSaveUrnToLocalSecondaryIndex(bazUrn);
+    dao1.updateLocalIndex(barUrn, aspectBar, 0);
+    dao2.updateLocalIndex(bazUrn, aspectBaz, 0);
 
-    List<EbeanMetadataIndex> barRecords = getAllRecordsFromLocalSecondaryIndex(barUrn);
+    List<EbeanMetadataIndex> barRecords = getAllRecordsFromLocalIndex(barUrn);
     assertEquals(barRecords.size(), 1);
     EbeanMetadataIndex barRecord = barRecords.get(0);
     assertEquals(barRecord.getUrn(), barUrn.toString());
@@ -790,7 +991,7 @@ public class EbeanLocalDAOTest {
     assertEquals(barRecord.getPath(), "/barId");
     assertEquals(barRecord.getLongVal().longValue(), 1L);
 
-    List<EbeanMetadataIndex> bazRecords = getAllRecordsFromLocalSecondaryIndex(bazUrn);
+    List<EbeanMetadataIndex> bazRecords = getAllRecordsFromLocalIndex(bazUrn);
     assertEquals(bazRecords.size(), 1);
     EbeanMetadataIndex bazRecord = bazRecords.get(0);
     assertEquals(bazRecord.getUrn(), bazUrn.toString());
@@ -799,18 +1000,133 @@ public class EbeanLocalDAOTest {
     assertEquals(bazRecord.getLongVal().longValue(), 2L);
 
     // Test if new record is inserted with an existing urn
-    dao.processAndSaveUrnToLocalSecondaryIndex(barUrn);
-    assertEquals(getAllRecordsFromLocalSecondaryIndex(barUrn).size(), 1);
+    dao1.updateLocalIndex(barUrn, aspectBar, 1);
+    assertEquals(getAllRecordsFromLocalIndex(barUrn).size(), 1);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  void testNullAspectStorageConfigMap() {
+    // null aspect storage config map should throw an exception
+    LocalDAOStorageConfig.builder().aspectStorageConfigMap(null).build();
   }
 
   @Test
-  void testSaveToLocalSecondaryIndex() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
-    BarUrn urn = makeBarUrn(1);
-    AspectFoo aspect = new AspectFoo();
+  void testEmptyAspectStorageConfigMap() {
+    FooUrn urn = makeFooUrn(1);
 
-    dao.saveToLocalSecondaryIndex(urn, aspect, 0);
-    List<EbeanMetadataIndex> barRecords = getAllRecordsFromLocalSecondaryIndex(urn);
+    // default storage config constructed, resulting in empty aspect storage config map
+    LocalDAOStorageConfig storageConfig = LocalDAOStorageConfig.builder().build();
+    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, storageConfig, FooUrn.class);
+    dao.enableLocalSecondaryIndex(true);
+    AspectFoo aspect = new AspectFoo().setValue("val1");
+
+    // only urn is updated, aspect isn't
+    dao.updateLocalIndex(urn, aspect, 0);
+    List<EbeanMetadataIndex> fooRecords = getAllRecordsFromLocalIndex(urn);
+    assertEquals(fooRecords.size(), 1);
+    EbeanMetadataIndex record = fooRecords.get(0);
+    assertEquals(record.getUrn(), urn.toString());
+    assertEquals(record.getAspect(), FooUrn.class.getCanonicalName());
+    assertEquals(record.getPath(), "/fooId");
+    assertEquals(record.getLongVal().longValue(), 1L);
+  }
+
+  @Test
+  void testNullPathStorageConfigMap() {
+    FooUrn urn = makeFooUrn(2);
+
+    // path storage config map is manually set as null
+    Map<Class<? extends RecordTemplate>, LocalDAOStorageConfig.AspectStorageConfig> aspectStorageConfigMap = new HashMap<>();
+    aspectStorageConfigMap.put(AspectFoo.class, null);
+    LocalDAOStorageConfig storageConfig = LocalDAOStorageConfig.builder().aspectStorageConfigMap(aspectStorageConfigMap).build();
+    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, storageConfig, FooUrn.class);
+    dao.enableLocalSecondaryIndex(true);
+    AspectFoo aspect = new AspectFoo().setValue("val2");
+
+    // only urn is updated, aspect isn't
+    dao.updateLocalIndex(urn, aspect, 0);
+    List<EbeanMetadataIndex> fooRecords = getAllRecordsFromLocalIndex(urn);
+    assertEquals(fooRecords.size(), 1);
+    EbeanMetadataIndex record = fooRecords.get(0);
+    assertEquals(record.getUrn(), urn.toString());
+    assertEquals(record.getAspect(), FooUrn.class.getCanonicalName());
+    assertEquals(record.getPath(), "/fooId");
+    assertEquals(record.getLongVal().longValue(), 2L);
+  }
+
+  @Test
+  void testUpdateUrnAndAspectInLocalIndex() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(_mockProducer, _server, makeLocalDAOStorageConfig(AspectFooEvolved.class,
+        Arrays.asList("/value", "/newValue")), FooUrn.class);
+    FooUrn urn = makeFooUrn(1);
+    AspectFooEvolved aspect1 = new AspectFooEvolved().setValue("val1").setNewValue("newVal1");
+
+    dao.updateLocalIndex(urn, aspect1, 0);
+    List<EbeanMetadataIndex> fooRecords1 = getAllRecordsFromLocalIndex(urn);
+    assertEquals(fooRecords1.size(), 3);
+    EbeanMetadataIndex fooRecord1 = fooRecords1.get(0);
+    EbeanMetadataIndex fooRecord2 = fooRecords1.get(1);
+    EbeanMetadataIndex fooRecord3 = fooRecords1.get(2);
+    assertEquals(fooRecord1.getUrn(), urn.toString());
+    assertEquals(fooRecord1.getAspect(), FooUrn.class.getCanonicalName());
+    assertEquals(fooRecord1.getPath(), "/fooId");
+    assertEquals(fooRecord1.getLongVal().longValue(), 1L);
+    assertEquals(fooRecord2.getUrn(), urn.toString());
+    assertEquals(fooRecord2.getAspect(), AspectFooEvolved.class.getCanonicalName());
+    assertEquals(fooRecord2.getPath(), "/newValue");
+    assertEquals(fooRecord2.getStringVal(), "newVal1");
+    assertEquals(fooRecord3.getUrn(), urn.toString());
+    assertEquals(fooRecord3.getAspect(), AspectFooEvolved.class.getCanonicalName());
+    assertEquals(fooRecord3.getPath(), "/value");
+    assertEquals(fooRecord3.getStringVal(), "val1");
+
+    // Only the aspect and not urn will be inserted, with an aspect version different than 0. Old aspect rows should be deleted, new inserted
+    AspectFooEvolved aspect2 = new AspectFooEvolved().setValue("val2").setNewValue("newVal2");
+    dao.updateLocalIndex(urn, aspect2, 1);
+    assertEquals(getAllRecordsFromLocalIndex(urn).size(), 3);
+    List<EbeanMetadataIndex> fooRecords2 = getAllRecordsFromLocalIndex(urn);
+    EbeanMetadataIndex fooRecord4 = fooRecords2.get(0);
+    EbeanMetadataIndex fooRecord5 = fooRecords2.get(1);
+    EbeanMetadataIndex fooRecord6 = fooRecords2.get(2);
+    assertEquals(fooRecord4.getUrn(), urn.toString());
+    assertEquals(fooRecord4.getAspect(), FooUrn.class.getCanonicalName());
+    assertEquals(fooRecord4.getPath(), "/fooId");
+    assertEquals(fooRecord4.getLongVal().longValue(), 1L);
+    assertEquals(fooRecord5.getUrn(), urn.toString());
+    assertEquals(fooRecord5.getAspect(), AspectFooEvolved.class.getCanonicalName());
+    assertEquals(fooRecord5.getPath(), "/newValue");
+    assertEquals(fooRecord5.getStringVal(), "newVal2");
+    assertEquals(fooRecord6.getUrn(), urn.toString());
+    assertEquals(fooRecord6.getAspect(), AspectFooEvolved.class.getCanonicalName());
+    assertEquals(fooRecord6.getPath(), "/value");
+    assertEquals(fooRecord6.getStringVal(), "val2");
+
+    // if the value of a path is null then the corresponding path should not be inserted. Again old aspect rows should be deleted, new inserted
+    AspectFooEvolved aspect3 = new AspectFooEvolved().setValue("val3");
+    dao.updateLocalIndex(urn, aspect3, 2);
+    assertEquals(getAllRecordsFromLocalIndex(urn).size(), 2);
+    List<EbeanMetadataIndex> fooRecords3 = getAllRecordsFromLocalIndex(urn);
+    EbeanMetadataIndex fooRecord7 = fooRecords1.get(0);
+    EbeanMetadataIndex fooRecord8 = fooRecords3.get(1);
+    assertEquals(fooRecord7.getUrn(), urn.toString());
+    assertEquals(fooRecord7.getAspect(), FooUrn.class.getCanonicalName());
+    assertEquals(fooRecord7.getPath(), "/fooId");
+    assertEquals(fooRecord7.getLongVal().longValue(), 1L);
+    assertEquals(fooRecord8.getUrn(), urn.toString());
+    assertEquals(fooRecord8.getAspect(), AspectFooEvolved.class.getCanonicalName());
+    assertEquals(fooRecord8.getPath(), "/value");
+    assertEquals(fooRecord8.getStringVal(), "val3");
+  }
+
+
+  @Test
+  void testUpdateLocalIndex() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, BarUrn.class);
+    BarUrn urn = makeBarUrn(1);
+    AspectBar aspect = new AspectBar();
+
+    dao.updateLocalIndex(urn, aspect, 0);
+    List<EbeanMetadataIndex> barRecords = getAllRecordsFromLocalIndex(urn);
     assertEquals(barRecords.size(), 1);
     EbeanMetadataIndex barRecord = barRecords.get(0);
     assertEquals(barRecord.getUrn(), urn.toString());
@@ -819,8 +1135,8 @@ public class EbeanLocalDAOTest {
     assertEquals(barRecord.getLongVal().longValue(), 1L);
 
     // Test if new record is inserted with an aspect version different than 0
-    dao.saveToLocalSecondaryIndex(urn, aspect, 1);
-    assertEquals(getAllRecordsFromLocalSecondaryIndex(urn).size(), 1);
+    dao.updateLocalIndex(urn, aspect, 1);
+    assertEquals(getAllRecordsFromLocalIndex(urn).size(), 1);
   }
 
   @Test
@@ -839,16 +1155,18 @@ public class EbeanLocalDAOTest {
     assertEquals(dVal, gmaIndexPair.value);
     // 3. IndexValue pair corresponds to float
     float fVal = 0.0001f;
+    double doubleVal = fVal;
     indexValue.setFloat(fVal);
     gmaIndexPair = EbeanLocalDAO.getGMAIndexPair(indexValue);
     assertEquals(EbeanMetadataIndex.DOUBLE_COLUMN, gmaIndexPair.valueType);
-    assertEquals(fVal, gmaIndexPair.value);
+    assertEquals(doubleVal, gmaIndexPair.value);
     // 4. IndexValue pair corresponds to int
     int iVal = 100;
+    long longVal = iVal;
     indexValue.setInt(iVal);
     gmaIndexPair = EbeanLocalDAO.getGMAIndexPair(indexValue);
     assertEquals(EbeanMetadataIndex.LONG_COLUMN, gmaIndexPair.valueType);
-    assertEquals(iVal, gmaIndexPair.value);
+    assertEquals(longVal, gmaIndexPair.value);
     // 5. IndexValue pair corresponds to long
     long lVal = 1L;
     indexValue.setLong(lVal);
@@ -865,18 +1183,22 @@ public class EbeanLocalDAOTest {
 
   @Test
   void testListUrnsFromIndex() {
-    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server);
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
     FooUrn urn1 = makeFooUrn(1);
     FooUrn urn2 = makeFooUrn(2);
     FooUrn urn3 = makeFooUrn(3);
-    addIndex(urn1, "aspect1", "/path1", "val1");
-    addIndex(urn1, "aspect1", "/path2", "val2");
-    addIndex(urn1, "aspect1", "/path3", "val3");
-    addIndex(urn2, "aspect1", "/path1", "val1");
-    addIndex(urn3, "aspect1", "/path1", "val1");
+    String aspect = "aspect" + System.currentTimeMillis();
+    addIndex(urn1, aspect, "/path1", "val1");
+    addIndex(urn1, aspect, "/path2", "val2");
+    addIndex(urn1, aspect, "/path3", "val3");
+    addIndex(urn1, FooUrn.class.getCanonicalName(), "/fooId", 1);
+    addIndex(urn2, aspect, "/path1", "val1");
+    addIndex(urn2, FooUrn.class.getCanonicalName(), "/fooId", 2);
+    addIndex(urn3, aspect, "/path1", "val1");
+    addIndex(urn3, FooUrn.class.getCanonicalName(), "/fooId", 3);
 
     // 1. local secondary index is not enabled, should throw exception
-    IndexCriterion indexCriterion = new IndexCriterion().setAspect("aspect1");
+    IndexCriterion indexCriterion = new IndexCriterion().setAspect(aspect);
     final IndexFilter indexFilter1 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
     dao.enableLocalSecondaryIndex(false);
 
@@ -890,18 +1212,15 @@ public class EbeanLocalDAOTest {
 
     assertThrows(UnsupportedOperationException.class, () -> dao.listUrns(indexFilter2, null, 2));
 
-    // 3. index criterion array contains more than 1 criterion, should throw an exception
-    IndexCriterion indexCriterion1 = new IndexCriterion().setAspect("aspect1");
-    IndexCriterion indexCriterion2 = new IndexCriterion().setAspect("aspect2");
-    final IndexFilter indexFilter3 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion1, indexCriterion2));
-
+    // 3. index criterion array contains more than 10 criterion, should throw an exception
+    final IndexFilter indexFilter3 = new IndexFilter().setCriteria(makeIndexCriterionArray(11));
     assertThrows(UnsupportedOperationException.class, () -> dao.listUrns(indexFilter3, null, 2));
 
-    // 4. only aspect is provided in Index Filter
-    indexCriterion = new IndexCriterion().setAspect("aspect1");
+    // 3. only aspect and not path or value is provided in Index Filter
+    indexCriterion = new IndexCriterion().setAspect(aspect);
     final IndexFilter indexFilter4 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
 
-    ListResult<Urn> urns = dao.listUrns(indexFilter4, null, 2);
+    ListResult<FooUrn> urns = dao.listUrns(indexFilter4, null, 2);
 
     assertEquals(urns.getValues(), Arrays.asList(urn1, urn2));
     assertEquals(urns.getTotalCount(), 3);
@@ -910,7 +1229,7 @@ public class EbeanLocalDAOTest {
     IndexValue indexValue = new IndexValue();
     indexValue.setString("val1");
     IndexPathParams indexPathParams = new IndexPathParams().setPath("/path1").setValue(indexValue);
-    indexCriterion = new IndexCriterion().setAspect("aspect1").setPathParams(indexPathParams);
+    indexCriterion = new IndexCriterion().setAspect(aspect).setPathParams(indexPathParams);
     final IndexFilter indexFilter5 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
 
     urns = dao.listUrns(indexFilter5, urn1, 2);
@@ -920,12 +1239,83 @@ public class EbeanLocalDAOTest {
     // 6. aspect with correct path but incorrect value
     indexValue.setString("valX");
     indexPathParams = new IndexPathParams().setPath("/path1").setValue(indexValue);
-    indexCriterion = new IndexCriterion().setAspect("aspect1").setPathParams(indexPathParams);
+    indexCriterion = new IndexCriterion().setAspect(aspect).setPathParams(indexPathParams);
     final IndexFilter indexFilter6 = new IndexFilter().setCriteria(new IndexCriterionArray(indexCriterion));
 
     urns = dao.listUrns(indexFilter6, urn1, 2);
 
     assertEquals(urns.getTotalCount(), 0);
+  }
+
+  @Test
+  void testAddEntityTypeFilter() {
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+
+    String aspect = "aspect" + System.currentTimeMillis();
+    IndexValue indexValue = new IndexValue();
+    indexValue.setString("val1");
+    IndexCriterion indexCriterion1 = new IndexCriterion().setAspect(aspect).setPathParams(new IndexPathParams().setValue(indexValue).setPath("path"));
+    IndexCriterion indexCriterion2 = new IndexCriterion().setAspect(FooUrn.class.getCanonicalName());
+
+    IndexFilter filter1 = new IndexFilter().setCriteria(new IndexCriterionArray(Arrays.asList(indexCriterion1, indexCriterion2)));
+    IndexFilter filter2 = new IndexFilter().setCriteria(new IndexCriterionArray(Collections.singletonList(indexCriterion1)));
+    IndexFilter filter3 = new IndexFilter().setCriteria(new IndexCriterionArray(Arrays.asList(indexCriterion1, indexCriterion2)));
+
+    // entity class is not set in the index filter
+    dao.addEntityTypeFilter(filter2);
+    assertEquals(filter2, filter1);
+
+    // if entity class already added, then no further changes
+    dao.addEntityTypeFilter(filter3);
+    assertEquals(filter3, filter1);
+  }
+
+  @Test
+  void testListUrnsFromIndexForAnEntity() {
+    EbeanLocalDAO dao1 = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    EbeanLocalDAO dao2 = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, BarUrn.class);
+    dao1.enableLocalSecondaryIndex(true);
+    dao2.enableLocalSecondaryIndex(true);
+
+    FooUrn urn1 = makeFooUrn(1);
+    FooUrn urn2 = makeFooUrn(2);
+    FooUrn urn3 = makeFooUrn(3);
+    BarUrn urn4 = makeBarUrn(4);
+    AspectFoo aspectFoo = new AspectFoo();
+    AspectBar aspectBar = new AspectBar();
+
+    dao1.updateLocalIndex(urn1, aspectFoo, 0);
+    dao1.updateLocalIndex(urn2, aspectFoo, 0);
+    dao1.updateLocalIndex(urn3, aspectFoo, 0);
+    dao2.updateLocalIndex(urn4, aspectBar, 0);
+
+    // List foo urns
+    ListResult<FooUrn> urns1 = dao1.listUrns(FooUrn.class, null, 2);
+    assertEquals(urns1.getValues(), Arrays.asList(urn1, urn2));
+    assertEquals(urns1.getTotalCount(), 3);
+
+    // List bar urns
+    ListResult<BarUrn> urns2 = dao2.listUrns(BarUrn.class, null, 1);
+    assertEquals(urns2.getValues(), Arrays.asList(urn4));
+    assertEquals(urns2.getTotalCount(), 1);
+  }
+
+  @Test
+  void testGetUrn() {
+    // case 1: valid urn
+    EbeanLocalDAO dao = new EbeanLocalDAO(EntityAspectUnion.class, _mockProducer, _server, FooUrn.class);
+    String urn1 = "urn:li:entityFoo:1";
+    FooUrn fooUrn = makeFooUrn(1);
+
+    assertEquals(fooUrn, dao.getUrn(urn1));
+
+    // case 2: invalid entity type, correct id
+    String urn2 = "urn:li:test:1";
+    assertThrows(IllegalArgumentException.class, () -> dao.getUrn(urn2));
+
+    // case 3: invalid urn
+    String urn3 = "badUrn";
+    assertThrows(IllegalArgumentException.class, () -> dao.getUrn(urn3));
   }
 
   private void addMetadata(Urn urn, String aspectName, long version, RecordTemplate metadata) {
@@ -938,22 +1328,36 @@ public class EbeanLocalDAOTest {
     _server.save(aspect);
   }
 
-  private EbeanMetadataIndex getRecordFromLocalSecondaryIndex(long id) {
+  private EbeanMetadataIndex getRecordFromLocalIndex(long id) {
     return _server.find(EbeanMetadataIndex.class, id);
   }
 
-  private <URN extends Urn> List<EbeanMetadataIndex> getAllRecordsFromLocalSecondaryIndex(URN urn) {
+  private <URN extends Urn> List<EbeanMetadataIndex> getAllRecordsFromLocalIndex(URN urn) {
     return _server.find(EbeanMetadataIndex.class).where()
         .eq(EbeanMetadataIndex.URN_COLUMN, urn.toString())
         .findList();
   }
 
-  private void addIndex(Urn urn, String aspectName, String pathName, String sVal) {
+  private void addIndex(Urn urn, String aspectName, String pathName, Object val) {
     EbeanMetadataIndex index = new EbeanMetadataIndex();
     index.setUrn(urn.toString())
         .setAspect(aspectName)
-        .setPath(pathName)
-        .setStringVal(sVal);
+        .setPath(pathName);
+    if (val instanceof String) {
+      index.setStringVal(val.toString());
+    } else if (val instanceof Boolean) {
+      index.setStringVal(String.valueOf(val));
+    } else if (val instanceof Double) {
+      index.setDoubleVal((Double) val);
+    } else if (val instanceof Float) {
+      index.setDoubleVal(((Float) val).doubleValue());
+    } else if (val instanceof Integer) {
+      index.setLongVal(Long.valueOf((Integer) val));
+    } else if (val instanceof Long) {
+      index.setLongVal((Long) val);
+    } else {
+      return;
+    }
     _server.save(index);
   }
 

--- a/metadata-dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/ImmutableLocalDAOTest.java
+++ b/metadata-dao-impl/ebean-dao/src/test/java/com/linkedin/metadata/dao/ImmutableLocalDAOTest.java
@@ -1,8 +1,8 @@
 package com.linkedin.metadata.dao;
 
-import com.linkedin.common.urn.Urn;
 import com.linkedin.testing.AspectFoo;
 import com.linkedin.testing.EntityAspectUnion;
+import com.linkedin.testing.urn.FooUrn;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -20,20 +20,20 @@ public class ImmutableLocalDAOTest {
 
   @Test
   public void testLoadAspects() {
-    Map<Urn, AspectFoo> aspects = loadAspectsFromResource("immutable.json");
+    Map<FooUrn, AspectFoo> aspects = loadAspectsFromResource("immutable.json");
 
     assertEquals(aspects.size(), 3);
-    assertTrue(aspects.containsKey(makeUrn(1)));
-    assertTrue(aspects.containsKey(makeUrn(2)));
-    assertTrue(aspects.containsKey(makeUrn(3)));
+    assertTrue(aspects.containsKey(makeFooUrn(1)));
+    assertTrue(aspects.containsKey(makeFooUrn(2)));
+    assertTrue(aspects.containsKey(makeFooUrn(3)));
   }
 
   @Test
   public void testGet() {
-    ImmutableLocalDAO<EntityAspectUnion, Urn> dao =
-        new ImmutableLocalDAO<>(EntityAspectUnion.class, loadAspectsFromResource("immutable.json"), true);
+    ImmutableLocalDAO<EntityAspectUnion, FooUrn> dao =
+        new ImmutableLocalDAO<>(EntityAspectUnion.class, loadAspectsFromResource("immutable.json"), true, FooUrn.class);
 
-    Optional<AspectFoo> foo1 = dao.get(AspectFoo.class, makeUrn(1));
+    Optional<AspectFoo> foo1 = dao.get(AspectFoo.class, makeFooUrn(1));
 
     assertTrue(foo1.isPresent());
     assertEquals(foo1.get(), new AspectFoo().setValue("1"));
@@ -41,21 +41,21 @@ public class ImmutableLocalDAOTest {
 
   @Test(expectedExceptions = UnsupportedOperationException.class)
   public void testAdd() {
-    ImmutableLocalDAO<EntityAspectUnion, Urn> dao =
-        new ImmutableLocalDAO<>(EntityAspectUnion.class, new HashMap<>(), true);
+    ImmutableLocalDAO<EntityAspectUnion, FooUrn> dao =
+        new ImmutableLocalDAO<>(EntityAspectUnion.class, new HashMap<>(), true, FooUrn.class);
 
-    dao.add(makeUrn(1), new AspectFoo().setValue("1"), makeAuditStamp("foo"));
+    dao.add(makeFooUrn(1), new AspectFoo().setValue("1"), makeAuditStamp("foo"));
   }
 
   @Test(expectedExceptions = UnsupportedOperationException.class)
   public void testNewNumericId() {
-    ImmutableLocalDAO<EntityAspectUnion, Urn> dao =
-        new ImmutableLocalDAO<>(EntityAspectUnion.class, new HashMap<>(), true);
+    ImmutableLocalDAO<EntityAspectUnion, FooUrn> dao =
+        new ImmutableLocalDAO<>(EntityAspectUnion.class, new HashMap<>(), true, FooUrn.class);
 
     dao.newNumericId();
   }
 
-  private Map<Urn, AspectFoo> loadAspectsFromResource(String name) {
+  private Map<FooUrn, AspectFoo> loadAspectsFromResource(String name) {
     try {
       return ImmutableLocalDAO.loadAspects(AspectFoo.class, getClass().getClassLoader().getResourceAsStream(name));
     } catch (ParseException | IOException | URISyntaxException e) {

--- a/metadata-dao-impl/ebean-dao/src/test/resources/immutable.json
+++ b/metadata-dao-impl/ebean-dao/src/test/resources/immutable.json
@@ -1,11 +1,11 @@
 {
-  "urn:li:testing:1": {
+  "urn:li:entityFoo:1": {
     "value": "1"
   },
-  "urn:li:testing:2": {
+  "urn:li:entityFoo:2": {
     "value": "2"
   },
-  "urn:li:testing:3": {
+  "urn:li:entityFoo:3": {
     "value": "3"
   }
 }

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/browse/ESBrowseDAO.java
@@ -53,7 +53,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Gets a list of groups/entities that match given browse request
+   * Gets a list of groups/entities that match given browse request.
    *
    * @param path the path to be browsed
    * @param requestParams the request map with fields and values as filters
@@ -81,7 +81,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Builds aggregations for search request
+   * Builds aggregations for search request.
    *
    * @param path the path which is being browsed
    * @return {@link AggregationBuilder}
@@ -99,7 +99,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Constructs group search request
+   * Constructs group search request.
    *
    * @param path the path which is being browsed
    * @return {@link SearchRequest}
@@ -115,7 +115,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Builds query string
+   * Builds query string.
    *
    * @param path the path which is being browsed
    * @param requestMap entity filters e.g. status=PUBLISHED for features
@@ -154,7 +154,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Constructs search request for entity search
+   * Constructs search request for entity search.
    *
    * @param path the path which is being browsed
    * @param from index of first entity
@@ -177,7 +177,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Extracts search responses into browse result
+   * Extracts search responses into browse result.
    *
    * @param groupsResponse groups search response
    * @param entitiesResponse entity search response
@@ -200,7 +200,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Extracts group search response into browse result metadata
+   * Extracts group search response into browse result metadata.
    *
    * @param groupsResponse groups search response
    * @param path the path which is being browsed
@@ -221,7 +221,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Extracts entity search response into list of browse result entities
+   * Extracts entity search response into list of browse result entities.
    *
    * @param entitiesResponse entity search response
    * @return list of {@link BrowseResultEntity}
@@ -247,9 +247,9 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Extracts the name of group/entity from path
+   * Extracts the name of group/entity from path.
    *
-   * Example: /foo/bar/baz => baz
+   * <p>Example: /foo/bar/baz => baz
    *
    * @param path path of the group/entity
    * @return String
@@ -275,7 +275,7 @@ public class ESBrowseDAO extends BaseBrowseDAO {
   }
 
   /**
-   * Gets a list of paths for a given urn
+   * Gets a list of paths for a given urn.
    *
    * @param urn urn of the entity
    * @return all paths related to a given urn

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/BaseESAutoCompleteQuery.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/BaseESAutoCompleteQuery.java
@@ -18,20 +18,21 @@ public abstract class BaseESAutoCompleteQuery {
   }
 
   /**
-   * Constructs the search query for auto complete request
+   * Constructs the search query for auto complete request.
+   *
+   * <p>TODO: merge this with regular search query construction to take filters as context for suggestions
    *
    * @param field the field name for the auto complete
    * @param input the type ahead query text
    * @param requestParams the request map as filters
    * @return a valid search request
-   * TODO: merge this with regular search query construction to take filters as context for suggestions
    */
   @Nonnull
   abstract SearchRequest constructAutoCompleteQuery(@Nonnull String input, @Nonnull String field,
       @Nullable Filter requestParams);
 
   /**
-   * Gets a list of suggestions out of raw search hits
+   * Gets a list of suggestions out of raw search hits.
    *
    * @param searchResponse the raw search response from search engine
    * @param field the field name for the auto complete

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESAutoCompleteQueryForHighCardinalityFields.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESAutoCompleteQueryForHighCardinalityFields.java
@@ -2,7 +2,6 @@ package com.linkedin.metadata.dao.search;
 
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.dao.utils.ESUtils;
-import com.linkedin.metadata.dao.utils.SearchUtils;
 import com.linkedin.metadata.query.Filter;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -31,23 +30,21 @@ public class ESAutoCompleteQueryForHighCardinalityFields extends BaseESAutoCompl
 
   @Nonnull
   SearchRequest constructAutoCompleteQuery(@Nonnull String input, @Nonnull String field,
-      @Nullable Filter requestParams) {
+      @Nullable Filter filter) {
 
     SearchRequest searchRequest = new SearchRequest(_config.getIndexName());
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
-    Map<String, String> requestMap = SearchUtils.getRequestMap(requestParams);
-
     searchSourceBuilder.size(DEFAULT_AUTOCOMPLETE_QUERY_SIZE);
     searchSourceBuilder.query(buildAutoCompleteQueryString(input, field));
-    searchSourceBuilder.postFilter(ESUtils.buildFilterQuery(requestMap));
+    searchSourceBuilder.postFilter(ESUtils.buildFilterQuery(filter));
     searchRequest.source(searchSourceBuilder);
     log.debug("Auto complete request is: " + searchRequest.toString());
     return searchRequest;
   }
 
   /**
-   * Constructs auto complete query given request
+   * Constructs auto complete query given request.
    *
    * @param input the type ahead query text
    * @param field the field name for the auto complete

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESAutoCompleteQueryForLowCardinalityFields.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/search/ESAutoCompleteQueryForLowCardinalityFields.java
@@ -3,10 +3,8 @@ package com.linkedin.metadata.dao.search;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.metadata.dao.utils.ESUtils;
-import com.linkedin.metadata.dao.utils.SearchUtils;
 import com.linkedin.metadata.query.Filter;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,14 +31,12 @@ public class ESAutoCompleteQueryForLowCardinalityFields extends BaseESAutoComple
 
   @Nonnull
   SearchRequest constructAutoCompleteQuery(@Nonnull String input, @Nonnull String field,
-      @Nullable Filter requestParams) {
+      @Nullable Filter filter) {
 
     SearchRequest searchRequest = new SearchRequest(_config.getIndexName());
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
-    Map<String, String> requestMap = SearchUtils.getRequestMap(requestParams);
-
-    searchSourceBuilder.query(buildAutoCompleteQueryString(input, field, requestMap));
+    searchSourceBuilder.query(buildAutoCompleteQueryString(input, field, filter));
     searchSourceBuilder.aggregation(AggregationBuilders.terms(field).field(field));
     searchRequest.source(searchSourceBuilder);
     log.debug("Auto complete request is: " + searchRequest.toString());
@@ -48,18 +44,19 @@ public class ESAutoCompleteQueryForLowCardinalityFields extends BaseESAutoComple
   }
 
   /**
-   * Constructs auto complete query given request
+   * Constructs auto complete query given request.
    *
    * @param input the type ahead query text
    * @param field the field name for the auto complete
+   * @param filter the search filters
    * @return built autocomplete query
    */
   @Nonnull
   QueryBuilder buildAutoCompleteQueryString(@Nonnull String input, @Nonnull String field,
-      @Nonnull Map<String, String> requestMap) {
+      @Nullable Filter filter) {
     String subFieldDelimitEdgeNgram = field + ".delimited_edgengram";
     String subFieldEdgeNgram = field + ".edgengram";
-    BoolQueryBuilder query = ESUtils.buildFilterQuery(requestMap);
+    BoolQueryBuilder query = ESUtils.buildFilterQuery(filter);
     if (input.length() > 0) {
       query.must(QueryBuilders
           .queryStringQuery(input)

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/ESUtils.java
@@ -1,11 +1,14 @@
 package com.linkedin.metadata.dao.utils;
 
+import com.linkedin.metadata.query.Condition;
+import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.Filter;
 import com.linkedin.metadata.query.SortCriterion;
 import java.util.Arrays;
-import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -28,27 +31,48 @@ public class ESUtils {
   }
 
   /**
-   * Constructs the filter query given filter map
+   * Constructs the filter query given filter map.
    *
-   * Multiple values can be selected for a filter, and it is currently modeled as string separated by comma
+   * <p>Multiple values can be selected for a filter, and it is currently modeled as string separated by comma
    *
-   * @param requestMap the search request map with fields and its values
-   * @return built filters
+   * @param filter the search filter
+   * @return built filter query
    */
   @Nonnull
-  public static BoolQueryBuilder buildFilterQuery(@Nonnull Map<String, String> requestMap) {
+  public static BoolQueryBuilder buildFilterQuery(@Nullable Filter filter) {
     BoolQueryBuilder boolFilter = new BoolQueryBuilder();
-    for (Map.Entry<String, String> entry : requestMap.entrySet()) {
-      BoolQueryBuilder filters = new BoolQueryBuilder();
-      Arrays.stream(entry.getValue().split(","))
-          .forEach(elem -> filters.should(QueryBuilders.matchQuery(entry.getKey(), elem)));
-      boolFilter.must(filters);
+    if (filter == null) {
+      return boolFilter;
+    }
+    for (Criterion criterion : filter.getCriteria()) {
+      boolFilter.must(getQueryBuilderFromCriterionForSearch(criterion));
     }
     return boolFilter;
   }
 
   /**
-   * Populates source field of search query with the sort order as per the criterion provided
+   * Builds search query using criterion.
+   * This method is similar to SearchUtils.getQueryBuilderFromCriterion().
+   * The only difference is this method use match query instead of term query for EQUAL.
+   *
+   * @param criterion {@link Criterion} single criterion which contains field, value and a comparison operator
+   * @return QueryBuilder
+   */
+  @Nonnull
+  public static QueryBuilder getQueryBuilderFromCriterionForSearch(@Nonnull Criterion criterion) {
+    final Condition condition = criterion.getCondition();
+    if (condition == Condition.EQUAL) {
+      BoolQueryBuilder filters = new BoolQueryBuilder();
+      Arrays.stream(criterion.getValue().trim().split("\\s*,\\s*"))
+          .forEach(elem -> filters.should(QueryBuilders.matchQuery(criterion.getField(), elem)));
+      return filters;
+    } else {
+      return SearchUtils.getQueryBuilderFromCriterion(criterion);
+    }
+  }
+
+  /**
+   * Populates source field of search query with the sort order as per the criterion provided.
    *
    * <p>
    * If no sort criterion is provided then the default sorting criterion is chosen which is descending order of score
@@ -74,7 +98,7 @@ public class ESUtils {
   }
 
   /**
-   * Escapes the Elasticsearch reserved characters in the given input string
+   * Escapes the Elasticsearch reserved characters in the given input string.
    *
    * @param input input string
    * @return input string in which reserved characters are escaped

--- a/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/main/java/com/linkedin/metadata/dao/utils/SearchUtils.java
@@ -24,7 +24,7 @@ public class SearchUtils {
   }
 
   /**
-   * Validates the request params and create a request map out of it
+   * Validates the request params and create a request map out of it.
    *
    * @param requestParams the search request with fields and values
    * @return a request map
@@ -45,7 +45,7 @@ public class SearchUtils {
   }
 
   /**
-   * Builds search query using criterion
+   * Builds search query using criterion.
    *
    * @param criterion {@link Criterion} single criterion which contains field, value and a comparison operator
    * @return QueryBuilder

--- a/metadata-dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/ESUtilsTest.java
+++ b/metadata-dao-impl/elasticsearch-dao/src/test/java/com/linkedin/metadata/dao/ESUtilsTest.java
@@ -1,38 +1,71 @@
 package com.linkedin.metadata.dao;
 
-import com.google.common.collect.ImmutableMap;
-import com.linkedin.metadata.dao.utils.ESUtils;
+import com.linkedin.metadata.query.Condition;
+import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.CriterionArray;
+import com.linkedin.metadata.query.Filter;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.testng.annotations.Test;
 
 import static com.linkedin.metadata.dao.utils.ESUtils.*;
 import static com.linkedin.metadata.utils.TestUtils.*;
 import static org.testng.Assert.*;
 
+
 public class ESUtilsTest {
+
   @Test
-  public void testBuildFilterQuery() throws Exception {
-    // Test empty request map
-    Map<String, String> requestMap = Collections.emptyMap();
-    BoolQueryBuilder queryBuilder = ESUtils.buildFilterQuery(requestMap);
+  public void testBuildFilterQueryWithEmptyFilter() throws Exception {
+    // Test null filter
+    BoolQueryBuilder queryBuilder = buildFilterQuery(null);
     assertEquals(queryBuilder.toString(), loadJsonFromResource("filterQuery/EmptyFilterQuery.json"));
 
-    // Test and filters
-    requestMap = ImmutableMap.of("key1", "value1", "key2", "value2");
-    queryBuilder = ESUtils.buildFilterQuery(requestMap);
+    // Test empty filter
+    Filter filter = new Filter().setCriteria(new CriterionArray());
+    queryBuilder = buildFilterQuery(filter);
+    assertEquals(queryBuilder.toString(), loadJsonFromResource("filterQuery/EmptyFilterQuery.json"));
+  }
+
+  @Test
+  public void testBuildFilterQueryWithAndFilter() throws IOException {
+    Filter filter = new Filter().setCriteria(new CriterionArray(
+        Arrays.asList(new Criterion().setField("key1").setValue("value1").setCondition(Condition.EQUAL),
+            new Criterion().setField("key2").setValue("value2").setCondition(Condition.EQUAL))));
+    QueryBuilder queryBuilder = buildFilterQuery(filter);
     assertEquals(queryBuilder.toString(), loadJsonFromResource("filterQuery/AndFilterQuery.json"));
+  }
 
-    // Test or filters
-    requestMap = ImmutableMap.of("key1", "value1,value2");
-    queryBuilder = ESUtils.buildFilterQuery(requestMap);
+  @Test
+  public void testBuildFilterQueryWithOrFilter() throws IOException {
+    Filter filter = new Filter().setCriteria(new CriterionArray(Collections.singletonList(
+        new Criterion().setField("key1").setValue("value1,value2").setCondition(Condition.EQUAL))));
+    QueryBuilder queryBuilder = buildFilterQuery(filter);
     assertEquals(queryBuilder.toString(), loadJsonFromResource("filterQuery/OrFilterQuery.json"));
+  }
 
-    // Test complex filter
-    requestMap = ImmutableMap.of("key1", "value1,value2", "key2", "value2");
-    queryBuilder = ESUtils.buildFilterQuery(requestMap);
+  @Test
+  public void testBuildFilterQueryWithComplexFilter() throws IOException {
+    Filter filter = new Filter().setCriteria(new CriterionArray(
+        Arrays.asList(new Criterion().setField("key1").setValue("value1,value2").setCondition(Condition.EQUAL),
+            new Criterion().setField("key2").setValue("value2").setCondition(Condition.EQUAL))));
+    QueryBuilder queryBuilder = buildFilterQuery(filter);
     assertEquals(queryBuilder.toString(), loadJsonFromResource("filterQuery/ComplexFilterQuery.json"));
+  }
+
+  @Test
+  public void testBuildFilterQueryWithRangeFilter() throws IOException {
+    Filter filter = new Filter().setCriteria(new CriterionArray(
+        Arrays.asList(new Criterion().setField("key1").setValue("value1").setCondition(Condition.GREATER_THAN),
+            new Criterion().setField("key1").setValue("value2").setCondition(Condition.LESS_THAN),
+            new Criterion().setField("key2").setValue("value3").setCondition(Condition.GREATER_THAN_OR_EQUAL_TO),
+            new Criterion().setField("key3").setValue("value4").setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
+            )));
+    QueryBuilder queryBuilder = buildFilterQuery(filter);
+    assertEquals(queryBuilder.toString(), loadJsonFromResource("filterQuery/RangeFilterQuery.json"));
   }
 
   @Test

--- a/metadata-dao-impl/elasticsearch-dao/src/test/resources/filterQuery/RangeFilterQuery.json
+++ b/metadata-dao-impl/elasticsearch-dao/src/test/resources/filterQuery/RangeFilterQuery.json
@@ -1,0 +1,53 @@
+{
+  "bool" : {
+    "must" : [
+      {
+        "range" : {
+          "key1" : {
+            "from" : "value1",
+            "to" : null,
+            "include_lower" : false,
+            "include_upper" : true,
+            "boost" : 1.0
+          }
+        }
+      },
+      {
+        "range" : {
+          "key1" : {
+            "from" : null,
+            "to" : "value2",
+            "include_lower" : true,
+            "include_upper" : false,
+            "boost" : 1.0
+          }
+        }
+      },
+      {
+        "range" : {
+          "key2" : {
+            "from" : "value3",
+            "to" : null,
+            "include_lower" : true,
+            "include_upper" : true,
+            "boost" : 1.0
+          }
+        }
+      },
+      {
+        "range" : {
+          "key3" : {
+            "from" : null,
+            "to" : "value4",
+            "include_lower" : true,
+            "include_upper" : true,
+            "boost" : 1.0
+          }
+        }
+      }
+    ],
+    "disable_coord" : false,
+    "adjust_pure_negative" : true,
+    "boost" : 1.0
+  }
+}

--- a/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaMetadataEventProducer.java
+++ b/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/KafkaMetadataEventProducer.java
@@ -40,7 +40,7 @@ public class KafkaMetadataEventProducer<SNAPSHOT extends RecordTemplate, ASPECT_
   private final Optional<Callback> _callback;
 
   /**
-   * Constructor
+   * Constructor.
    *
    * @param snapshotClass The snapshot class for the produced events
    * @param aspectUnionClass The aspect union in the snapshot
@@ -54,7 +54,7 @@ public class KafkaMetadataEventProducer<SNAPSHOT extends RecordTemplate, ASPECT_
   }
 
   /**
-   * Constructor
+   * Constructor.
    *
    * @param snapshotClass The snapshot class for the produced events
    * @param aspectUnionClass The aspect union in the snapshot
@@ -117,8 +117,8 @@ public class KafkaMetadataEventProducer<SNAPSHOT extends RecordTemplate, ASPECT_
   public <ASPECT extends RecordTemplate> void produceAspectSpecificMetadataAuditEvent(@Nonnull URN urn,
       @Nullable ASPECT oldValue, @Nonnull ASPECT newValue) {
     final String topicKey = ModelUtils.getAspectSpecificMAETopicName(urn, newValue);
-    if (!isValidateAspectSpecificTopic(topicKey)) {
-      log.error("The aspect specific topic {} is not registered.", topicKey);
+    if (!isValidAspectSpecificTopic(topicKey)) {
+      log.warn(makeUnregisteredMAEMessage(urn, newValue));
       return;
     }
 
@@ -164,7 +164,13 @@ public class KafkaMetadataEventProducer<SNAPSHOT extends RecordTemplate, ASPECT_
     return snapshot;
   }
 
-  static boolean isValidateAspectSpecificTopic(@Nonnull String topic) {
+  static boolean isValidAspectSpecificTopic(@Nonnull String topic) {
     return Arrays.stream(Topics.class.getFields()).anyMatch(field -> field.getName().equals(topic));
+  }
+
+  @Nonnull
+  private String makeUnregisteredMAEMessage(@Nonnull URN urn, @Nonnull RecordTemplate value) {
+    return String.format("The MAEv5 event of entity %s with aspect %s has not been registered.",
+        urn.getClass().getCanonicalName(), value.getClass().getCanonicalName());
   }
 }

--- a/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jQueryDAO.java
+++ b/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jQueryDAO.java
@@ -60,6 +60,18 @@ public class Neo4jQueryDAO extends BaseQueryDAO {
     return runQuery(queryStatement, this::nodeRecordToEntity);
   }
 
+  /**
+   * Similar to other free form APIs, such as findEntities, findRelationships, findMixedTypesEntities, etc.
+   * findPaths should be used when there is a specific need to query the graph DB and no existing APIs could be used.
+   *
+   * @param queryStatement
+   * @return A list of paths, each of which should be [Node1, Edge1, Node2, Edge2, ....]
+   */
+  @Nonnull
+  public List<List<RecordTemplate>> findPaths(@Nonnull Statement queryStatement) {
+    return runQuery(queryStatement, this::pathRecordToPathList);
+  }
+
   @Nonnull
   @Override
   public <SRC_ENTITY extends RecordTemplate, DEST_ENTITY extends RecordTemplate, RELATIONSHIP extends RecordTemplate> List<RecordTemplate> findEntities(
@@ -185,7 +197,7 @@ public class Neo4jQueryDAO extends BaseQueryDAO {
 
   @Nonnull
   public <SRC_ENTITY extends RecordTemplate, DEST_ENTITY extends RecordTemplate, RELATIONSHIP extends RecordTemplate>
-  List<List<RecordTemplate>> getTraversedPaths(
+  List<List<RecordTemplate>> findPaths(
       @Nullable Class<SRC_ENTITY> sourceEntityClass, @Nonnull Filter sourceEntityFilter,
       @Nullable Class<DEST_ENTITY> destinationEntityClass, @Nonnull Filter destinationEntityFilter,
       @Nonnull Class<RELATIONSHIP> relationshipType, @Nonnull RelationshipFilter relationshipFilter,
@@ -225,16 +237,30 @@ public class Neo4jQueryDAO extends BaseQueryDAO {
   }
 
   /**
-   * Runs a query statement with parameters and return StatementResult
+   * Runs a query statement with parameters and return StatementResult.
    *
    * @param statement a statement with parameters to be executed
    * @param mapperFunction lambda to transform query result
-   * @return List<T> list of elements in the query result
+   * @return list of elements in the query result
    */
   @Nonnull
   private <T> List<T> runQuery(@Nonnull Statement statement, @Nonnull Function<Record, T> mapperFunction) {
     try (final Session session = _driver.session()) {
       return session.run(statement.getCommandText(), statement.getParams()).list(mapperFunction);
+    }
+  }
+
+
+  /**
+   * Runs a free-form Cypher query.
+   *
+   * @param query Cypher query to be executed
+   * @return query result as a list of {@link Record}
+   */
+  @Nonnull
+  public List<Record> runFreeFormQuery(@Nonnull String query) {
+    try (final Session session = _driver.session()) {
+      return session.run(query).list();
     }
   }
 
@@ -296,7 +322,7 @@ public class Neo4jQueryDAO extends BaseQueryDAO {
   }
 
   @Nonnull
-  private <ENTITY extends RecordTemplate> ENTITY nodeRecordToEntity(@Nonnull Class<ENTITY> entityClass,
+  <ENTITY extends RecordTemplate> ENTITY nodeRecordToEntity(@Nonnull Class<ENTITY> entityClass,
       @Nonnull Record nodeRecord) {
     return nodeToEntity(entityClass, nodeRecord.values().get(0).asNode());
   }

--- a/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
+++ b/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
@@ -35,7 +35,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts ENTITY to node (field:value map)
+   * Converts ENTITY to node (field:value map).
    *
    * @param entity ENTITY defined in models
    * @return unmodifiable field value map
@@ -51,7 +51,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts RELATIONSHIP to edge (field:value map), excluding source and destination
+   * Converts RELATIONSHIP to edge (field:value map), excluding source and destination.
    *
    * @param relationship RELATIONSHIP defined in models
    * @return unmodifiable field value map
@@ -72,7 +72,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts RELATIONSHIP to cypher matching criteria, excluding source and destination, e.g. {key: "value"}
+   * Converts RELATIONSHIP to cypher matching criteria, excluding source and destination, e.g. {key: "value"}.
    *
    * @param relationship RELATIONSHIP defined in models
    * @return Criteria String, or "" if no additional fields in relationship
@@ -113,7 +113,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts {@link Filter} to neo4j query criteria, filter criterion condition requires to be EQUAL
+   * Converts {@link Filter} to neo4j query criteria, filter criterion condition requires to be EQUAL.
    *
    * @param filter Query Filter
    * @return Neo4j criteria string
@@ -124,7 +124,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts {@link CriterionArray} to neo4j query string
+   * Converts {@link CriterionArray} to neo4j query string.
    *
    * @param criterionArray CriterionArray in a Filter
    * @return Neo4j criteria string
@@ -143,7 +143,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts node (field:value map) to ENTITY
+   * Converts node (field:value map) to ENTITY.
    *
    * @param entityClass Class of Entity
    * @param node Neo4j Node of entityClass type
@@ -156,7 +156,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts node (field:value map) to ENTITY RecordTemplate
+   * Converts node (field:value map) to ENTITY RecordTemplate.
    *
    * @param node Neo4j Node of entityClass type
    * @return RecordTemplate
@@ -169,10 +169,9 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts path segment (field:value map) list of {@link RecordTemplate}s of nodes & edges
+   * Converts path segment (field:value map) list of {@link RecordTemplate}s of nodes & edges.
    *
    * @param segment The segment of a path containing nodes & edges
-   * @return List<RecordTemplate>
    */
   @Nonnull
   public static List<RecordTemplate> pathSegmentToRecordList(@Nonnull Path.Segment segment) {
@@ -188,7 +187,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts edge (source-relationship->destination) to RELATIONSHIP
+   * Converts edge (source-relationship->destination) to RELATIONSHIP.
    *
    * @param relationshipClass Class of RELATIONSHIP
    * @param source Neo4j source Node
@@ -206,7 +205,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Converts edge (source-relationship->destination) to RELATIONSHIP RecordTemplate
+   * Converts edge (source-relationship->destination) to RELATIONSHIP RecordTemplate.
    *
    * @param source Neo4j source Node
    * @param destination Neo4j destination Node
@@ -251,7 +250,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Create {@link RelationshipFilter} using filter and relationship direction
+   * Create {@link RelationshipFilter} using filter and relationship direction.
    *
    * @param filter {@link Filter} filter
    * @param relationshipDirection {@link RelationshipDirection} relationship direction
@@ -264,7 +263,7 @@ public class Neo4jUtil {
   }
 
   /**
-   * Create {@link RelationshipFilter} using filter conditions and relationship direction
+   * Create {@link RelationshipFilter} using filter conditions and relationship direction.
    *
    * @param field field to create a filter on
    * @param value field value to be filtered

--- a/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAO.java
+++ b/metadata-dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAO.java
@@ -103,7 +103,7 @@ public class Neo4jGraphWriterDAO extends BaseGraphWriterDAO {
   }
 
   /**
-   * Run a query statement with parameters and return StatementResult
+   * Run a query statement with parameters and return StatementResult.
    *
    * @param statement a statement with parameters to be executed
    */
@@ -208,7 +208,7 @@ public class Neo4jGraphWriterDAO extends BaseGraphWriterDAO {
   }
 
   /**
-   * Gets Node based on Urn, if not exist, creates placeholder node
+   * Gets Node based on Urn, if not exist, creates placeholder node.
    */
   @Nonnull
   private Statement getOrInsertNode(@Nonnull Urn urn) {

--- a/metadata-dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jQueryDAOTest.java
+++ b/metadata-dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jQueryDAOTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.javatuples.Triplet;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -511,17 +512,114 @@ public class Neo4jQueryDAOTest {
     // Get reports roll-up - 2 levels
     Filter sourceFilter = newFilter("urn", urn1.toString());
     RelationshipFilter relationshipFilter = createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING);
-    List<List<RecordTemplate>> paths = _dao.getTraversedPaths(EntityFoo.class, sourceFilter, null,
+    List<List<RecordTemplate>> paths = _dao.findPaths(EntityFoo.class, sourceFilter, null,
         EMPTY_FILTER, RelationshipFoo.class, relationshipFilter, 1, 2, -1, -1);
     assertEquals(paths.size(), 5);
     assertEquals(paths.stream().filter(l -> l.size() == 3).collect(Collectors.toList()).size(), 2);
     assertEquals(paths.stream().filter(l -> l.size() == 5).collect(Collectors.toList()).size(), 3);
 
     // Get reports roll-up - 1 level
-    paths = _dao.getTraversedPaths(EntityFoo.class, sourceFilter, null,
+    paths = _dao.findPaths(EntityFoo.class, sourceFilter, null,
         EMPTY_FILTER, RelationshipFoo.class, relationshipFilter, 1, 1, -1, -1);
     assertEquals(paths.size(), 2);
     assertEquals(paths.stream().filter(l -> l.size() == 3).collect(Collectors.toList()).size(), 2);
     assertEquals(paths.stream().filter(l -> l.size() == 5).collect(Collectors.toList()).size(), 0);
+  }
+
+  @Test
+  public void testFindPaths() throws Exception {
+    BarUrn srcUrn = makeBarUrn(0);
+    BarUrn des1Urn = makeBarUrn(1);
+    BarUrn des2Urn = makeBarUrn(2);
+
+    FooUrn srcField1Urn = makeFooUrn(1);
+    FooUrn srcField2Urn = makeFooUrn(2);
+    FooUrn des1Field1Urn = makeFooUrn(11);
+    FooUrn des1Field2Urn = makeFooUrn(12);
+    FooUrn des2Field1Urn = makeFooUrn(21);
+
+    EntityBar src = new EntityBar().setUrn(srcUrn);
+    EntityBar des1 = new EntityBar().setUrn(des1Urn);
+    EntityBar des2 = new EntityBar().setUrn(des2Urn);
+    EntityFoo srcField1 = new EntityFoo().setUrn(srcField1Urn);
+    EntityFoo srcField2 = new EntityFoo().setUrn(srcField2Urn);
+    EntityFoo des1Field1 = new EntityFoo().setUrn(des1Field1Urn);
+    EntityFoo des1Field2 = new EntityFoo().setUrn(des1Field2Urn);
+    EntityFoo des2Field1 = new EntityFoo().setUrn(des2Field1Urn);
+
+    _writer.addEntity(src);
+    _writer.addEntity(des1);
+    _writer.addEntity(des2);
+    _writer.addEntity(srcField1);
+    _writer.addEntity(srcField2);
+    _writer.addEntity(des1Field1);
+    _writer.addEntity(des1Field2);
+    _writer.addEntity(des2Field1);
+
+    String commandText = "MATCH p=(n1 {urn:$src})-"
+        + "[r1]->(n2)-[r2:`com.linkedin.testing.RelationshipFoo`*0..100]->(n3)<-[r3]-() return p";
+    Map<String, Object> params = new HashMap<>();
+    params.put("src", srcUrn.toString());
+    Statement statement = new Statement(commandText, params);
+
+    // Test one path
+    createBarRelationship(srcUrn, srcField1Urn);
+    createBarRelationship(des1Urn, des1Field1Urn);
+    createFooRelationship(srcField1Urn, des1Field1Urn);
+
+    List<List<RecordTemplate>> paths = _dao.findPaths(statement);
+    assertEquals(paths.size(), 1);
+
+    List<RecordTemplate> path = paths.get(0);
+    assertEquals(path.size(), 7);
+
+    assertEquals(path.get(0), src);
+    assertEquals(path.get(2), srcField1);
+    assertEquals(path.get(4), des1Field1);
+    assertEquals(path.get(6), des1);
+
+    // Test multiple paths
+    createBarRelationship(des1Urn, des1Field2Urn);
+    createBarRelationship(des2Urn, des2Field1Urn);
+    createBarRelationship(srcUrn, srcField2Urn);
+    createFooRelationship(srcField2Urn, des1Field2Urn);
+    createFooRelationship(srcField2Urn, des2Field1Urn);
+
+    paths = _dao.findPaths(statement);
+
+    assertEquals(paths.size(), 3);
+    paths.forEach(p -> assertEquals(p.size(), 7));
+  }
+
+  @Test
+  public void testRunFreeFormQuery() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    FooUrn urn2 = makeFooUrn(2);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo");
+    _writer.addEntity(entity1);
+    _writer.addEntity(entity2);
+
+    String cypherQuery = "MATCH (n {value:\"foo\"}) RETURN n ORDER BY n.urn";
+    List<Record> result = _dao.runFreeFormQuery(cypherQuery);
+    List<EntityFoo> nodes = result.stream()
+        .map(record -> _dao.nodeRecordToEntity(EntityFoo.class, record))
+        .collect(Collectors.toList());
+    assertEquals(nodes.size(), 2);
+    assertEquals(nodes.get(0), entity1);
+    assertEquals(nodes.get(1), entity2);
+
+    cypherQuery = "MATCH (n {value:\"foo\"}) RETURN count(n)";
+    result = _dao.runFreeFormQuery(cypherQuery);
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0).values().get(0).asInt(), 2);
+  }
+
+  private void createFooRelationship(FooUrn f1, FooUrn f2) throws Exception {
+    _writer.addRelationship(new RelationshipFoo().setSource(f1).setDestination(f2));
+  }
+
+  private void createBarRelationship(BarUrn d1, FooUrn f1) throws Exception {
+    _writer.addRelationship(new RelationshipBar().setSource(d1).setDestination(f1));
   }
 }

--- a/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/BaseActionRequestBuilder.java
+++ b/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/BaseActionRequestBuilder.java
@@ -30,7 +30,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 /**
  * A base class for generating rest.li requests against entity-specific action methods.
  *
- * See http://go/gma for more details.
+ * <p>See http://go/gma for more details.
  *
  * @param <SNAPSHOT> must be a valid snapshot type defined in com.linkedin.metadata.snapshot
  * @param <URN> must be the URN type used in {@code SNAPSHOT}

--- a/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/internal/RestliRemoteWriterDAO.java
+++ b/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/internal/RestliRemoteWriterDAO.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
 /**
  * A rest.li implementation of {@link BaseRemoteWriterDAO}.
  *
- * Uses rest.li snapshot endpoints to update metadata on remote services.
+ * <p>Uses rest.li snapshot endpoints to update metadata on remote services.
  */
 public class RestliRemoteWriterDAO extends BaseRemoteWriterDAO {
 

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseBrowseDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseBrowseDAO.java
@@ -11,13 +11,12 @@ import javax.annotation.Nullable;
 /**
  * A base class for all Browse DAOs.
  *
- * A browse DAO is a standardized interface to browse metadata.
- * See http://go/gma for more details.
+ * <p>A browse DAO is a standardized interface to browse metadata. See http://go/gma for more details.
  */
 public abstract class BaseBrowseDAO {
 
   /**
-   * Gets a list of groups/entities that match given browse request
+   * Gets a list of groups/entities that match given browse request.
    *
    * @param path the path to be browsed
    * @param requestParams the request map with fields and values as filters
@@ -29,7 +28,7 @@ public abstract class BaseBrowseDAO {
   public abstract BrowseResult browse(@Nonnull String path, @Nullable Filter requestParams, int from, int size);
 
   /**
-   * Gets a list of paths for a given urn
+   * Gets a list of paths for a given urn.
    *
    * @param urn urn of the entity
    * @return all paths related to a given urn

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseLocalDAO.java
@@ -10,6 +10,7 @@ import com.linkedin.data.schema.validation.ValidationOptions;
 import com.linkedin.data.schema.validation.ValidationResult;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.dao.equality.DefaultEqualityTester;
 import com.linkedin.metadata.dao.equality.EqualityTester;
 import com.linkedin.metadata.dao.exception.ModelValidationException;
@@ -20,9 +21,12 @@ import com.linkedin.metadata.dao.retention.TimeBasedRetention;
 import com.linkedin.metadata.dao.retention.VersionBasedRetention;
 import com.linkedin.metadata.dao.storage.LocalDAOStorageConfig;
 import com.linkedin.metadata.query.ExtraInfo;
+import com.linkedin.metadata.query.IndexCriterion;
+import com.linkedin.metadata.query.IndexCriterionArray;
 import com.linkedin.metadata.query.IndexFilter;
 import java.time.Clock;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +44,7 @@ import lombok.Value;
 /**
  * A base class for all Local DAOs.
  *
- * Local DAO is a standardized interface to store and retrieve aspects from a document store.
+ * <p>Local DAO is a standardized interface to store and retrieve aspects from a document store.
  *
  * @param <ASPECT_UNION> must be a valid aspect union type defined in com.linkedin.metadata.aspect
  * @param <URN> must be the entity URN type in {@code ASPECT_UNION}
@@ -97,9 +101,10 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   private Clock _clock = Clock.systemUTC();
 
   /**
-   * Constructor for BaseLocalDAO
+   * Constructor for BaseLocalDAO.
    *
-   * @param aspectUnionClass containing union of all supported aspects. Must be a valid aspect union defined in com.linkedin.metadata.aspect
+   * @param aspectUnionClass containing union of all supported aspects. Must be a valid aspect union defined in
+   *     com.linkedin.metadata.aspect
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
    */
   public BaseLocalDAO(@Nonnull Class<ASPECT_UNION> aspectUnionClass, @Nonnull BaseMetadataEventProducer producer) {
@@ -109,7 +114,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * Constructor for BaseLocalDAO
+   * Constructor for BaseLocalDAO.
    *
    * @param producer {@link BaseMetadataEventProducer} for the metadata event producer
    * @param storageConfig {@link LocalDAOStorageConfig} containing storage config of full list of supported aspects
@@ -121,7 +126,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * For tests to override the internal clock
+   * For tests to override the internal clock.
    */
   public void setClock(@Nonnull Clock clock) {
     _clock = clock;
@@ -148,8 +153,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Registers a post-update hook for a specific aspect.
    *
-   * The hook will be invoked with the latest value of an aspect after it's updated. There's no guarantee on the order
-   * of invocation when multiple hooks are added for a single aspect. Adding the same hook again will result in
+   * <p>The hook will be invoked with the latest value of an aspect after it's updated. There's no guarantee on the
+   * order of invocation when multiple hooks are added for a single aspect. Adding the same hook again will result in
    * {@link IllegalArgumentException} thrown. Hooks are invoked in the order they're registered.
    */
   public <URN extends Urn, ASPECT extends RecordTemplate> void addPostUpdateHook(@Nonnull Class<ASPECT> aspectClass,
@@ -210,7 +215,8 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * Sets if writes to local secondary index enabled
+   * Sets if writes to local secondary index enabled.
+   *
    * @deprecated Use {@link #enableLocalSecondaryIndex(boolean)} instead
    */
   public void setWriteToLocalSecondaryIndex(boolean writeToLocalSecondaryIndex) {
@@ -218,21 +224,21 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * Enables reads from and writes to local secondary index
+   * Enables reads from and writes to local secondary index.
    */
   public void enableLocalSecondaryIndex(boolean enableLocalSecondaryIndex) {
     _enableLocalSecondaryIndex = enableLocalSecondaryIndex;
   }
 
   /**
-   * Gets if reads and writes to local secondary index are enabled
+   * Gets if reads and writes to local secondary index are enabled.
    */
   public boolean isLocalSecondaryIndexEnabled() {
     return _enableLocalSecondaryIndex;
   }
 
   /**
-   * Sets if local secondary index backfilling is enabled
+   * Sets if local secondary index backfilling is enabled.
    */
   public void setBackfillLocalSecondaryIndex(boolean backfillLocalSecondaryIndex) {
     _backfillLocalSecondaryIndex = backfillLocalSecondaryIndex;
@@ -241,9 +247,9 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   /**
    * Adds a new version of aspect for an entity.
    *
-   * The new aspect will have an automatically assigned version number, which is guaranteed to be positive and
-   * monotonically increasing. Older versions of aspect will be purged automatically based on the retention setting.
-   * A MetadataAuditEvent is also emitted if there's an actual update.
+   * <p>The new aspect will have an automatically assigned version number, which is guaranteed to be positive and
+   * monotonically increasing. Older versions of aspect will be purged automatically based on the retention setting. A
+   * MetadataAuditEvent is also emitted if there's an actual update.
    *
    * @param urn the URN for the entity the aspect is attached to
    * @param auditStamp the audit stamp for the operation
@@ -284,7 +290,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
 
       // 5. Save to local secondary index
       if (_enableLocalSecondaryIndex) {
-        saveToLocalSecondaryIndex(urn, newValue, largestVersion);
+        updateLocalIndex(urn, newValue, largestVersion);
       }
 
       return new AddResult<>(oldValue, newValue);
@@ -348,7 +354,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * Saves the latest aspect
+   * Saves the latest aspect.
    *
    * @param urn the URN for the entity the aspect is attached to
    * @param aspectClass the aspectClass of the aspect being saved
@@ -356,20 +362,20 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @param oldAuditStamp the audit stamp of the previous latest aspect, null if new value is the first version
    * @param newEntry {@link RecordTemplate} of the new latest value of aspect
    * @param newAuditStamp the audit stamp for the operation
-   * @return the largestVersion
+   * @return the largest version
    */
   protected abstract <ASPECT extends RecordTemplate> long saveLatest(@Nonnull URN urn,
       @Nonnull Class<ASPECT> aspectClass, @Nullable ASPECT oldEntry, @Nullable AuditStamp oldAuditStamp,
       @Nonnull ASPECT newEntry, @Nonnull AuditStamp newAuditStamp);
 
   /**
-   * Saves the new value of an aspect to local secondary index
+   * Saves the new value of an aspect to local secondary index.
    *
    * @param urn the URN for the entity the aspect is attached to
    * @param newValue {@link RecordTemplate} of the new value of aspect
    * @param version version of the aspect
    */
-  protected abstract <ASPECT extends RecordTemplate> void saveToLocalSecondaryIndex(@Nonnull URN urn,
+  protected abstract <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull URN urn,
       @Nullable ASPECT newValue, long version);
 
   /**
@@ -381,7 +387,34 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return {@link ListResult} of urns from local secondary index that satisfy the given filter conditions
    */
   @Nonnull
-  public abstract ListResult<Urn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize);
+  public abstract ListResult<URN> listUrns(@Nonnull IndexFilter indexFilter, @Nullable URN lastUrn, int pageSize);
+
+  /**
+   * Similar to {@link #listUrns(IndexFilter, URN, int)}. This is to get all urns with type URN.
+   */
+  @Nonnull
+  public ListResult<URN> listUrns(@Nonnull Class<URN> urnClazz, @Nullable URN lastUrn, int pageSize) {
+    final IndexFilter indexFilter = new IndexFilter()
+            .setCriteria(new IndexCriterionArray(new IndexCriterion().setAspect(urnClazz.getCanonicalName())));
+    return listUrns(indexFilter, lastUrn, pageSize);
+  }
+
+  /**
+   * Retrieves multiple aspects latest versions associated with list of urns returned from local secondary index that satisfy given filter conditions.
+   *
+   * @param aspectClasses aspect classes whose latest versions need to be retrieved
+   * @param indexFilter {@link IndexFilter} containing filter conditions to be applied
+   * @param lastUrn last urn of the previous fetched page. For the first page, this should be set as NULL
+   * @param pageSize maximum number of distinct urns whose aspects need to be retrieved
+   * @return latest versions of multiple aspects associated with urns returned from local secondary index that satisfy given filter conditions
+   */
+  @Nonnull
+  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> get(
+      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull IndexFilter indexFilter,
+      @Nullable URN lastUrn, int pageSize) {
+    final Set<URN> urns = new HashSet<>(listUrns(indexFilter, lastUrn, pageSize).getValues());
+    return get(aspectClasses, urns);
+  }
 
   /**
    * Runs the given lambda expression in a transaction with a limited number of retries.
@@ -395,7 +428,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   protected abstract <T> T runInTransactionWithRetry(@Nonnull Supplier<T> block, int maxTransactionRetry);
 
   /**
-   * Gets the latest version of a specific aspect type for an entity
+   * Gets the latest version of a specific aspect type for an entity.
    *
    * @param urn {@link Urn} for the entity
    * @param aspectClass the type of aspect to get
@@ -428,7 +461,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       long version, boolean insert);
 
   /**
-   * Applies version-based retention against a specific aspect type for an entity
+   * Applies version-based retention against a specific aspect type for an entity.
    *
    * @param aspectClass the type of aspect to apply retention to
    * @param urn {@link Urn} for the entity
@@ -439,7 +472,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull URN urn, @Nonnull VersionBasedRetention retention, long largestVersion);
 
   /**
-   * Applies time-based retention against a specific aspect type for an entity
+   * Applies time-based retention against a specific aspect type for an entity.
    *
    * @param aspectClass the type of aspect to apply retention to
    * @param urn {@link Urn} for the entity
@@ -450,74 +483,98 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull URN urn, @Nonnull TimeBasedRetention retention, long currentTime);
 
   /**
-   * Emits backfill MAE for the latest version of an aspect of an entity and also backfills local
-   * secondary index if writes & backfill enabled
+   * Emits backfill MAE for the latest version of an aspect and also backfills SCSI (if it exists and is enabled).
    *
    * @param aspectClass the type of aspect to backfill
-   * @param urn {@link Urn} for the entity
+   * @param urn urn for the entity
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
-   * @return the aspect emitted in the backfill message
+   * @return backfilled aspect
+   * @deprecated Use {@link #backfill(Set, Set)} instead
    */
   @Nonnull
-  public <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull URN urn) {
+  public <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn) {
+    return backfill(BackfillMode.BACKFILL_ALL, aspectClass, urn);
+  }
+
+  /**
+   * Similar to {@link #backfill(Class, URN)} but does a scoped backfill.
+   *
+   * @param mode backfill mode to scope the backfill process
+   */
+  @Nonnull
+  private <ASPECT extends RecordTemplate> Optional<ASPECT> backfill(@Nonnull BackfillMode mode,
+      @Nonnull Class<ASPECT> aspectClass, @Nonnull URN urn) {
     checkValidAspect(aspectClass);
     Optional<ASPECT> aspect = get(aspectClass, urn, LATEST_VERSION);
-    aspect.ifPresent(value -> backfill(value, urn));
+    aspect.ifPresent(value -> backfill(mode, value, urn));
     return aspect;
   }
 
   /**
-   * Similar to {@link #backfill(Class, URN)} but gets a set of aspect classes and do a batch backfill
-   */
-  @Nonnull
-  public Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> backfill(
-      @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull URN urn) {
-    checkValidAspects(aspectClasses);
-    Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>> aspects = get(aspectClasses, urn);
-    aspects.forEach((aspectClass, aspect) -> aspect.ifPresent(value -> backfill(value, urn)));
-    return aspects;
-  }
-
-  /**
-   * Similar to {@link #backfill(Class, URN)} but gets a set of urns and do a batch backfill
-   */
-  @Nonnull
-  public <ASPECT extends RecordTemplate> Map<URN, Optional<ASPECT>> backfill(@Nonnull Class<ASPECT> aspectClass,
-      @Nonnull Set<URN> urns) {
-    checkValidAspect(aspectClass);
-    final Map<URN, Optional<ASPECT>> urnToAspects = get(aspectClass, urns);
-    urnToAspects.forEach((urn, aspect) -> aspect.ifPresent(value -> backfill(value, urn)));
-    return urnToAspects;
-  }
-
-  /**
-   * Similar to {@link #backfill(Class, URN)} but gets a set of aspect classes and a set of URNs and do a batch backfill
+   * Emits backfill MAE for the latest version of a set of aspects for a set of urns and also backfills SCSI (if it exists and is enabled).
+   *
+   * @param aspectClasses set of aspects to backfill
+   * @param urns set of urns to backfill
+   * @return map of urn to their backfilled aspect values
    */
   @Nonnull
   public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
       @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
+    return backfill(BackfillMode.BACKFILL_ALL, aspectClasses, urns);
+  }
+
+  /**
+   * Similar to {@link #backfill(Set, Set)} but does a scoped backfill.
+   *
+   * @param mode backfill mode to scope the backfill process
+   */
+  @Nonnull
+  private Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
+      @Nonnull BackfillMode mode, @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses, @Nonnull Set<URN> urns) {
     checkValidAspects(aspectClasses);
     final Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> urnToAspects = get(aspectClasses, urns);
     urnToAspects.forEach((urn, aspects) -> {
-      aspects.forEach((aspectClass, aspect) -> aspect.ifPresent(value -> backfill(value, urn)));
+      aspects.forEach((aspectClass, aspect) -> aspect.ifPresent(value -> backfill(mode, value, urn)));
     });
     return urnToAspects;
   }
 
   /**
-   * Emits backfill MAE for an aspect of an entity and also backfills local secondary index if writes & backfill enabled
+   * Emits backfill MAE for the latest version of a set of aspects for a set of urns
+   * and also backfills SCSI (if it exists and is enabled) depending on the backfill mode.
    *
+   * @param mode backfill mode to scope the backfill process
+   * @param aspectClasses set of aspects to backfill
+   * @param urnClazz the type of urn to backfill - needed to list urns using SCSI
+   * @param lastUrn last urn of the previous backfilled page - needed to list urns using SCSI
+   * @param pageSize the number of entities to backfill
+   * @return map of urn to their backfilled aspect values
+   */
+  @Nonnull
+  public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> backfill(
+      @Nonnull BackfillMode mode, @Nonnull Set<Class<? extends RecordTemplate>> aspectClasses,
+      @Nonnull Class<URN> urnClazz, @Nullable URN lastUrn, int pageSize) {
+
+    final ListResult<URN> urnList = listUrns(urnClazz, lastUrn, pageSize);
+    return backfill(mode, aspectClasses, new HashSet(urnList.getValues()));
+  }
+
+  /**
+   * Emits backfill MAE for an aspect of an entity and/or backfills SCSI depending on the backfill mode.
+   *
+   * @param mode backfill mode
    * @param aspect aspect to backfill
    * @param urn {@link Urn} for the entity
    * @param <ASPECT> must be a supported aspect type in {@code ASPECT_UNION}.
    */
-  private <ASPECT extends RecordTemplate> void backfill(@Nonnull ASPECT aspect, @Nonnull URN urn) {
-    // Backfill local secondary index as well if writes & backfill enabled
-    if (_enableLocalSecondaryIndex && _backfillLocalSecondaryIndex) {
-      saveToLocalSecondaryIndex(urn, aspect, FIRST_VERSION);
+  private <ASPECT extends RecordTemplate> void backfill(@Nonnull BackfillMode mode,  @Nonnull ASPECT aspect, @Nonnull URN urn) {
+    if (_enableLocalSecondaryIndex && (mode == BackfillMode.SCSI_ONLY || mode == BackfillMode.BACKFILL_ALL)) {
+      updateLocalIndex(urn, aspect, FIRST_VERSION);
     }
-    _producer.produceMetadataAuditEvent(urn, aspect, aspect);
+
+    if (mode == BackfillMode.MAE_ONLY || mode == BackfillMode.BACKFILL_ALL) {
+      _producer.produceMetadataAuditEvent(urn, aspect, aspect);
+    }
   }
 
   /**
@@ -544,7 +601,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
    * @return a {@link ListResult} containing a list of URN and other pagination information
    */
   @Nonnull
-  public abstract <ASPECT extends RecordTemplate> ListResult<Urn> listUrns(@Nonnull Class<ASPECT> aspectClass,
+  public abstract <ASPECT extends RecordTemplate> ListResult<URN> listUrns(@Nonnull Class<ASPECT> aspectClass,
       int start, int pageSize);
 
   /**
@@ -562,7 +619,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       @Nonnull URN urn, int start, int pageSize);
 
   /**
-   * Paginates over a specific version of a specific aspect for all Urns
+   * Paginates over a specific version of a specific aspect for all Urns.
    *
    * @param aspectClass the type of the aspect to query
    * @param version the version of the aspect
@@ -576,7 +633,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
       long version, int start, int pageSize);
 
   /**
-   * Paginates over the latest version of a specific aspect for all Urns
+   * Paginates over the latest version of a specific aspect for all Urns.
    *
    * @param aspectClass the type of the aspect to query
    * @param start the starting offset of the page
@@ -609,7 +666,7 @@ public abstract class BaseLocalDAO<ASPECT_UNION extends UnionTemplate, URN exten
   }
 
   /**
-   * Similar to {@link #newNumericId(String, int)} but uses a single global namespace
+   * Similar to {@link #newNumericId(String, int)} but uses a single global namespace.
    */
   public long newNumericId() {
     return newNumericId(DEFAULT_ID_NAMESPACE);

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseQueryDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseQueryDAO.java
@@ -15,19 +15,17 @@ import static com.linkedin.metadata.dao.utils.QueryUtils.*;
 /**
  * A base class for all Query DAOs.
  *
- * Query DAO is a standardized interface to query the centralized graph DB.
- * See http://go/gma for more details.
+ * <p>Query DAO is a standardized interface to query the centralized graph DB. See http://go/gma for more details.
  */
 public abstract class BaseQueryDAO {
 
   /**
-   * Finds a list of entities of a specific type based on the given filter on the entity
+   * Finds a list of entities of a specific type based on the given filter on the entity.
    *
    * @param entityClass the entity class to query
    * @param filter the filter to apply when querying
    * @param offset the offset query should start at. Ignored if set to a negative value.
    * @param count the maximum number of entities to return. Ignored if set to a non-positive value.
-   *
    * @param <ENTITY> returned entity type. Must be a type defined in com.linkedin.metadata.entity.
    * @return a list of entities that match the conditions specified in {@code filter}
    */
@@ -40,7 +38,6 @@ public abstract class BaseQueryDAO {
    *
    * @param entityClass the entity class to query
    * @param queryStatement a {@link Statement} with query text and parameters
-   *
    * @param <ENTITY> returned entity type. Must be a type defined in com.linkedin.metadata.entity.
    * @return a list of entities from the outcome of the query statement
    */
@@ -58,8 +55,9 @@ public abstract class BaseQueryDAO {
   public abstract List<RecordTemplate> findMixedTypesEntities(@Nonnull Statement queryStatement);
 
   /**
-   * Finds a list of entities through certain relationships given an entity filter
-   * For more details on design and use cases, refer to interface 1 in go/gma/graph/dao
+   * Finds a list of entities through certain relationships given an entity filter.
+   *
+   * <p>For more details on design and use cases, refer to interface 1 in go/gma/graph/dao.
    *
    * @param sourceEntityClass the source entity class to query
    * @param sourceEntityFilter the filter to apply to the source entity when querying
@@ -87,7 +85,8 @@ public abstract class BaseQueryDAO {
   }
 
   /**
-   * Finds a list of entities of a specific type via multiple hops traversal based on the given relationship filter and source/destination entity filter.
+   * Finds a list of entities of a specific type via multiple hops traversal based on the given relationship filter and
+   * source/destination entity filter.
    *
    * @param sourceEntityClass the source entity class to query
    * @param sourceEntityFilter the filter to apply to the source entity when querying
@@ -118,12 +117,16 @@ public abstract class BaseQueryDAO {
    *
    * @param sourceEntityClass the source entity class as the starting point for the query
    * @param sourceEntityFilter the filter to apply to the source entity when querying
-   * @param traversePaths specify the traverse paths via a list of <relationship type, relationship filter, intermediate entities>
+   * @param traversePaths specify the traverse paths via a list of (relationship type, relationship filter,
+   *     intermediate entities)
    * @param count the maximum number of entities to return. Ignored if set to a non-positive value.
    *
-   * @param <SRC_ENTITY> source ENTITY type. Starting point of the traverse path. Must be a type defined in com.linkedin.metadata.entity.
-   * @param <INTER_ENTITY> intermediate entity type on the traverse path. Must be a type defined in com.linkedin.metadata.entity.
-   * @param <RELATIONSHIP> relationship type on the traverse path. Must be a type defined in com.linkedin.metadata.relationship.
+   * @param <SRC_ENTITY> source ENTITY type. Starting point of the traverse path. Must be a type defined in
+   *     com.linkedin.metadata.entity.
+   * @param <INTER_ENTITY> intermediate entity type on the traverse path. Must be a type defined in
+   *     com.linkedin.metadata.entity.
+   * @param <RELATIONSHIP> relationship type on the traverse path. Must be a type defined in
+   *     com.linkedin.metadata.relationship.
    * @return a list of entities that match the conditions specified in {@code filter}
    */
   @Nonnull
@@ -155,7 +158,8 @@ public abstract class BaseQueryDAO {
   }
 
   /**
-   * Finds a list of relationships of a specific type based on the given relationship filter and destination entity filter.
+   * Finds a list of relationships of a specific type based on the given relationship filter and destination entity
+   * filter.
    *
    * @param destinationEntityClass the destination entity class
    * @param destinationEntityFilter the filter to apply to the destination entity when querying
@@ -177,7 +181,8 @@ public abstract class BaseQueryDAO {
   }
 
   /**
-   * Finds a list of relationships of a specific type based on the given relationship filter and source/destination entity filter.
+   * Finds a list of relationships of a specific type based on the given relationship filter and source/destination
+   * entity filter.
    *
    * @param sourceEntityClass the source entity class to query
    * @param sourceEntityFilter the filter to apply to the source entity when querying

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseReadDAO.java
@@ -72,7 +72,7 @@ public abstract class BaseReadDAO<ASPECT_UNION extends UnionTemplate, URN extend
   /**
    * Similar to {@link #get(Class, Urn)} but retrieves multiple aspects latest versions associated with multiple URNs.
    *
-   * The returned {@link Map} contains all the .
+   * <p>The returned {@link Map} contains all the .
    */
   @Nonnull
   public Map<URN, Map<Class<? extends RecordTemplate>, Optional<? extends RecordTemplate>>> get(

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseRemoteDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseRemoteDAO.java
@@ -8,8 +8,8 @@ import javax.annotation.Nonnull;
 /**
  * A base class for all Remote DAO.
  *
- * Remote DAO is a standardized interface to fetch aspects stored on a remote service.
- * See http://go/gma for more details.
+ * <p>Remote DAO is a standardized interface to fetch aspects stored on a remote service. See http://go/gma for more
+ * details.
  *
  * @param <ASPECT_UNION> must be an aspect union type defined in com.linkedin.metadata.aspect
  */

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseSearchDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseSearchDAO.java
@@ -14,8 +14,7 @@ import javax.annotation.Nullable;
 /**
  * A base class for all Search DAOs.
  *
- * A search DAO is a standardized interface to search metadata.
- * See http://go/gma for more details.
+ * <p>A search DAO is a standardized interface to search metadata. See http://go/gma for more details.
  *
  * @param <DOCUMENT> must be a search document type defined in com.linkedin.metadata.search
  */
@@ -56,9 +55,9 @@ public abstract class BaseSearchDAO<DOCUMENT extends RecordTemplate> {
   public abstract SearchResult<DOCUMENT> filter(@Nullable Filter filters, @Nullable SortCriterion sortCriterion, int from, int size);
 
   /**
-   * Returns a list of suggestions given type ahead query
+   * Returns a list of suggestions given type ahead query.
    *
-   * The advanced auto complete can take filters and provides suggestions based on filtered context
+   * <p>The advanced auto complete can take filters and provides suggestions based on filtered context.
    *
    * @param query the type ahead query text
    * @param field the field name for the auto complete

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseSearchWriterDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/BaseSearchWriterDAO.java
@@ -8,7 +8,7 @@ import javax.annotation.Nonnull;
 /**
  * A base class for all Search Writer DAOs.
  *
- * Search Writer DAO is a standardized interface to update a search index.
+ * <p>Search Writer DAO is a standardized interface to update a search index.
  */
 public abstract class BaseSearchWriterDAO<DOCUMENT extends RecordTemplate> {
 

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/internal/BaseGraphWriterDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/internal/BaseGraphWriterDAO.java
@@ -10,7 +10,7 @@ import javax.annotation.Nonnull;
 /**
  * A base class for all Graph Writer DAOs.
  *
- * Graph Writer DAO is a standardized interface to update a centralized graph DB.
+ * <p>Graph Writer DAO is a standardized interface to update a centralized graph DB.
  */
 public abstract class BaseGraphWriterDAO {
 
@@ -74,7 +74,7 @@ public abstract class BaseGraphWriterDAO {
   }
 
   /**
-   * Adds a relationship in the graph, with removal operations before adding
+   * Adds a relationship in the graph, with removal operations before adding.
    *
    * @param relationship the relationship to be persisted
    * @param removalOption whether to remove existing relationship of the same type
@@ -99,7 +99,7 @@ public abstract class BaseGraphWriterDAO {
   }
 
   /**
-   * Adds a batch of relationships in the graph, with removal operations before adding
+   * Adds a batch of relationships in the graph, with removal operations before adding.
    *
    * @param relationships the list of relationships to be persisted
    * @param removalOption whether to remove existing relationship of the same type

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/internal/BaseRemoteWriterDAO.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/internal/BaseRemoteWriterDAO.java
@@ -8,13 +8,13 @@ import javax.annotation.Nonnull;
 /**
  * A base class for all remote writer DAOs.
  *
- * Remote writer DAO allows updating metadata aspects hosted on a remote service without knowing the exact
+ * <p>Remote writer DAO allows updating metadata aspects hosted on a remote service without knowing the exact
  * URN-to-service mapping.
  */
 public abstract class BaseRemoteWriterDAO {
 
   /**
-   * Creates a new metadata snapshot against a remote service
+   * Creates a new metadata snapshot against a remote service.
    *
    * @param urn the {@link Urn} for the entity
    * @param snapshot the snapshot containing updated metadata aspects

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/producer/BaseMetadataEventProducer.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 /**
  * A base class for all metadata event producers.
  *
- * See http://go/gma for more details.
+ *<p>See http://go/gma for more details.
  */
 public abstract class BaseMetadataEventProducer<SNAPSHOT extends RecordTemplate, ASPECT_UNION extends UnionTemplate, URN extends Urn> {
 

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/retention/TimeBasedRetention.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/retention/TimeBasedRetention.java
@@ -10,7 +10,7 @@ import lombok.Value;
 public class TimeBasedRetention implements Retention {
 
   /**
-   * Constructs a {@link TimeBasedRetention} object
+   * Constructs a {@link TimeBasedRetention} object.
    *
    * @param maxAgeToRetain maximal age (in milliseconds) to retain. Must be positive.
    */

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/retention/VersionBasedRetention.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/retention/VersionBasedRetention.java
@@ -9,7 +9,7 @@ import lombok.Value;
 public class VersionBasedRetention implements Retention {
 
   /**
-   * Constructs a {@link VersionBasedRetention} object
+   * Constructs a {@link VersionBasedRetention} object.
    *
    * @param maxVersionsToRetain maximal number of versions to retain. Must be greater than 0.
    */

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/storage/LocalDAOStorageConfig.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/storage/LocalDAOStorageConfig.java
@@ -1,47 +1,51 @@
 package com.linkedin.metadata.dao.storage;
 
 import com.linkedin.data.template.RecordTemplate;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 
 
 /**
- * Immutable class that holds the storage config for different paths of different metadata aspects
+ * Immutable class that holds the storage config for different paths of different metadata aspects.
  */
 @Value
 @Builder
 public final class LocalDAOStorageConfig {
 
   /**
-   * Map of corresponding {@link Class} of metadata aspect to {@link AspectStorageConfig} config
+   * Map of corresponding {@link Class} of metadata aspect to {@link AspectStorageConfig} config.
    */
-  Map<Class<? extends RecordTemplate>, AspectStorageConfig> aspectStorageConfigMap;
+  @NonNull
+  @Builder.Default
+  private final Map<Class<? extends RecordTemplate>, AspectStorageConfig> aspectStorageConfigMap = new HashMap<>();
 
   /**
-   * Immutable class that holds the storage config of different pegasus paths of a given metadata aspect
+   * Immutable class that holds the storage config of different pegasus paths of a given metadata aspect.
    */
   @Value
   @Builder
   public final static class AspectStorageConfig {
 
     /**
-     * Map of string representation of Pegasus Path to {@link PathStorageConfig} config
+     * Map of string representation of Pegasus Path to {@link PathStorageConfig} config.
      */
-    Map<String, PathStorageConfig> pathStorageConfigMap;
+    private final Map<String, PathStorageConfig> pathStorageConfigMap;
   }
 
   /**
-   * Immutable class that holds the storage config of a given pegasus path of a given metadata aspect
+   * Immutable class that holds the storage config of a given pegasus path of a given metadata aspect.
    */
   @Value
   @Builder
   public final static class PathStorageConfig {
 
     /**
-     * Whether to index the pegasus path to local secondary index
+     * Whether to index the pegasus path to local secondary index.
      */
     @Builder.Default
-    boolean strongConsistentSecondaryIndex = false;
+    private final boolean strongConsistentSecondaryIndex = false;
   }
 }

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/utils/ModelUtils.java
@@ -103,7 +103,7 @@ public class ModelUtils {
   }
 
   /**
-   * Gets a snapshot class given its FQCN
+   * Gets a snapshot class given its FQCN.
    *
    * @param className FQCN of snapshot class
    * @return snapshot class that extends {@link RecordTemplate}, associated with className
@@ -116,7 +116,7 @@ public class ModelUtils {
   }
 
   /**
-   * Extracts the "urn" field from a snapshot
+   * Extracts the "urn" field from a snapshot.
    *
    * @param snapshot the snapshot to extract urn from
    * @param <SNAPSHOT> must be a valid snapshot model defined in com.linkedin.metadata.snapshot
@@ -129,7 +129,7 @@ public class ModelUtils {
   }
 
   /**
-   * Similar to {@link #getUrnFromSnapshot(RecordTemplate)} but extracts from a Snapshot union instead
+   * Similar to {@link #getUrnFromSnapshot(RecordTemplate)} but extracts from a Snapshot union instead.
    */
   @Nonnull
   public static Urn getUrnFromSnapshotUnion(@Nonnull UnionTemplate snapshotUnion) {
@@ -137,7 +137,7 @@ public class ModelUtils {
   }
 
   /**
-   * Extracts the "urn" field from a delta
+   * Extracts the "urn" field from a delta.
    *
    * @param delta the delta to extract urn from
    * @param <DELTA> must be a valid delta model defined in com.linkedin.metadata.delta
@@ -150,7 +150,7 @@ public class ModelUtils {
   }
 
   /**
-   * Similar to {@link #getUrnFromDelta(RecordTemplate)} but extracts from a delta union instead
+   * Similar to {@link #getUrnFromDelta(RecordTemplate)} but extracts from a delta union instead.
    */
   @Nonnull
   public static Urn getUrnFromDeltaUnion(@Nonnull UnionTemplate deltaUnion) {
@@ -158,7 +158,7 @@ public class ModelUtils {
   }
 
   /**
-   * Extracts the "urn" field from a search document
+   * Extracts the "urn" field from a search document.
    *
    * @param document the document to extract urn from
    * @param <DOCUMENT> must be a valid document model defined in com.linkedin.metadata.search
@@ -171,7 +171,7 @@ public class ModelUtils {
   }
 
   /**
-   * Extracts the "urn" field from an entity
+   * Extracts the "urn" field from an entity.
    *
    * @param entity the entity to extract urn from
    * @param <ENTITY> must be a valid entity model defined in com.linkedin.metadata.entity
@@ -184,7 +184,7 @@ public class ModelUtils {
   }
 
   /**
-   * Extracts the fields with type urn from a relationship
+   * Extracts the fields with type urn from a relationship.
    *
    * @param relationship the relationship to extract urn from
    * @param <RELATIONSHIP> must be a valid relationship model defined in com.linkedin.metadata.relationship
@@ -200,7 +200,7 @@ public class ModelUtils {
   }
 
   /**
-   * Similar to {@link #getUrnFromRelationship} but extracts from a delta union instead
+   * Similar to {@link #getUrnFromRelationship} but extracts from a delta union instead.
    */
   @Nonnull
   public static <RELATIONSHIP extends RecordTemplate> Urn getSourceUrnFromRelationship(
@@ -209,7 +209,7 @@ public class ModelUtils {
   }
 
   /**
-   * Similar to {@link #getUrnFromRelationship} but extracts from a delta union instead
+   * Similar to {@link #getUrnFromRelationship} but extracts from a delta union instead.
    */
   @Nonnull
   public static <RELATIONSHIP extends RecordTemplate> Urn getDestinationUrnFromRelationship(
@@ -251,7 +251,7 @@ public class ModelUtils {
   }
 
   /**
-   * Similar to {@link #getAspectsFromSnapshot(RecordTemplate)} but extracts from a snapshot union instead
+   * Similar to {@link #getAspectsFromSnapshot(RecordTemplate)} but extracts from a snapshot union instead.
    */
   @Nonnull
   public static List<RecordTemplate> getAspectsFromSnapshotUnion(@Nonnull UnionTemplate snapshotUnion) {
@@ -270,7 +270,7 @@ public class ModelUtils {
   }
 
   /**
-   * Creates a snapshot with its urn field set
+   * Creates a snapshot with its urn field set.
    *
    * @param snapshotClass the type of snapshot to create
    * @param urn value for the urn field
@@ -492,7 +492,7 @@ public class ModelUtils {
   }
 
   /**
-   * Returns all entity classes
+   * Returns all entity classes.
    */
   @Nonnull
   public static Set<Class<? extends RecordTemplate>> getAllEntities() {
@@ -503,7 +503,7 @@ public class ModelUtils {
   }
 
   /**
-   * Get entity type from urn class
+   * Get entity type from urn class.
    */
   @Nonnull
   public static String getEntityTypeFromUrnClass(@Nonnull Class<? extends Urn> urnClass) {
@@ -526,9 +526,33 @@ public class ModelUtils {
   }
 
   /**
-   * Return true if the aspect is defined in common namespace
+   * Return true if the aspect is defined in common namespace.
    */
   public static boolean isCommonAspect(@Nonnull Class<? extends RecordTemplate> clazz) {
     return clazz.getPackage().getName().startsWith("com.linkedin.common");
+  }
+
+  /**
+   * Creates an entity union with a specific entity set.
+   *
+   * @param entityUnionClass the type of entity union to create
+   * @param entity the entity to set
+   * @param <ENTITY_UNION> must be a valid enity union defined in com.linkedin.metadata.entity
+   * @param <ENTITY> must be a supported entity in entity union
+   * @return the created entity union
+   */
+  @Nonnull
+  public static <ENTITY_UNION extends UnionTemplate, ENTITY extends RecordTemplate> ENTITY_UNION newEntityUnion(
+      @Nonnull Class<ENTITY_UNION> entityUnionClass, @Nonnull ENTITY entity) {
+
+    EntityValidator.validateEntityUnionSchema(entityUnionClass);
+
+    try {
+      ENTITY_UNION entityUnion = entityUnionClass.newInstance();
+      RecordUtils.setSelectedRecordTemplateInUnion(entityUnion, entity);
+      return entityUnion;
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/metadata-dao/src/main/java/com/linkedin/metadata/dao/utils/QueryUtils.java
+++ b/metadata-dao/src/main/java/com/linkedin/metadata/dao/utils/QueryUtils.java
@@ -68,7 +68,7 @@ public class QueryUtils {
   }
 
   /**
-   * Calculates the total page count
+   * Calculates the total page count.
    *
    * @param totalCount total count
    * @param size page size
@@ -82,7 +82,7 @@ public class QueryUtils {
   }
 
   /**
-   * Calculates whether there is more results
+   * Calculates whether there is more results.
    *
    * @param from offset from the first result you want to fetch
    * @param size page size

--- a/metadata-dao/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
+++ b/metadata-dao/src/main/pegasus/com/linkedin/metadata/backfill/BackfillMode.pdl
@@ -1,0 +1,22 @@
+namespace com.linkedin.metadata.backfill
+
+/**
+ * The mode of backfill. It's used to limit the scope of backfill process
+ */
+enum BackfillMode {
+
+  /**
+   * To backfill only SCSI
+   */
+  SCSI_ONLY
+
+  /**
+   * To backfill only using MAE
+   */
+  MAE_ONLY
+
+  /**
+   * To backfill all secondary stores
+   */
+  BACKFILL_ALL
+}

--- a/metadata-dao/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
+++ b/metadata-dao/src/test/java/com/linkedin/metadata/dao/BaseLocalDAOTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.dao;
 
 import com.linkedin.common.AuditStamp;
-import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.producer.BaseMetadataEventProducer;
 import com.linkedin.metadata.dao.retention.TimeBasedRetention;
@@ -50,7 +49,7 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    protected <ASPECT extends RecordTemplate> void saveToLocalSecondaryIndex(@Nonnull FooUrn urn,
+    protected <ASPECT extends RecordTemplate> void updateLocalIndex(@Nonnull FooUrn urn,
         @Nullable ASPECT newValue, long version) {
 
     }
@@ -94,13 +93,13 @@ public class BaseLocalDAOTest {
     }
 
     @Override
-    public <ASPECT extends RecordTemplate> ListResult<Urn> listUrns(Class<ASPECT> aspectClass, int start,
+    public <ASPECT extends RecordTemplate> ListResult<FooUrn> listUrns(Class<ASPECT> aspectClass, int start,
         int pageSize) {
       return null;
     }
 
     @Override
-    public ListResult<Urn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable FooUrn lastUrn, int pageSize) {
+    public ListResult<FooUrn> listUrns(@Nonnull IndexFilter indexFilter, @Nullable FooUrn lastUrn, int pageSize) {
       return null;
     }
 

--- a/metadata-dao/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
+++ b/metadata-dao/src/test/java/com/linkedin/metadata/dao/utils/ModelUtilsTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.testing.EntityFoo;
+import com.linkedin.testing.EntityUnion;
 import com.linkedin.testing.urn.BarUrn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.validator.InvalidSchemaException;
@@ -282,5 +283,13 @@ public class ModelUtilsTest {
 
     result = ModelUtils.isCommonAspect(Ownership.class);
     assertTrue(result);
+  }
+
+  @Test
+  public void testNewEntityUnion() {
+    EntityFoo entityFoo = new EntityFoo().setUrn(makeFooUrn(1));
+    EntityUnion entityUnion = ModelUtils.newEntityUnion(EntityUnion.class, entityFoo);
+
+    assertEquals(entityUnion.getEntityFoo(), entityFoo);
   }
 }

--- a/metadata-dao/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
+++ b/metadata-dao/src/test/java/com/linkedin/metadata/dao/utils/RecordUtilsTest.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.dao.utils;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.schema.PathSpec;
 import com.linkedin.data.schema.RecordDataSchema;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
@@ -10,10 +11,15 @@ import com.linkedin.metadata.validator.ValidationUtils;
 import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectBaz;
 import com.linkedin.testing.AspectFoo;
+import com.linkedin.testing.AspectFooArray;
 import com.linkedin.testing.EntitySnapshot;
+import com.linkedin.testing.EntityValueArray;
+import com.linkedin.testing.MixedRecord;
 import com.linkedin.testing.singleaspectentity.EntityValue;
+import com.linkedin.testing.urn.FooUrn;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Optional;
 import org.testng.annotations.Test;
 
 import static com.linkedin.metadata.utils.TestUtils.*;
@@ -166,7 +172,171 @@ public class RecordUtilsTest {
     assertEquals(RecordUtils.extractAspectFromSingleAspectEntity(value, AspectBar.class), aspect);
   }
 
+  @Test(description = "Test getFieldValue() when RecordTemplate has primitive fields")
+  public void testGetFieldValuePrimitive() {
+    // case 1: string field set, bool field isn't set, default field should return default value
+    final MixedRecord mixedRecord1 = new MixedRecord().setValue("fooVal1");
+    PathSpec ps1 = MixedRecord.fields().value();
+    PathSpec ps2 = MixedRecord.fields().flag();
+    PathSpec ps3 = MixedRecord.fields().defaultField();
+
+    Optional<Object> o1 = RecordUtils.getFieldValue(mixedRecord1, ps1);
+    Optional<Object> o2 = RecordUtils.getFieldValue(mixedRecord1, ps2);
+    Optional<Object> o3 = RecordUtils.getFieldValue(mixedRecord1, ps3);
+    assertEquals(o1.get(), "fooVal1");
+    assertFalse(o2.isPresent());
+    assertEquals(o3.get(), "defaultVal");
+    assertEquals(ps1.toString(), "/value");
+    assertEquals(ps2.toString(), "/flag");
+    assertEquals(ps3.toString(), "/defaultField");
+
+    // case 2: string and bool field both set
+    final MixedRecord mixedRecord2 = new MixedRecord().setValue("fooVal2").setFlag(true);
+    Object o4 = RecordUtils.getFieldValue(mixedRecord2, MixedRecord.fields().value()).get();
+    Object o5 = RecordUtils.getFieldValue(mixedRecord2, MixedRecord.fields().flag()).get();
+    assertEquals(o4, "fooVal2");
+    assertEquals(o5, true);
+
+    // case 3: similar to case1, just that pegasus path as string is used as input
+    Object o6 = RecordUtils.getFieldValue(mixedRecord1, "/value");
+    assertEquals(o6, o1);
+  }
+
+  @Test(description = "Test getFieldValue() when RecordTemplate has TypeRef field")
+  public void testGetFieldValueTypeRef() {
+    // case 1: Urn as the TypeRef
+    FooUrn urn = makeFooUrn(1);
+    final MixedRecord mixedRecord1 = new MixedRecord().setFooUrn(urn);
+    PathSpec ps1 = MixedRecord.fields().fooUrn();
+    Object o1 = RecordUtils.getFieldValue(mixedRecord1, ps1).get();
+    assertEquals(o1, urn);
+    assertEquals(ps1.toString(), "/fooUrn");
+
+    // case 2: TypeRef defined in the same pdl
+    final MixedRecord mixedRecord2 = new MixedRecord().setIntTypeRef(2);
+    PathSpec ps2 = MixedRecord.fields().intTypeRef();
+    Object o2 = RecordUtils.getFieldValue(mixedRecord2, ps2).get();
+    assertEquals(o2, 2);
+    assertEquals(ps2.toString(), "/intTypeRef");
+
+    // case 3: TypeRef for Record field reference
+    AspectFoo aspectFoo = new AspectFoo().setValue("fooVal");
+    PathSpec ps3 = MixedRecord.fields().recordTypeRef().value();
+    final MixedRecord mixedRecord3 = new MixedRecord().setRecordTypeRef(aspectFoo);
+    Object o3 = RecordUtils.getFieldValue(mixedRecord3, ps3).get();
+    assertEquals(o3, "fooVal");
+    assertEquals(ps3.toString(), "/recordTypeRef/value");
+  }
+
+  @Test(description = "Test getFieldValue() when RecordTemplate has another field of Record type")
+  public void testGetFieldValueRecordType() {
+    // case 1: referencing a field inside a RecordTemplate, one level deep.
+    AspectFoo foo1 = new AspectFoo().setValue("fooVal1");
+    MixedRecord mixedRecord1 = new MixedRecord().setRecordField(foo1);
+    PathSpec ps1f1 = MixedRecord.fields().recordField().value();
+    PathSpec ps1f2 = MixedRecord.fields().nestedRecordField().foo().value(); // referencing a nullable record template field
+
+    Optional<Object> o1f1 = RecordUtils.getFieldValue(mixedRecord1, ps1f1);
+    Optional<Object> o1f2 = RecordUtils.getFieldValue(mixedRecord1, ps1f2);
+
+    assertEquals(o1f1.get(), "fooVal1");
+    assertEquals(ps1f1.toString(), "/recordField/value");
+    assertFalse(o1f2.isPresent());
+    assertEquals(ps1f2.toString(), "/nestedRecordField/foo/value");
+
+    // case 2: referencing a field inside a RecordTemplate, two levels deep i.e. nested field
+    AspectFoo foo2 = new AspectFoo().setValue("fooVal2");
+    com.linkedin.testing.EntityValue entityValue = new com.linkedin.testing.EntityValue().setFoo(foo2);
+    MixedRecord mixedRecord2 = new MixedRecord().setNestedRecordField(entityValue);
+    PathSpec ps2 = MixedRecord.fields().nestedRecordField().foo().value();
+
+    Object o2 = RecordUtils.getFieldValue(mixedRecord2, ps2).get();
+
+    assertEquals(o2, "fooVal2");
+    assertEquals(ps2.toString(), "/nestedRecordField/foo/value");
+  }
+
+  @Test(description = "Test getFieldValue() when RecordTemplate has field of type array")
+  public void testGetFieldValueArray() {
+
+    // case 1: array of strings
+    final MixedRecord mixedRecord1 = new MixedRecord().setStringArray(new StringArray(Arrays.asList("val1", "val2", "val3", "val4")));
+
+    PathSpec ps1 = MixedRecord.fields().stringArray();
+    Object o1 = RecordUtils.getFieldValue(mixedRecord1, ps1).get();
+
+    assertEquals(o1, new StringArray(Arrays.asList("val1", "val2", "val3", "val4")));
+    assertEquals(ps1.toString(), "/stringArray");
+
+    // case 2: wildcard on array of records
+    AspectFoo aspectFoo1 = new AspectFoo().setValue("fooVal1");
+    AspectFoo aspectFoo2 = new AspectFoo().setValue("fooVal2");
+    AspectFoo aspectFoo3 = new AspectFoo().setValue("fooVal3");
+    AspectFoo aspectFoo4 = new AspectFoo().setValue("fooVal4");
+    final AspectFooArray aspectFooArray = new AspectFooArray(Arrays.asList(aspectFoo1, aspectFoo2, aspectFoo3, aspectFoo4));
+    final MixedRecord mixedRecord2 = new MixedRecord().setRecordArray(aspectFooArray);
+
+    PathSpec ps2 = MixedRecord.fields().recordArray().items().value();
+    Object o2 = RecordUtils.getFieldValue(mixedRecord2, ps2).get();
+
+    assertEquals(o2, new StringArray(Arrays.asList("fooVal1", "fooVal2", "fooVal3", "fooVal4")));
+    assertEquals(ps2.toString(), "/recordArray/*/value");
+
+    // case 3: array of records is empty
+    final MixedRecord mixedRecord3 = new MixedRecord().setRecordArray(new AspectFooArray());
+    Object o3 = RecordUtils.getFieldValue(mixedRecord3, MixedRecord.fields().recordArray().items().value()).get();
+    assertEquals(o3, new StringArray());
+
+    // case 4: referencing an index of array is not supported
+    final MixedRecord mixedRecord4 = new MixedRecord().setRecordArray(aspectFooArray);
+
+    assertThrows(UnsupportedOperationException.class, () -> RecordUtils.getFieldValue(mixedRecord4, "/recordArray/0/value"));
+
+    // case 5: referencing nested field inside array of records, field being 2 levels deep
+    AspectFoo f1 = new AspectFoo().setValue("val1");
+    AspectFoo f2 = new AspectFoo().setValue("val2");
+    com.linkedin.testing.EntityValue val1 = new com.linkedin.testing.EntityValue().setFoo(f1);
+    com.linkedin.testing.EntityValue val2 = new com.linkedin.testing.EntityValue().setFoo(f2);
+    EntityValueArray entityValues = new EntityValueArray(Arrays.asList(val1, val2));
+    final MixedRecord mixedRecord5 = new MixedRecord().setNestedRecordArray(entityValues);
+
+    PathSpec psFoo5 = MixedRecord.fields().nestedRecordArray().items().foo().value();
+    PathSpec psBar5 = MixedRecord.fields().nestedRecordArray().items().bar().value();
+    Optional<Object> oFoo5 = RecordUtils.getFieldValue(mixedRecord5, psFoo5);
+    Optional<Object> oBar5 = RecordUtils.getFieldValue(mixedRecord5, psBar5);
+
+    assertEquals(oFoo5.get(), new StringArray("val1", "val2"));
+    assertEquals(psFoo5.toString(), "/nestedRecordArray/*/foo/value");
+    assertEquals(oBar5.get(), new StringArray());
+    assertEquals(psBar5.toString(), "/nestedRecordArray/*/bar/value");
+
+    // case 6: optional field containing array of strings is not set
+    final MixedRecord mixedRecord6 = new MixedRecord();
+    PathSpec ps6 = MixedRecord.fields().stringArray();
+    Optional<Object> o6 = RecordUtils.getFieldValue(mixedRecord6, ps6);
+    assertFalse(o6.isPresent());
+
+    // case 7: optional field containing array of records is not set
+    final MixedRecord mixedRecord7 = new MixedRecord();
+    PathSpec ps7 = MixedRecord.fields().recordArray().items().value();
+    Optional<Object> o7 = RecordUtils.getFieldValue(mixedRecord7, ps7);
+    assertFalse(o7.isPresent());
+  }
+
+  @Test
+  public void testCapitalizeFirst() {
+    String s = "field1";
+    assertEquals(RecordUtils.capitalizeFirst(s), "Field1");
+
+    s = "t";
+    assertEquals(RecordUtils.capitalizeFirst(s), "T");
+
+    s = "";
+    assertEquals(RecordUtils.capitalizeFirst(s), "");
+  }
+
   private AspectBaz loadAspectBaz(String resourceName) throws IOException {
     return RecordUtils.toRecordTemplate(AspectBaz.class, loadJsonFromResource(resourceName));
   }
+
 }

--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/EventSchemaComposer.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/EventSchemaComposer.java
@@ -13,7 +13,7 @@ import static com.linkedin.metadata.generator.SchemaGeneratorConstants.*;
 import static com.linkedin.metadata.generator.SchemaGeneratorUtil.*;
 
 
-/***
+/**
  * Render the property annotations to the MXE pdl schema.
  */
 @Slf4j

--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/EventSpec.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/EventSpec.java
@@ -6,8 +6,8 @@ import javax.annotation.Nonnull;
 import lombok.Data;
 
 
-/***
- *  Getter & setter class for schema event metadata.
+/**
+ * Getter & setter class for schema event metadata.
  */
 @Data
 public class EventSpec {

--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/SchemaAnnotationRetriever.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/SchemaAnnotationRetriever.java
@@ -14,7 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import static com.linkedin.metadata.generator.SchemaGeneratorConstants.*;
 
 
-/***
+/**
  * Parse the property annotations from the pdl schema.
  */
 @Slf4j

--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/SchemaGenerator.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/generator/SchemaGenerator.java
@@ -7,6 +7,9 @@ import javax.annotation.Nonnull;
 import org.rythmengine.Rythm;
 
 
+/**
+ * Generates MXE schemas.
+ */
 public class SchemaGenerator {
 
   private final DataSchemaParser _dataSchemaParser;

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseBrowsableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseBrowsableClient.java
@@ -11,7 +11,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Base client that all entities supporting browse as well as search should implement in their respective restli MPs
+ * Base client that all entities supporting browse as well as search should implement in their respective restli MPs.
+ *
  * @param <VALUE> the client's value type
  * @param <URN> urn type of the entity
  */
@@ -37,7 +38,7 @@ public abstract class BaseBrowsableClient<VALUE extends RecordTemplate, URN exte
       throws RemoteInvocationException;
 
   /**
-   * Returns a list of paths for a given urn
+   * Returns a list of paths for a given urn.
    *
    * @param urn Urn of the entity
    * @return all paths that are related to the urn

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseBrowsableEntityResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseBrowsableEntityResource.java
@@ -19,9 +19,9 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 
 
 /**
- * A base class for the entity rest.li resource that supports CRUD + search + browse methods
+ * A base class for the entity rest.li resource that supports CRUD + search + browse methods.
  *
- * See http://go/gma for more details
+ * <p>See http://go/gma for more details
  *
  * @param <KEY> the resource's key type
  * @param <VALUE> the resource's value type

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseClient.java
@@ -51,7 +51,7 @@ public abstract class BaseClient implements AutoCloseable {
   }
 
   /**
-   * Similar to {@link #get(GetRequest)} but takes a @{link GetRequestBuilderBase} instead
+   * Similar to {@link #get(GetRequest)} but takes a @{link GetRequestBuilderBase} instead.
    */
   protected <K, ASPECT extends RecordTemplate, RB extends GetRequestBuilderBase<K, ASPECT, RB>>
   ASPECT get(@Nonnull GetRequestBuilderBase<K, ASPECT, RB> requestBuilder) throws RemoteInvocationException {
@@ -82,8 +82,8 @@ public abstract class BaseClient implements AutoCloseable {
   }
 
   /**
-   * Similar to {@link #batchGet(BatchGetEntityRequest, Function)} but
-   * takes a @{link BatchGetEntityRequestBuilder} instead
+   * Similar to {@link #batchGet(BatchGetEntityRequest, Function)} but takes a {@link BatchGetEntityRequestBuilder}
+   * instead.
    */
   protected <URN, KEY extends RecordTemplate, ASPECT extends RecordTemplate> Map<URN, ASPECT> batchGet(
       @Nonnull BatchGetEntityRequestBuilder<ComplexResourceKey<KEY, EmptyRecord>, ASPECT> requestBuilder,
@@ -102,7 +102,7 @@ public abstract class BaseClient implements AutoCloseable {
   }
 
   /**
-   * Similar to {@link #batchGet(BatchGetEntityRequest)} but takes a @{link BatchGetEntityRequestBuilder} instead
+   * Similar to {@link #batchGet(BatchGetEntityRequest)} but takes a @{link BatchGetEntityRequestBuilder} instead.
    */
   protected <KEY extends RecordTemplate, ASPECT extends RecordTemplate> Map<KEY, ASPECT> batchGet(
       @Nonnull BatchGetEntityRequestBuilder<ComplexResourceKey<KEY, EmptyRecord>, ASPECT> requestBuilder
@@ -125,7 +125,7 @@ public abstract class BaseClient implements AutoCloseable {
   }
 
   /**
-   * Similar to {@link #getAll(GetAllRequest)} but takes a @{link GetAllRequestBuilderBase} instead
+   * Similar to {@link #getAll(GetAllRequest)} but takes a @{link GetAllRequestBuilderBase} instead.
    */
   protected <K, ASPECT extends RecordTemplate, RB extends GetAllRequestBuilderBase<K, ASPECT, RB>>
   CollectionResponse<ASPECT> getAll(@Nonnull GetAllRequestBuilderBase<K, ASPECT, RB> requestBuilder)
@@ -148,7 +148,7 @@ public abstract class BaseClient implements AutoCloseable {
   }
 
   /**
-   * Similar to {@link #doAction(ActionRequest)} but takes a @{link ActionRequestBuilderBase} instead
+   * Similar to {@link #doAction(ActionRequest)} but takes a @{link ActionRequestBuilderBase} instead.
    */
   protected <K, ASPECT extends RecordTemplate, RB extends ActionRequestBuilderBase<K, ASPECT, RB>>
   ASPECT doAction(@Nonnull ActionRequestBuilderBase<K, ASPECT, RB> requestBuilder) throws RemoteInvocationException {

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseEntityResource.java
@@ -3,7 +3,9 @@ package com.linkedin.metadata.restli;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.UnionTemplate;
+import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
 import com.linkedin.metadata.dao.utils.ModelUtils;
@@ -24,9 +26,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -39,7 +43,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 /**
  * A base class for the entity rest.li resource, that supports CRUD methods.
  *
- * See http://go/gma for more details
+ * <p>See http://go/gma for more details
  *
  * @param <KEY> the resource's key type
  * @param <VALUE> the resource's value type
@@ -209,10 +213,12 @@ public abstract class BaseEntityResource<
 
   /**
    * An action method for emitting MAE backfill messages for an entity.
+   *
+   * @deprecated Use {@link #backfill(String[], String[])} instead
    */
-  @Action(name = ACTION_BACKFILL)
+  @Action(name = ACTION_BACKFILL_LEGACY)
   @Nonnull
-  public Task<String[]> backfill(@ActionParam(PARAM_URN) @Nonnull String urnString,
+  public Task<BackfillResult> backfill(@ActionParam(PARAM_URN) @Nonnull String urnString,
       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 
     return RestliUtils.toTask(() -> {
@@ -222,23 +228,65 @@ public abstract class BaseEntityResource<
           .filter(optionalAspect -> optionalAspect.isPresent())
           .map(optionalAspect -> ModelUtils.getAspectName(optionalAspect.get().getClass()))
           .collect(Collectors.toList());
-      return backfilledAspects.toArray(new String[0]);
+      return new BackfillResult().setEntities(new BackfillResultEntityArray(Collections.singleton(
+          new BackfillResultEntity().setUrn(urn).setAspects(new StringArray(backfilledAspects))
+      )));
     });
   }
 
   /**
    * An action method for emitting MAE backfill messages for a set of entities.
    */
-  @Action(name = ACTION_BATCH_BACKFILL)
+  @Action(name = ACTION_BACKFILL_WITH_URNS)
   @Nonnull
-  public Task<Void> batchBackfill(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
-      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
+  public Task<BackfillResult> backfill(@ActionParam(PARAM_URNS) @Nonnull String[] urns,
+                                       @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
 
     return RestliUtils.toTask(() -> {
       final Set<URN> urnSet = Arrays.stream(urns).map(urnString -> parseUrnParam(urnString)).collect(Collectors.toSet());
-      getLocalDAO().backfill(parseAspectsParam(aspectNames), urnSet);
-      return null;
+      return buildBackfillResult(getLocalDAO().backfill(parseAspectsParam(aspectNames), urnSet));
     });
+  }
+
+  /**
+   * An action method for emitting MAE backfill messages for a set of entities using SCSI.
+   */
+  @Action(name = ACTION_BACKFILL)
+  @Nonnull
+  public Task<BackfillResult> backfill(@ActionParam(PARAM_MODE) @Nonnull BackfillMode mode,
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames,
+      @ActionParam(PARAM_URN) @Optional @Nullable String lastUrn,
+      @ActionParam(PARAM_LIMIT) int limit) {
+
+    return RestliUtils.toTask(() ->
+            buildBackfillResult(getLocalDAO().backfill(mode, parseAspectsParam(aspectNames),
+                    _urnClass,
+                    parseUrnParam(lastUrn),
+                    limit)));
+  }
+
+  @Nonnull
+  private BackfillResult buildBackfillResult(@Nonnull Map<URN, Map<Class<? extends RecordTemplate>,
+          java.util.Optional<? extends RecordTemplate>>> backfilledAspects) {
+
+    final Set<URN> urns = new TreeSet<>(Comparator.comparing(Urn::toString));
+    urns.addAll(backfilledAspects.keySet());
+    return new BackfillResult().setEntities(new BackfillResultEntityArray(
+            urns.stream().map(urn -> buildBackfillResultEntity(urn, backfilledAspects.get(urn)))
+                    .collect(Collectors.toList())));
+  }
+
+  @Nonnull
+  private BackfillResultEntity buildBackfillResultEntity(@Nonnull URN urn, Map<Class<? extends RecordTemplate>,
+          java.util.Optional<? extends RecordTemplate>> aspectMap) {
+
+    return new BackfillResultEntity()
+            .setUrn(urn)
+            .setAspects(new StringArray(aspectMap.entrySet().stream()
+                    .filter(aspect -> aspect.getValue().isPresent())
+                    .map(aspect -> aspect.getKey().getCanonicalName())
+                    .collect(Collectors.toList()))
+            );
   }
 
   /**
@@ -272,7 +320,7 @@ public abstract class BaseEntityResource<
 
     return RestliUtils.toTask(() ->
         getLocalDAO()
-            .listUrns(filter, lastUrn == null ? null : parseUrnParam(lastUrn), limit)
+            .listUrns(filter, parseUrnParam(lastUrn), limit)
             .getValues()
             .stream()
             .map(Urn::toString)
@@ -289,7 +337,7 @@ public abstract class BaseEntityResource<
   }
 
   /**
-   * Returns a map of {@link VALUE} models given the collection of {@link URN}s and set of aspect classes
+   * Returns a map of {@link VALUE} models given the collection of {@link URN}s and set of aspect classes.
    *
    * @param urns collection of urns
    * @param aspectClasses set of aspect classes
@@ -341,8 +389,12 @@ public abstract class BaseEntityResource<
     return ModelUtils.newSnapshot(_snapshotClass, urn, aspects);
   }
 
-  @Nonnull
-  private URN parseUrnParam(@Nonnull String urnString) {
+  @Nullable
+  private URN parseUrnParam(@Nullable String urnString) {
+    if (urnString == null) {
+      return null;
+    }
+
     try {
       return createUrnFromString(urnString);
     } catch (Exception e) {

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseEntitySimpleKeyResource.java
@@ -34,7 +34,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 /**
  * A base class for the entity rest.li resource where the key is of a primitive (simple) type.
  *
- * See http://go/gma for more details
+ * <p>See http://go/gma for more details
  *
  * @param <KEY> the resource's simple key type
  * @param <VALUE> the resource's value type
@@ -229,7 +229,7 @@ public abstract class BaseEntitySimpleKeyResource<
   }
 
   /**
-   * Returns a map of {@link VALUE} models given the collection of {@link URN}s and set of aspect classes
+   * Returns a map of {@link VALUE} models given the collection of {@link URN}s and set of aspect classes.
    *
    * @param urns collection of urns
    * @param aspectClasses set of aspect classes

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSearchableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSearchableClient.java
@@ -11,8 +11,10 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+
 /**
- * Base client that all entities supporting search should implement in their respective restli MPs
+ * Base client that all entities supporting search should implement in their respective restli MPs.
+ *
  * @param <VALUE> the client's value type
  */
 public abstract class BaseSearchableClient<VALUE extends RecordTemplate> extends BaseClient {
@@ -22,7 +24,8 @@ public abstract class BaseSearchableClient<VALUE extends RecordTemplate> extends
   }
 
   /**
-   * Search method that the client inheriting this class must implement. Returns {@link CollectionResponse} containing list of aspects
+   * Search method that the client inheriting this class must implement. Returns {@link CollectionResponse} containing
+   * list of aspects.
    *
    * @param input Input query
    * @param aspectNames List of aspects to be returned in the VALUE model
@@ -34,11 +37,13 @@ public abstract class BaseSearchableClient<VALUE extends RecordTemplate> extends
    * @throws RemoteInvocationException when the rest.li request fails
    */
   @Nonnull
-  public abstract CollectionResponse<VALUE> search(@Nonnull String input, @Nullable StringArray aspectNames, @Nullable Map<String, String> requestFilters,
-      @Nullable SortCriterion sortCriterion, int start, int count) throws RemoteInvocationException;
+  public abstract CollectionResponse<VALUE> search(@Nonnull String input, @Nullable StringArray aspectNames,
+      @Nullable Map<String, String> requestFilters, @Nullable SortCriterion sortCriterion, int start, int count)
+      throws RemoteInvocationException;
 
   /**
-   * Similar to {@link #search(String, StringArray, Map, SortCriterion, int, int)} with null for aspect names, meaning all aspects will be returned
+   * Similar to {@link #search(String, StringArray, Map, SortCriterion, int, int)} with null for aspect names, meaning
+   * all aspects will be returned.
    */
   @Nonnull
   public CollectionResponse<VALUE> search(@Nonnull String input, @Nullable Map<String, String> requestFilters,
@@ -47,7 +52,7 @@ public abstract class BaseSearchableClient<VALUE extends RecordTemplate> extends
   }
 
   /**
-   * Autocomplete method that the client will override only if they need this capability. It returns {@link AutoCompleteResult} containing list of suggestions.
+   * Autocomplete method that the client will override only if they need this capability.
    *
    * @param query Input query
    * @param field Field against which the query needs autocompletion
@@ -61,5 +66,4 @@ public abstract class BaseSearchableClient<VALUE extends RecordTemplate> extends
       @Nullable Map<String, String> requestFilters, int limit) throws RemoteInvocationException {
     throw new UnsupportedOperationException("Not implemented yet.");
   }
-
 }

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSearchableEntityResource.java
@@ -33,9 +33,9 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 
 
 /**
- * A base class for the entity rest.li resource that supports CRUD + search methods
+ * A base class for the entity rest.li resource that supports CRUD + search methods.
  *
- * See http://go/gma for more details
+ * <p>See http://go/gma for more details
  *
  * @param <KEY> the resource's key type
  * @param <VALUE> the resource's value type

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyResource.java
@@ -145,10 +145,11 @@ public abstract class BaseSingleAspectEntitySimpleKeyResource<
 
   /**
    * Gets all {@link VALUE} objects from DB for an entity with single aspect
-   * Warning: this works only if the aspect is not shared with other entities.
    *
-   * It paginates over the latest version of a specific aspect for all Urns
-   * By default the list is sorted in ascending order of urn
+   * <p>Warning: this works only if the aspect is not shared with other entities.
+   *
+   * <p>It paginates over the latest version of a specific aspect for all Urns. By default the list is sorted in
+   * ascending order of urn
    *
    * @param pagingContext Paging context.
    * @return collection of latest resource(s).

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyVersionedSubResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectEntitySimpleKeyVersionedSubResource.java
@@ -25,8 +25,8 @@ import javax.annotation.Nonnull;
  * A base resource class for serving a versioned single-aspect entity values as sub resource. This resource class is
  * meant to be used as a child resource for classes extending from {@link BaseSingleAspectEntitySimpleKeyResource}.
  *
- * The key for the sub-resource is typically a version field which is a Long value. The versioned resources
- * are retrieved using {@link #get(Long)} and {@link #getAllWithMetadata(PagingContext)}.
+ * <p>The key for the sub-resource is typically a version field which is a Long value. The versioned resources are
+ * retrieved using {@link #get(Long)} and {@link #getAllWithMetadata(PagingContext)}.
  *
  * @param <VALUE> the resource's value type
  * @param <URN> must be a valid {@link Urn} type
@@ -40,7 +40,7 @@ public abstract class BaseSingleAspectEntitySimpleKeyVersionedSubResource<
     ASPECT extends RecordTemplate,
     ASPECT_UNION extends UnionTemplate>
     extends CollectionResourceTaskTemplate<Long, VALUE> {
-   // @formatter:on
+  // @formatter:on
 
   private final Class<ASPECT> _aspectClass;
   private final Class<VALUE> _valueClass;

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntitySimpleKeyResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseSingleAspectSearchableEntitySimpleKeyResource.java
@@ -18,7 +18,7 @@ import static com.linkedin.metadata.dao.BaseReadDAO.*;
 /**
  * A base class for the single aspect entity rest.li resource that supports CRUD + search methods.
  *
- * See http://go/gma for more details
+ * <p>See http://go/gma for more details.
  *
  * @param <KEY> the resource's key type
  * @param <VALUE> the resource's value type

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BaseVersionedAspectResource.java
@@ -31,7 +31,7 @@ import static com.linkedin.metadata.dao.BaseReadDAO.*;
 /**
  * A base class for an aspect rest.li subresource with versioning support.
  *
- * See http://go/gma for more details
+ * <p>See http://go/gma for more details
  *
  * @param <URN> must be a valid {@link Urn} type
  * @param <ASPECT_UNION> must be a valid union of aspect models defined in com.linkedin.metadata.aspect
@@ -112,7 +112,7 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   }
 
   /**
-   * Similar to {@link #create(RecordTemplate)} but uses a create lambda instead
+   * Similar to {@link #create(RecordTemplate)} but uses a create lambda instead.
    */
   @Nonnull
   public Task<CreateResponse> create(@Nonnull Class<ASPECT> aspectClass,
@@ -126,7 +126,8 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   }
 
   /**
-   * Similar to {@link #create(Class, Function)} but returns {@link CreateKVResponse} containing latest version and created aspect
+   * Similar to {@link #create(Class, Function)} but returns {@link CreateKVResponse} containing latest version and
+   * created aspect.
    */
   @RestMethod.Create
   @ReturnEntity
@@ -142,7 +143,7 @@ public abstract class BaseVersionedAspectResource<URN extends Urn, ASPECT_UNION 
   }
 
   /**
-   * Creates using the provided default value only if the aspect is not set already
+   * Creates using the provided default value only if the aspect is not set already.
    *
    * @param defaultValue provided default value
    * @return {@link CreateKVResponse} containing lastest version and created aspect

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BrowsableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/BrowsableClient.java
@@ -10,7 +10,7 @@ import javax.annotation.Nullable;
 
 
 /**
- * Interface which all entities supporting browse should implement in their respective restli MPs
+ * Interface which all entities supporting browse should implement in their respective restli MPs.
  *
  * @deprecated Use {@link BaseBrowsableClient} instead
  */

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/RestliConstants.java
@@ -7,7 +7,8 @@ public final class RestliConstants {
 
   public static final String ACTION_AUTOCOMPLETE = "autocomplete";
   public static final String ACTION_BACKFILL = "backfill";
-  public static final String ACTION_BATCH_BACKFILL = "batchBackfill";
+  public static final String ACTION_BACKFILL_WITH_URNS = "backfillWithUrns";
+  public static final String ACTION_BACKFILL_LEGACY = "backfillLegacy";
   public static final String ACTION_BROWSE = "browse";
   public static final String ACTION_GET_BROWSE_PATHS = "getBrowsePaths";
   public static final String ACTION_GET_SNAPSHOT = "getSnapshot";
@@ -26,4 +27,5 @@ public final class RestliConstants {
   public static final String PARAM_SNAPSHOT = "snapshot";
   public static final String PARAM_URN = "urn";
   public static final String PARAM_URNS = "urns";
+  public static final String PARAM_MODE = "mode";
 }

--- a/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/SearchableClient.java
+++ b/metadata-restli-resource/src/main/java/com/linkedin/metadata/restli/SearchableClient.java
@@ -11,9 +11,9 @@ import javax.annotation.Nullable;
 
 
 /**
- * Interface that all entities that support search and autocomplete should implement in their respective restli MPs
- * @param <VALUE> the client's value type
+ * Interface that all entities that support search and autocomplete should implement in their respective restli MPs.
  *
+ * @param <VALUE> the client's value type.
  * @deprecated Use {@link BaseSearchableClient} instead
  */
 public interface SearchableClient<VALUE extends RecordTemplate> {

--- a/metadata-restli-resource/src/main/pegasus/com/linkedin/metadata/restli/BackfillResult.pdl
+++ b/metadata-restli-resource/src/main/pegasus/com/linkedin/metadata/restli/BackfillResult.pdl
@@ -1,0 +1,23 @@
+namespace com.linkedin.metadata.restli
+
+import com.linkedin.common.Urn
+
+/**
+ * The model for the result of a backfill
+ */
+record BackfillResult {
+  /**
+   * List of backfilled entities
+   */
+  entities: array[record BackfillResultEntity {
+    /**
+     * Urn of the backfilled entity
+     */
+    urn: Urn
+
+    /**
+     * List of the aspects backfilled for the entity
+     */
+    aspects: array[string]
+  }]
+}

--- a/metadata-restli-resource/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
+++ b/metadata-restli-resource/src/test/java/com/linkedin/metadata/restli/BaseEntityResourceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.backfill.BackfillMode;
 import com.linkedin.metadata.dao.AspectKey;
 import com.linkedin.metadata.dao.BaseLocalDAO;
 import com.linkedin.metadata.dao.ListResult;
@@ -315,9 +316,14 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     when(_mockLocalDAO.backfill(AspectFoo.class, urn)).thenReturn(Optional.of(foo));
     String[] aspectNames = new String[]{ModelUtils.getAspectName(AspectFoo.class)};
 
-    String[] backfilledAspects = runAndWait(_resource.backfill(urn.toString(), aspectNames));
+    BackfillResult backfillResult = runAndWait(_resource.backfill(urn.toString(), aspectNames));
 
-    assertEquals(ImmutableSet.copyOf(backfilledAspects), ImmutableSet.of(ModelUtils.getAspectName(AspectFoo.class)));
+    assertEquals(backfillResult.getEntities().size(), 1);
+
+    BackfillResultEntity backfillResultEntity = backfillResult.getEntities().get(0);
+    assertEquals(backfillResultEntity.getUrn(), urn);
+    assertEquals(backfillResultEntity.getAspects().size(), 1);
+    assertEquals(backfillResultEntity.getAspects().get(0), ModelUtils.getAspectName(AspectFoo.class));
   }
 
   @Test
@@ -328,9 +334,14 @@ public class BaseEntityResourceTest extends BaseEngineTest {
     when(_mockLocalDAO.backfill(AspectFoo.class, urn)).thenReturn(Optional.of(foo));
     when(_mockLocalDAO.backfill(AspectBar.class, urn)).thenReturn(Optional.of(bar));
 
-    String[] backfilledAspects = runAndWait(_resource.backfill(urn.toString(), null));
+    BackfillResult backfillResult = runAndWait(_resource.backfill(urn.toString(), null));
 
-    assertEquals(ImmutableSet.copyOf(backfilledAspects),
+    assertEquals(backfillResult.getEntities().size(), 1);
+
+    BackfillResultEntity backfillResultEntity = backfillResult.getEntities().get(0);
+    assertEquals(backfillResultEntity.getUrn(), urn);
+    assertEquals(backfillResultEntity.getAspects().size(), 2);
+    assertEquals(ImmutableSet.copyOf(backfillResultEntity.getAspects()),
         ImmutableSet.of(ModelUtils.getAspectName(AspectFoo.class), ModelUtils.getAspectName(AspectBar.class)));
   }
 
@@ -350,12 +361,58 @@ public class BaseEntityResourceTest extends BaseEngineTest {
   public void testBatchBackfill() {
     Urn urn1 = makeUrn(1);
     Urn urn2 = makeUrn(2);
+    AspectFoo foo1 = new AspectFoo().setValue("foo1");
+    AspectBar bar1 = new AspectBar().setValue("bar1");
+    AspectBar bar2 = new AspectBar().setValue("bar2");
+    String[] aspects = new String[] {"com.linkedin.testing.AspectFoo", "com.linkedin.testing.AspectBar"};
+    when(_mockLocalDAO.backfill(_resource.parseAspectsParam(aspects), ImmutableSet.of(urn1, urn2)))
+            .thenReturn(ImmutableMap.of(urn1, ImmutableMap.of(AspectFoo.class, Optional.of(foo1), AspectBar.class, Optional.of(bar1)),
+                    urn2, ImmutableMap.of(AspectBar.class, Optional.of(bar2))));
 
-    runAndWait(_resource.batchBackfill(new String[]{urn1.toString(), urn2.toString()},
-        new String[] {"com.linkedin.testing.AspectFoo", "com.linkedin.testing.AspectBar"}));
+    BackfillResult backfillResult = runAndWait(_resource.backfill(new String[]{urn1.toString(), urn2.toString()}, aspects));
+    assertEquals(backfillResult.getEntities().size(), 2);
 
-    verify(_mockLocalDAO, times(1))
-        .backfill(ImmutableSet.of(AspectFoo.class, AspectBar.class), ImmutableSet.of(urn1, urn2));
+    // Test first entity
+    BackfillResultEntity backfillResultEntity = backfillResult.getEntities().get(0);
+    assertEquals(backfillResultEntity.getUrn(), urn1);
+    assertEquals(backfillResultEntity.getAspects().size(), 2);
+    assertTrue(backfillResultEntity.getAspects().contains("com.linkedin.testing.AspectFoo"));
+    assertTrue(backfillResultEntity.getAspects().contains("com.linkedin.testing.AspectBar"));
+
+    // Test second entity
+    backfillResultEntity = backfillResult.getEntities().get(1);
+    assertEquals(backfillResultEntity.getUrn(), urn2);
+    assertEquals(backfillResultEntity.getAspects().size(), 1);
+    assertTrue(backfillResultEntity.getAspects().contains("com.linkedin.testing.AspectBar"));
+  }
+
+  @Test
+  public void testBackfillUsingSCSI() {
+    Urn urn1 = makeUrn(1);
+    Urn urn2 = makeUrn(2);
+    AspectFoo foo1 = new AspectFoo().setValue("foo1");
+    AspectBar bar1 = new AspectBar().setValue("bar1");
+    AspectBar bar2 = new AspectBar().setValue("bar2");
+    String[] aspects = new String[] {"com.linkedin.testing.AspectFoo", "com.linkedin.testing.AspectBar"};
+    when(_mockLocalDAO.backfill(BackfillMode.BACKFILL_ALL, _resource.parseAspectsParam(aspects), Urn.class, null, 10))
+            .thenReturn(ImmutableMap.of(urn1, ImmutableMap.of(AspectFoo.class, Optional.of(foo1), AspectBar.class, Optional.of(bar1)),
+                    urn2, ImmutableMap.of(AspectBar.class, Optional.of(bar2))));
+
+    BackfillResult backfillResult = runAndWait(_resource.backfill(BackfillMode.BACKFILL_ALL, aspects, null, 10));
+    assertEquals(backfillResult.getEntities().size(), 2);
+
+    // Test first entity
+    BackfillResultEntity backfillResultEntity = backfillResult.getEntities().get(0);
+    assertEquals(backfillResultEntity.getUrn(), urn1);
+    assertEquals(backfillResultEntity.getAspects().size(), 2);
+    assertTrue(backfillResultEntity.getAspects().contains("com.linkedin.testing.AspectFoo"));
+    assertTrue(backfillResultEntity.getAspects().contains("com.linkedin.testing.AspectBar"));
+
+    // Test second entity
+    backfillResultEntity = backfillResult.getEntities().get(1);
+    assertEquals(backfillResultEntity.getUrn(), urn2);
+    assertEquals(backfillResultEntity.getAspects().size(), 1);
+    assertTrue(backfillResultEntity.getAspects().contains("com.linkedin.testing.AspectBar"));
   }
 
   @Test

--- a/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/TestUtils.java
+++ b/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/TestUtils.java
@@ -81,7 +81,7 @@ public class TestUtils {
   }
 
   /**
-   * Returns all test entity classes
+   * Returns all test entity classes.
    */
   @Nonnull
   public static Set<Class<? extends RecordTemplate>> getAllTestEntities() {
@@ -95,7 +95,7 @@ public class TestUtils {
   }
 
   /**
-   * Returns all test relationship classes
+   * Returns all test relationship classes.
    */
   @Nonnull
   public static Set<Class<? extends RecordTemplate>> getAllTestRelationships() {

--- a/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/urn/BarUrn.java
+++ b/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/urn/BarUrn.java
@@ -29,4 +29,14 @@ public final class BarUrn extends Urn {
   public int hashCode() {
     return super.hashCode();
   }
+
+  public static BarUrn createFromString(String rawUrn) throws URISyntaxException {
+    final Urn urn = Urn.createFromString(rawUrn);
+
+    if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Can't cast Urn to BarUrn, not same ENTITY");
+    }
+
+    return new BarUrn(urn.getIdAsInt());
+  }
 }

--- a/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/urn/BazUrn.java
+++ b/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/urn/BazUrn.java
@@ -29,4 +29,14 @@ public final class BazUrn extends Urn {
   public int hashCode() {
     return super.hashCode();
   }
+
+  public static BazUrn createFromString(String rawUrn) throws URISyntaxException {
+    final Urn urn = Urn.createFromString(rawUrn);
+
+    if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Can't cast Urn to BazUrn, not same ENTITY");
+    }
+
+    return new BazUrn(urn.getIdAsInt());
+  }
 }

--- a/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/urn/FooUrn.java
+++ b/metadata-testing/metadata-test-models/src/main/java/com/linkedin/testing/urn/FooUrn.java
@@ -29,4 +29,14 @@ public final class FooUrn extends Urn {
   public int hashCode() {
     return super.hashCode();
   }
+
+  public static FooUrn createFromString(String rawUrn) throws URISyntaxException {
+    final Urn urn = Urn.createFromString(rawUrn);
+
+    if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Can't cast Urn to FooUrn, not same ENTITY");
+    }
+
+    return new FooUrn(urn.getIdAsInt());
+  }
 }

--- a/metadata-testing/metadata-test-models/src/main/pegasus/com/linkedin/testing/EntityUnion.pdl
+++ b/metadata-testing/metadata-test-models/src/main/pegasus/com/linkedin/testing/EntityUnion.pdl
@@ -1,0 +1,6 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit testing
+ */
+typeref EntityUnion = union[EntityFoo, EntityBar]

--- a/metadata-testing/metadata-test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
+++ b/metadata-testing/metadata-test-models/src/main/pegasus/com/linkedin/testing/MixedRecord.pdl
@@ -1,0 +1,62 @@
+namespace com.linkedin.testing
+
+/**
+ * For unit tests
+ */
+record MixedRecord {
+
+  /**
+   * For unit tests
+   */
+  value: optional string
+
+  /**
+   * For unit tests
+   */
+  flag: optional boolean
+
+  /**
+   * For unit tests
+   */
+  defaultField: string = "defaultVal"
+
+  /**
+   * For unit tests
+   */
+  recordField: optional AspectFoo
+
+  /**
+   * For unit tests
+   */
+  nestedRecordField: optional EntityValue
+
+  /**
+   * For unit tests
+   */
+  stringArray: optional array[string]
+
+  /**
+   * For unit tests
+   */
+  recordArray: optional array[AspectFoo]
+
+  /**
+   * For unit tests
+   */
+  nestedRecordArray: optional array[EntityValue]
+
+  /**
+   * For unit tests
+   */
+  fooUrn: optional FooUrn
+
+  /**
+   * For unit tests
+   */
+  intTypeRef: optional typeref IntRef = int
+
+  /**
+   * For unit tests
+   */
+  recordTypeRef: optional typeref AspectFooTypeRef = AspectFoo
+}

--- a/metadata-validators/src/main/java/com/linkedin/metadata/validator/AspectValidator.java
+++ b/metadata-validators/src/main/java/com/linkedin/metadata/validator/AspectValidator.java
@@ -9,7 +9,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 
-public class AspectValidator {
+/**
+ * Utility class to validate aspects are part of the union schemas.
+ */
+public final class AspectValidator {
 
   // A cache of validated classes
   private static final Set<Class<? extends UnionTemplate>> VALIDATED = ConcurrentHashMap.newKeySet();

--- a/metadata-validators/src/main/java/com/linkedin/metadata/validator/DeltaValidator.java
+++ b/metadata-validators/src/main/java/com/linkedin/metadata/validator/DeltaValidator.java
@@ -8,7 +8,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 
-public class DeltaValidator {
+/**
+ * Utility class to validate delta event schemas.
+ */
+public final class DeltaValidator {
 
   // A cache of validated classes
   private static final Set<Class<? extends RecordTemplate>> VALIDATED = ConcurrentHashMap.newKeySet();

--- a/metadata-validators/src/main/java/com/linkedin/metadata/validator/DocumentValidator.java
+++ b/metadata-validators/src/main/java/com/linkedin/metadata/validator/DocumentValidator.java
@@ -9,7 +9,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 
-public class DocumentValidator {
+/**
+ * Utility class to validate search document schemas.
+ */
+public final class DocumentValidator {
 
   // Allowed non-optional fields. All other fields must be optional.
   private static final Set<String> NON_OPTIONAL_FIELDS = Collections.unmodifiableSet(new HashSet<String>() {

--- a/metadata-validators/src/main/java/com/linkedin/metadata/validator/EntityValidator.java
+++ b/metadata-validators/src/main/java/com/linkedin/metadata/validator/EntityValidator.java
@@ -1,7 +1,9 @@
 package com.linkedin.metadata.validator;
 
 import com.linkedin.data.schema.RecordDataSchema;
+import com.linkedin.data.schema.UnionDataSchema;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.data.template.UnionTemplate;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -9,7 +11,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 
-public class EntityValidator {
+/**
+ * Utility class to validate entity schemas.
+ */
+public final class EntityValidator {
 
   // Allowed non-optional fields. All other fields must be optional.
   private static final Set<String> NON_OPTIONAL_FIELDS = Collections.unmodifiableSet(new HashSet<String>() {
@@ -20,6 +25,10 @@ public class EntityValidator {
 
   // A cache of validated classes
   private static final Set<Class<? extends RecordTemplate>> VALIDATED = ConcurrentHashMap.newKeySet();
+
+  // A cache of validated classes
+  private static final Set<Class<? extends UnionTemplate>> UNION_VALIDATED = ConcurrentHashMap.newKeySet();
+
 
   private EntityValidator() {
     // Util class
@@ -61,7 +70,32 @@ public class EntityValidator {
   }
 
   /**
-   * Checks if an entity schema is valid
+   * Similar to {@link #validateEntityUnionSchema(UnionDataSchema, String)} but take a {@link Class} instead and caches
+   * results.
+   */
+  public static void validateEntityUnionSchema(@Nonnull Class<? extends UnionTemplate> clazz) {
+    if (UNION_VALIDATED.contains(clazz)) {
+      return;
+    }
+
+    validateEntityUnionSchema(ValidationUtils.getUnionSchema(clazz), clazz.getCanonicalName());
+    UNION_VALIDATED.add(clazz);
+  }
+
+  /**
+   * Validates the union of entity model defined in com.linkedin.metadata.entity.
+   *
+   * @param schema schema for the model
+   */
+  public static void validateEntityUnionSchema(@Nonnull UnionDataSchema schema, @Nonnull String entityClassName) {
+
+    if (!ValidationUtils.isUnionWithOnlyComplexMembers(schema)) {
+      ValidationUtils.invalidSchema("Entity '%s' must be a union containing only record type members", entityClassName);
+    }
+  }
+
+  /**
+   * Checks if an entity schema is valid.
    */
   public static boolean isValidEntitySchema(@Nonnull Class<? extends RecordTemplate> clazz) {
     if (!VALIDATED.contains(clazz)) {

--- a/metadata-validators/src/main/java/com/linkedin/metadata/validator/SnapshotValidator.java
+++ b/metadata-validators/src/main/java/com/linkedin/metadata/validator/SnapshotValidator.java
@@ -56,9 +56,9 @@ public class SnapshotValidator {
   }
 
   /**
-   * Validates that the URN class is unique across all snapshots
+   * Validates that the URN class is unique across all snapshots.
    *
-   * @param classes a collection of snapshot classes.
+   * @param snapshotClasses a collection of snapshot classes.
    */
   public static void validateUniqueUrn(@Nonnull Collection<? extends Class> snapshotClasses) {
     Set<Class> urnClasses = new HashSet<>();

--- a/metadata-validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
+++ b/metadata-validators/src/main/java/com/linkedin/metadata/validator/ValidationUtils.java
@@ -18,7 +18,10 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 
-public class ValidationUtils {
+/**
+ * Utility class for schema validation classes.
+ */
+public final class ValidationUtils {
 
   public static final Set<DataSchema.Type> PRIMITIVE_TYPES =
       Collections.unmodifiableSet(new HashSet<DataSchema.Type>() {
@@ -90,7 +93,7 @@ public class ValidationUtils {
   }
 
   /**
-   * Returns the Java class for an URN typeref field
+   * Returns the Java class for an URN typeref field.
    */
   public static Class getUrnClass(@Nonnull RecordDataSchema.Field field) {
     try {
@@ -108,7 +111,7 @@ public class ValidationUtils {
   }
 
   /**
-   * Returns all the non-whitelisted, non-optional fields in a {@link RecordDataSchema}
+   * Returns all the non-whitelisted, non-optional fields in a {@link RecordDataSchema}.
    */
   @Nonnull
   public static List<RecordDataSchema.Field> nonOptionalFields(@Nonnull RecordDataSchema schema,
@@ -124,7 +127,7 @@ public class ValidationUtils {
   }
 
   /**
-   * Returns all the non-whitelisted, optional fields in a {@link RecordDataSchema}
+   * Returns all the non-whitelisted, optional fields in a {@link RecordDataSchema}.
    */
   @Nonnull
   public static List<RecordDataSchema.Field> optionalFields(@Nonnull RecordDataSchema schema,


### PR DESCRIPTION
metadata-models 93.0.13 -> 94.0.0:

    93.0.10: Implementing a truly free-form query interface on Neo4j query DAO
    93.0.5: Update backfill API to allow for backfill modes
    93.0.3: [scsi] add resilience to EbeanLocalDAO
    93.0.2: add new entity union and validation
    93.0.1: change listUrns to return typed urns
    92.0.3: META-12819: Free form API for getPaths
    92.0.2: [scsi] support for  multiple filters
    92.0.1: generate data template for BackfillResult
    91.0.1: save aspect fields to index table
    91.0.0: Implement backfill API which uses SCSI
    90.0.18: [metadata-models] support range filter for ESSearchDAO
    90.0.16: add method to obtain field values from RecordTemplate


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
