### PR TITLE
build: fix build

### DIFF
--- a/metadata-ingestion-examples/common/build.gradle
+++ b/metadata-ingestion-examples/common/build.gradle
@@ -7,7 +7,6 @@ dependencies {
 
   compile externalDependency.javaxInject
   compile externalDependency.kafkaAvroSerde
-  compile externalDependency.kafkaSerializers
   compile externalDependency.lombok
   compile externalDependency.springBeans
   compile externalDependency.springBootAutoconfigure

--- a/metadata-ingestion-examples/kafka-etl/build.gradle
+++ b/metadata-ingestion-examples/kafka-etl/build.gradle
@@ -12,7 +12,6 @@ dependencies {
 
   compile externalDependency.javaxInject
   compile externalDependency.kafkaAvroSerde
-  compile externalDependency.kafkaSerializers
   compile externalDependency.lombok
   compile externalDependency.springBeans
   compile externalDependency.springBootAutoconfigure


### PR DESCRIPTION
`kafkaSerializers` is already included transitively via `kafkaAvroSerde`



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
