### PR TITLE
fix(docker): update mae and mce consumer images to include glibc compat

### DIFF
--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -6,6 +6,13 @@ ENV DOCKERIZE_VERSION v0.6.1
 RUN apk --no-cache add curl tar \
     && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
+# Workaround alpine issue with /lib64 not being in the ld library path
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/10140
+ENV LD_LIBRARY_PATH=/lib64
+
+# Add glibc compat layer into alpine linux, needed by java-snappy if kafka topics are compressed with snappy
+RUN apk add libc6-compat
+
 FROM openjdk:8 as prod-build
 COPY . datahub-src
 RUN cd datahub-src && ./gradlew :metadata-jobs:mae-consumer-job:build

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -6,6 +6,13 @@ ENV DOCKERIZE_VERSION v0.6.1
 RUN apk --no-cache add curl tar \
     && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
+# Workaround alpine issue with /lib64 not being in the ld library path
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/10140
+ENV LD_LIBRARY_PATH=/lib64
+
+# Add glibc compat layer into alpine linux, needed by java-snappy if kafka topics are compressed with snappy
+RUN apk add libc6-compat
+
 FROM openjdk:8 as prod-build
 COPY . datahub-src
 RUN cd datahub-src && ./gradlew :metadata-jobs:mce-consumer-job:build


### PR DESCRIPTION
Update mae and mce consumer images to include glibc compat layer. This allows the consumer jobs to deal with snappy compressed kafka topics when running on alpine linux. Otherwise you get errors like this:
```
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.7-bb847a5e-21b5-4d9b-babd-f31afc7109a7-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-1.1.7-bb847a5e-21b5-4d9b-babd-f31afc7109a7-libsnappyjava.so)
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
```

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable). Not applicable.
- [x] Tests for the changes have been added/updated (if applicable). Not applicable.
- [x] Docs related to the changes have been added/updated (if applicable). Not applicable.


An alternative approach is upgrading the snappy-java client library to a higher version that supports a purely java implementation of snappy so there is no dependence on native libraries. See here for more details:
https://github.com/xerial/snappy-java/issues/232#issuecomment-650033369
https://github.com/xerial/snappy-java#using-pure-java-snappy-implementation

That is probably the better option, but I was concerned about some potential backwards incompatible changes in the snappy-java library since it is transitively included by the [avro dependency](https://mvnrepository.com/artifact/org.apache.avro/avro/1.8.1). Wasn't sure of a great way to test it.
