### PR TITLE
Allow configuration of schema registry basic auth in gms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,9 @@ project.ext.externalDependency = [
     'jerseyGuava': 'org.glassfish.jersey.bundles.repackaged:jersey-guava:2.25.1',
     'jsonSimple': 'com.googlecode.json-simple:json-simple:1.1.1',
     'junit': 'junit:junit:4.12',
+    // avro-serde includes dependencies for `kafka-avro-serializer` `kafka-schema-registry-client` and `avro`
     'kafkaAvroSerde': 'io.confluent:kafka-streams-avro-serde:5.2.2',
     'kafkaClients': 'org.apache.kafka:kafka-clients:2.3.0',
-    'kafkaSchemaRegistry': 'io.confluent:kafka-schema-registry-client:3.3.1',
-    'kafkaSerializers': 'io.confluent:kafka-avro-serializer:3.3.1',
     'logbackClassic': 'ch.qos.logback:logback-classic:1.2.3',
     'lombok': 'org.projectlombok:lombok:1.18.12',
     'mariadbConnector': 'org.mariadb.jdbc:mariadb-java-client:2.6.0',

--- a/gms/factories/build.gradle
+++ b/gms/factories/build.gradle
@@ -5,7 +5,8 @@ dependencies {
   compile project(':metadata-dao-impl:kafka-producer')
 
   compile externalDependency.elasticSearchRest
-  compile externalDependency.kafkaSerializers
+  compile externalDependency.kafkaClients
+  compile externalDependency.kafkaAvroSerde
   compile externalDependency.lombok
   compile externalDependency.servletApi
   compile externalDependency.springBeans

--- a/metadata-jobs/mae-consumer-job/build.gradle
+++ b/metadata-jobs/mae-consumer-job/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     compile externalDependency.neo4jJavaDriver
 
     compile externalDependency.kafkaAvroSerde
-    compile externalDependency.kafkaSerializers
 
     compile (externalDependency.springBootStarterWeb) {
         exclude module: "spring-boot-starter-tomcat"

--- a/metadata-jobs/mce-consumer-job/build.gradle
+++ b/metadata-jobs/mce-consumer-job/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     compile spec.product.pegasus.restliCommon
     compile externalDependency.elasticSearchRest
     compile externalDependency.kafkaAvroSerde
-    compile externalDependency.kafkaSerializers
     compile (externalDependency.springBootStarterWeb) {
         exclude module: "spring-boot-starter-tomcat"
     }


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable) 
Should fix this issue as well, but since I do not have an SSL enabled schema registry I could not verify the fix: https://github.com/linkedin/datahub/issues/1861
- [ ] Tests for the changes have been added/updated (if applicable). Do you all have integration tests? I could update the schema registry container to use basic auth and then write an integration test against that, but otherwise hard to test.
- [ ] Docs related to the changes have been added/updated (if applicable). Not applicable.
