### PR TITLE
fix (docker): Fix install of Chrome in frontend Dockerimage

### DIFF
--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8 as builder
 
 RUN apt-get update && apt-get install -y wget \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install; dpkg -i google-chrome-stable_current_amd64.deb
+    && apt-get -y install ./google-chrome-stable_current_amd64.deb
 
 ENV CI=true
 

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8 as builder
 
 RUN apt-get update && apt-get install -y wget \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-    && dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
+    && dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install; dpkg -i google-chrome-stable_current_amd64.deb
 
 ENV CI=true
 


### PR DESCRIPTION
Chrome is required to run the tests during the building of the frontend. The frontend `Dockerimage` fails to install Chrome properly, as required dependencies are missing initially. This PR makes the fixes the install by installing Chrome and it's dependencies at the same time using `apt-get`.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
