### PR TITLE
Add new spring factories to customize metadata event topic names.

### DIFF
--- a/gms/factories/src/main/java/com/linkedin/common/factory/TopicConventionFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/common/factory/TopicConventionFactory.java
@@ -1,0 +1,34 @@
+package com.linkedin.common.factory;
+
+import com.linkedin.mxe.TopicConvention;
+import com.linkedin.mxe.TopicConventionImpl;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * Creates a {@link TopicConvention} to generate kafka metadata event topic names.
+ *
+ * <p>This allows you to easily override Kafka topic names within your organization.
+ */
+@Configuration
+public class TopicConventionFactory {
+  public static final String TOPIC_CONVENTION_BEAN = "metadataKafkaTopicConvention";
+
+  @Value("${METADATA_CHANGE_EVENT_NAME:" + TopicConventionImpl.DEFAULT_METADATA_CHANGE_EVENT_NAME + "}")
+  private String metadataChangeEventName;
+
+  @Value("${METADATA_AUDIT_EVENT_NAME:" + TopicConventionImpl.DEFAULT_METADATA_AUDIT_EVENT_NAME + "}")
+  private String metadataAuditEventName;
+
+  @Value("${FAILED_METADATA_CHANGE_EVENT_NAME:" + TopicConventionImpl.DEFAULT_FAILED_METADATA_CHANGE_EVENT_NAME + "}")
+  private String failedMetadataChangeEventName;
+
+  @Bean(name = TOPIC_CONVENTION_BEAN)
+  protected TopicConvention createInstance() {
+    return new TopicConventionImpl(metadataChangeEventName, metadataAuditEventName, failedMetadataChangeEventName,
+        // TODO once we start rolling out v5 add support for changing the new event names.
+        TopicConventionImpl.DEFAULT_EVENT_PATTERN);
+  }
+}

--- a/gms/factories/src/main/java/com/linkedin/dataprocess/factory/DataProcessDAOFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/dataprocess/factory/DataProcessDAOFactory.java
@@ -1,11 +1,13 @@
 package com.linkedin.dataprocess.factory;
 
+import com.linkedin.common.factory.TopicConventionFactory;
 import com.linkedin.common.urn.DataProcessUrn;
 import com.linkedin.metadata.aspect.DataProcessAspect;
 import com.linkedin.metadata.dao.EbeanLocalDAO;
 import com.linkedin.metadata.dao.producer.KafkaMetadataEventProducer;
 import com.linkedin.metadata.dao.producer.KafkaProducerCallback;
 import com.linkedin.metadata.snapshot.DataProcessSnapshot;
+import com.linkedin.mxe.TopicConvention;
 import io.ebean.config.ServerConfig;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,11 +25,12 @@ public class DataProcessDAOFactory {
   ApplicationContext applicationContext;
 
   @Bean(name = "dataProcessDAO")
-  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer"})
+  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer", TopicConventionFactory.TOPIC_CONVENTION_BEAN})
   protected EbeanLocalDAO<DataProcessAspect, DataProcessUrn> createInstance() {
     KafkaMetadataEventProducer<DataProcessSnapshot, DataProcessAspect, DataProcessUrn> producer =
         new KafkaMetadataEventProducer(DataProcessSnapshot.class, DataProcessAspect.class,
-            applicationContext.getBean(Producer.class), new KafkaProducerCallback());
+            applicationContext.getBean(Producer.class), applicationContext.getBean(TopicConvention.class),
+            new KafkaProducerCallback());
 
     return new EbeanLocalDAO<>(DataProcessAspect.class, producer, applicationContext.getBean(ServerConfig.class),
         DataProcessUrn.class);

--- a/gms/factories/src/main/java/com/linkedin/dataset/factory/DatasetDaoFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/dataset/factory/DatasetDaoFactory.java
@@ -1,11 +1,13 @@
 package com.linkedin.dataset.factory;
 
+import com.linkedin.common.factory.TopicConventionFactory;
 import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.metadata.aspect.DatasetAspect;
 import com.linkedin.metadata.dao.EbeanLocalDAO;
 import com.linkedin.metadata.dao.producer.KafkaMetadataEventProducer;
 import com.linkedin.metadata.dao.producer.KafkaProducerCallback;
 import com.linkedin.metadata.snapshot.DatasetSnapshot;
+import com.linkedin.mxe.TopicConvention;
 import io.ebean.config.ServerConfig;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,11 +23,12 @@ public class DatasetDaoFactory {
   ApplicationContext applicationContext;
 
   @Bean(name = "datasetDao")
-  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer"})
+  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer", TopicConventionFactory.TOPIC_CONVENTION_BEAN})
   protected EbeanLocalDAO<DatasetAspect, DatasetUrn> createInstance() {
     KafkaMetadataEventProducer<DatasetSnapshot, DatasetAspect, DatasetUrn> producer =
         new KafkaMetadataEventProducer(DatasetSnapshot.class, DatasetAspect.class,
-            applicationContext.getBean(Producer.class), new KafkaProducerCallback());
+            applicationContext.getBean(Producer.class), applicationContext.getBean(TopicConvention.class),
+            new KafkaProducerCallback());
 
     return new EbeanLocalDAO<>(DatasetAspect.class, producer, applicationContext.getBean(ServerConfig.class),
         DatasetUrn.class);

--- a/gms/factories/src/main/java/com/linkedin/identity/factory/CorpGroupDaoFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/identity/factory/CorpGroupDaoFactory.java
@@ -1,10 +1,12 @@
 package com.linkedin.identity.factory;
 
+import com.linkedin.common.factory.TopicConventionFactory;
 import com.linkedin.common.urn.CorpGroupUrn;
 import com.linkedin.metadata.aspect.CorpGroupAspect;
 import com.linkedin.metadata.dao.EbeanLocalDAO;
 import com.linkedin.metadata.dao.producer.KafkaMetadataEventProducer;
 import com.linkedin.metadata.snapshot.CorpGroupSnapshot;
+import com.linkedin.mxe.TopicConvention;
 import io.ebean.config.ServerConfig;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,19 +17,20 @@ import org.springframework.context.annotation.DependsOn;
 
 import javax.annotation.Nonnull;
 
+
 @Configuration
 public class CorpGroupDaoFactory {
-    @Autowired
-    ApplicationContext applicationContext;
+  @Autowired
+  ApplicationContext applicationContext;
 
-    @Bean(name = "corpGroupDao")
-    @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer"})
-    @Nonnull
-    protected EbeanLocalDAO createInstance() {
-        KafkaMetadataEventProducer<CorpGroupSnapshot, CorpGroupAspect, CorpGroupUrn> producer =
-                new KafkaMetadataEventProducer(CorpGroupSnapshot.class, CorpGroupAspect.class,
-                        applicationContext.getBean(Producer.class));
-        return new EbeanLocalDAO<>(CorpGroupAspect.class, producer, applicationContext.getBean(ServerConfig.class),
-            CorpGroupUrn.class);
-    }
+  @Bean(name = "corpGroupDao")
+  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer", TopicConventionFactory.TOPIC_CONVENTION_BEAN})
+  @Nonnull
+  protected EbeanLocalDAO createInstance() {
+    KafkaMetadataEventProducer<CorpGroupSnapshot, CorpGroupAspect, CorpGroupUrn> producer =
+        new KafkaMetadataEventProducer(CorpGroupSnapshot.class, CorpGroupAspect.class,
+            applicationContext.getBean(Producer.class), applicationContext.getBean(TopicConvention.class));
+    return new EbeanLocalDAO<>(CorpGroupAspect.class, producer, applicationContext.getBean(ServerConfig.class),
+        CorpGroupUrn.class);
+  }
 }

--- a/gms/factories/src/main/java/com/linkedin/identity/factory/CorpUserDaoFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/identity/factory/CorpUserDaoFactory.java
@@ -1,10 +1,12 @@
 package com.linkedin.identity.factory;
 
+import com.linkedin.common.factory.TopicConventionFactory;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.metadata.aspect.CorpUserAspect;
 import com.linkedin.metadata.dao.EbeanLocalDAO;
 import com.linkedin.metadata.dao.producer.KafkaMetadataEventProducer;
 import com.linkedin.metadata.snapshot.CorpUserSnapshot;
+import com.linkedin.mxe.TopicConvention;
 import io.ebean.config.ServerConfig;
 import org.apache.kafka.clients.producer.Producer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,12 +24,12 @@ public class CorpUserDaoFactory {
   ApplicationContext applicationContext;
 
   @Bean(name = "corpUserDao")
-  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer"})
+  @DependsOn({"gmsEbeanServiceConfig", "kafkaEventProducer", TopicConventionFactory.TOPIC_CONVENTION_BEAN})
   @Nonnull
   protected EbeanLocalDAO createInstance() {
     KafkaMetadataEventProducer<CorpUserSnapshot, CorpUserAspect, CorpuserUrn> producer =
         new KafkaMetadataEventProducer(CorpUserSnapshot.class, CorpUserAspect.class,
-            applicationContext.getBean(Producer.class));
+            applicationContext.getBean(Producer.class), applicationContext.getBean(TopicConvention.class));
     return new EbeanLocalDAO<>(CorpUserAspect.class, producer, applicationContext.getBean(ServerConfig.class),
         CorpuserUrn.class);
   }

--- a/metadata-ingestion-examples/common/src/main/java/com/linkedin/metadata/examples/configs/TopicConventionFactory.java
+++ b/metadata-ingestion-examples/common/src/main/java/com/linkedin/metadata/examples/configs/TopicConventionFactory.java
@@ -1,0 +1,34 @@
+package com.linkedin.metadata.examples.configs;
+
+import com.linkedin.mxe.TopicConvention;
+import com.linkedin.mxe.TopicConventionImpl;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+/**
+ * Creates a {@link TopicConvention} to generate kafka metadata event topic names.
+ *
+ * <p>This allows you to easily override Kafka topic names within your organization.
+ */
+@Configuration
+public class TopicConventionFactory {
+  public static final String TOPIC_CONVENTION_BEAN = "metadataKafkaTopicConvention";
+
+  @Value("${METADATA_CHANGE_EVENT_NAME:" + TopicConventionImpl.DEFAULT_METADATA_CHANGE_EVENT_NAME + "}")
+  private String metadataChangeEventName;
+
+  @Value("${METADATA_AUDIT_EVENT_NAME:" + TopicConventionImpl.DEFAULT_METADATA_AUDIT_EVENT_NAME + "}")
+  private String metadataAuditEventName;
+
+  @Value("${FAILED_METADATA_CHANGE_EVENT_NAME:" + TopicConventionImpl.DEFAULT_FAILED_METADATA_CHANGE_EVENT_NAME + "}")
+  private String failedMetadataChangeEventName;
+
+  @Bean(name = TOPIC_CONVENTION_BEAN)
+  protected TopicConvention createInstance() {
+    return new TopicConventionImpl(metadataChangeEventName, metadataAuditEventName, failedMetadataChangeEventName,
+        // TODO once we start rolling out v5 add support for changing the new event names.
+        TopicConventionImpl.DEFAULT_EVENT_PATTERN);
+  }
+}


### PR DESCRIPTION
New env vars:

- METADATA_CHANGE_EVENT_NAME: The name of the metadata change event topic.
- METADATA_AUDIT_EVENT_NAME: The name of the metadata audit event topic.
- FAILED_METADATA_CHANGE_EVENT_NAME: The name of the failed metadata change event topic.

This will need to be consistent throughout your ecosystem.

CLOSES: #1840



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
