### PR TITLE
fix(frontend): Fixes current user entity not being populated correctly

### DIFF
--- a/datahub-web/@datahub/shared/addon/services/current-user.ts
+++ b/datahub-web/@datahub/shared/addon/services/current-user.ts
@@ -55,7 +55,7 @@ export default class CurrentUser extends Service {
       const userV1: IUser = await currentUserDeprecated();
       const PersonEntityClass = dataModels.getModel(PersonEntity.displayName);
       const urn = PersonEntityClass.urnFromUsername(userV1.userName);
-      const entity = dataModels.createPartialInstance(PersonEntityClass.displayName, { ...userV1, urn });
+      const entity = await dataModels.createInstance(PersonEntityClass.displayName, urn);
 
       set(this, 'entity', entity);
     }


### PR DESCRIPTION
# Summary

Because of differences in the midtier for the current user `/me` api, we created a workaround that doesn't necessarily populate the current user's entity object correctly. This was expected to not have a significant impact on the operation of the application, however it turns out the ownership tab in datasets depends on the logged in user's entity object to validate ownership selections. As such, we went back and looked into how this object is being populated and see that we can simply make a second API call to populate the full information.

# Testing done
```
Locally tested.

Manually tested with docker images to ensure that application builds and behaves as expected for sample data
```

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
