### PR TITLE
Bump up kafkaAvroSerde to support SSL for Schema Registry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ project.ext.externalDependency = [
     'jsonSimple': 'com.googlecode.json-simple:json-simple:1.1.1',
     'junit': 'junit:junit:4.12',
     // avro-serde includes dependencies for `kafka-avro-serializer` `kafka-schema-registry-client` and `avro`
-    'kafkaAvroSerde': 'io.confluent:kafka-streams-avro-serde:5.2.2',
+    'kafkaAvroSerde': 'io.confluent:kafka-streams-avro-serde:5.5.1',
     'kafkaClients': 'org.apache.kafka:kafka-clients:2.3.0',
     'logbackClassic': 'ch.qos.logback:logback-classic:1.2.3',
     'lombok': 'org.projectlombok:lombok:1.18.12',

--- a/contrib/kubernetes/datahub/README.md
+++ b/contrib/kubernetes/datahub/README.md
@@ -51,3 +51,10 @@ Current chart version is `0.1.0`
 | global.sql.datasource.username | string | `"datahub"` |  |
 | global.sql.datasource.password.secretRef | string | `"mysql-secrets"` |  |
 | global.sql.datasource.password.secretKey | string | `"mysql-password"` |  |
+
+#### Optional Chart Values
+
+| global.credentialsAndCertsSecretPath | string | `"/mnt/certs"` |  |
+| global.credentialsAndCertsSecrets.name | string | `""` |  |
+| global.credentialsAndCertsSecrets.secureEnv | string | `""` |  |
+| global.springKafkaConfigurationOverrides | string | `""` |  |

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
+        {{- if .Values.global.credentialsAndCertsSecrets }}
+        - name: datahub-certs-dir
+          secret:
+            defaultMode: 256
+            secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
+        {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | indent 8 }}
       {{- end }}
@@ -72,10 +78,29 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.global.neo4j.password.secretRef }}"
                   key: "{{ .Values.global.neo4j.password.secretKey }}"
+            {{- if .Values.global.springKafkaConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+              value: {{ $configValue }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.credentialsAndCertsSecrets }}
+            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
+                  key: {{ $envVarValue }}
+            {{- end }}
+            {{- end }}
           {{- if .Values.extraEnvs }}
             {{ toYaml .Values.extraEnvs | indent 10 }}
           {{- end }}
           volumeMounts:
+          {{- if .Values.global.credentialsAndCertsSecrets }}
+            - name: datahub-certs-dir
+              mountPath: {{ .Values.global.credentialsAndCertsSecretPath | default "/mnt/certs" }}
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
+        {{- if .Values.global.credentialsAndCertsSecrets }}
+        - name: datahub-certs-dir
+          secret:
+            defaultMode: 256
+            secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
+        {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | indent 8 }}
       {{- end }}
@@ -55,10 +61,29 @@ spec:
                 secretKeyRef:
                   name: "{{ .Values.global.neo4j.password.secretRef }}"
                   key: "{{ .Values.global.neo4j.password.secretKey }}"
+            {{- if .Values.global.springKafkaConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+              value: {{ $configValue }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.credentialsAndCertsSecrets }}
+            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
+                  key: {{ $envVarValue }}
+            {{- end }}
+            {{- end }}
           {{- if .Values.extraEnvs }}
             {{ toYaml .Values.extraEnvs | indent 10 }}
           {{- end }}
           volumeMounts:
+          {{- if .Values.global.credentialsAndCertsSecrets }}
+            - name: datahub-certs-dir
+              mountPath: {{ .Values.global.credentialsAndCertsSecretPath | default "/mnt/certs" }}
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -26,6 +26,12 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
+        {{- if .Values.global.credentialsAndCertsSecrets }}
+        - name: datahub-certs-dir
+          secret:
+            defaultMode: 256
+            secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
+        {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | indent 8 }}
       {{- end }}
@@ -44,10 +50,29 @@ spec:
               value: {{ printf "%s-%s" .Release.Name "datahub-gms" }}
             - name: GMS_PORT
               value: "{{ .Values.global.datahub.gms.port }}"
+            {{- if .Values.global.springKafkaConfigurationOverrides }}
+            {{- range $configName, $configValue := .Values.global.springKafkaConfigurationOverrides }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $configName | replace "." "_" | upper }}
+              value: {{ $configValue }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.credentialsAndCertsSecrets }}
+            {{- range $envVarName, $envVarValue := .Values.global.credentialsAndCertsSecrets.secureEnv }}
+            - name: SPRING_KAFKA_PROPERTIES_{{ $envVarName | replace "." "_" | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.global.credentialsAndCertsSecrets.name }}
+                  key: {{ $envVarValue }}
+            {{- end }}
+            {{- end }}
           {{- if .Values.extraEnvs }}
             {{ toYaml .Values.extraEnvs | indent 10 }}
           {{- end }}
           volumeMounts:
+          {{- if .Values.global.credentialsAndCertsSecrets }}
+            - name: datahub-certs-dir
+              mountPath: {{ .Values.global.credentialsAndCertsSecretPath | default "/mnt/certs" }}
+          {{- end }}
           {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}

--- a/contrib/kubernetes/datahub/values.yaml
+++ b/contrib/kubernetes/datahub/values.yaml
@@ -67,3 +67,23 @@ global:
         - "mysql"
         - "elasticsearch"
         - "neo4j"
+
+  credentialsAndCertsSecretPath: /mnt/datahub/certs
+  credentialsAndCertsSecrets:
+    name: datahub-certs
+    secureEnv:
+      ssl.key.password: datahub.linkedin.com.KeyPass
+      ssl.keystore.password: datahub.linkedin.com.KeyStorePass
+      ssl.truststore.password: datahub.linkedin.com.TrustStorePass
+      kafkastore.ssl.truststore.password: datahub.linkedin.com.TrustStorePass
+
+  springKafkaConfigurationOverrides:
+    ssl.keystore.location: /mnt/datahub/certs/datahub.linkedin.com.keystore.jks
+    ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
+    kafkastore.ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
+    security.protocol: SSL
+    kafkastore.security.protocol: SSL
+    ssl.keystore.type: JKS
+    ssl.truststore.type: JKS
+    ssl.protocol: TLS
+    ssl.endpoint.identification.algorithm: 

--- a/contrib/kubernetes/datahub/values.yaml
+++ b/contrib/kubernetes/datahub/values.yaml
@@ -68,22 +68,22 @@ global:
         - "elasticsearch"
         - "neo4j"
 
-  credentialsAndCertsSecretPath: /mnt/datahub/certs
-  credentialsAndCertsSecrets:
-    name: datahub-certs
-    secureEnv:
-      ssl.key.password: datahub.linkedin.com.KeyPass
-      ssl.keystore.password: datahub.linkedin.com.KeyStorePass
-      ssl.truststore.password: datahub.linkedin.com.TrustStorePass
-      kafkastore.ssl.truststore.password: datahub.linkedin.com.TrustStorePass
+  # credentialsAndCertsSecretPath: /mnt/datahub/certs
+  # credentialsAndCertsSecrets:
+  #   name: datahub-certs
+  #   secureEnv:
+  #     ssl.key.password: datahub.linkedin.com.KeyPass
+  #     ssl.keystore.password: datahub.linkedin.com.KeyStorePass
+  #     ssl.truststore.password: datahub.linkedin.com.TrustStorePass
+  #     kafkastore.ssl.truststore.password: datahub.linkedin.com.TrustStorePass
 
-  springKafkaConfigurationOverrides:
-    ssl.keystore.location: /mnt/datahub/certs/datahub.linkedin.com.keystore.jks
-    ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
-    kafkastore.ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
-    security.protocol: SSL
-    kafkastore.security.protocol: SSL
-    ssl.keystore.type: JKS
-    ssl.truststore.type: JKS
-    ssl.protocol: TLS
-    ssl.endpoint.identification.algorithm: 
+  # springKafkaConfigurationOverrides:
+  #   ssl.keystore.location: /mnt/datahub/certs/datahub.linkedin.com.keystore.jks
+  #   ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
+  #   kafkastore.ssl.truststore.location: /mnt/datahub/certs/datahub.linkedin.com.truststore.jks
+  #   security.protocol: SSL
+  #   kafkastore.security.protocol: SSL
+  #   ssl.keystore.type: JKS
+  #   ssl.truststore.type: JKS
+  #   ssl.protocol: TLS
+  #   ssl.endpoint.identification.algorithm: 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -119,5 +119,4 @@ Yes. We are using the Spring Boot framework to start our apps, including setting
 
 If Schema Registry is configured to use security (SSL), then you also need to set the following config: https://docs.confluent.io/current/kafka/encryption.html#encryption-ssl-schema-registry.
 
-##### Note! 
-In the logs you might see something like `The configuration 'kafkastore.ssl.truststore.password' was supplied but isn't a known config.` The configuration is not a configuration required for the producer. These WARN message can be safely ignored. Each of Datahub services are passed a full set of configuration but may not require all the configurations that are passed to them. These warn messages indicate that the service was passed a configuration that is not relevant to it and can be safely ignored.
+> **Note** In the logs you might see something like `The configuration 'kafkastore.ssl.truststore.password' was supplied but isn't a known config.` The configuration is not a configuration required for the producer. These WARN message can be safely ignored. Each of Datahub services are passed a full set of configuration but may not require all the configurations that are passed to them. These warn messages indicate that the service was passed a configuration that is not relevant to it and can be safely ignored.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -116,3 +116,6 @@ You can call the [rest.li](https://github.com/linkedin/rest.li) API to ingest me
 ## Does Kafka support SSL? If so, how?
 
 Yes. We are using the Spring Boot framework to start our apps, including setting up Kafka. You can [use environment variables to set system properties](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-relaxed-binding-from-environment-variables), including [Kafka properties](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#integration-properties). From there you can set your SSL configuration for Kafka.
+
+If Schema Registry is configured to use security (SSL), then you also need to set the following config: https://docs.confluent.io/current/kafka/encryption.html#encryption-ssl-schema-registry.
+Note! The logs might say something similar to 'kafkastore.ssl.truststore.password was supplied but isn't a known config', but this is wrong and can be ignored.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,4 +118,6 @@ You can call the [rest.li](https://github.com/linkedin/rest.li) API to ingest me
 Yes. We are using the Spring Boot framework to start our apps, including setting up Kafka. You can [use environment variables to set system properties](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-relaxed-binding-from-environment-variables), including [Kafka properties](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html#integration-properties). From there you can set your SSL configuration for Kafka.
 
 If Schema Registry is configured to use security (SSL), then you also need to set the following config: https://docs.confluent.io/current/kafka/encryption.html#encryption-ssl-schema-registry.
-Note! The logs might say something similar to 'kafkastore.ssl.truststore.password was supplied but isn't a known config', but this is wrong and can be ignored.
+
+##### Note! 
+In the logs you might see something like `The configuration 'kafkastore.ssl.truststore.password' was supplied but isn't a known config.` The configuration is not a configuration required for the producer. These WARN message can be safely ignored. Each of Datahub services are passed a full set of configuration but may not require all the configurations that are passed to them. These warn messages indicate that the service was passed a configuration that is not relevant to it and can be safely ignored.


### PR DESCRIPTION
fix: Support Datahub to connect to Kafka Schema Registry using SSL
Related to: #1861

Test result:

1. Change kafkaAvroSerde to version io.confluent:kafka-streams-avro-serde:5.5.1
2. Rebuilt app 
3. Ran COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -p datahub build
4. Pushed to dockerhub
5. Deployed to our AWS EKS cluster using Helm
6. Verify that Datahub can connect to Confluent Schema Registry using SSL
7. Opened Datahub frontend and confirmed that data was loaded

You should also configure Schema Registry to use security (contrib/kubernetes/datahub/values.yaml):
- kafkastore.security.protocol=SSL
- kafkastore.ssl.truststore.location=/var/ssl/private/kafka.server.truststore.jks
- kafkastore.ssl.truststore.password=test1234

Note! The logs might say something similar to 'kafkastore.ssl.truststore.password was supplied but isn't a known config', but this is wrong and can be ignored.

Added note to docs/FAQ