### PR TITLE
feat(frontend): Adds UI support for custom dataset properties

### DIFF
--- a/datahub-web/@datahub/data-models/addon/constants/entity/dataset/tab-properties/all.ts
+++ b/datahub-web/@datahub/data-models/addon/constants/entity/dataset/tab-properties/all.ts
@@ -1,0 +1,59 @@
+import { CommonTabProperties } from '@datahub/data-models/constants/entity/shared/tabs';
+import { ITabProperties } from '@datahub/data-models/types/entity/rendering/entity-render-props';
+import { DatasetPropertiesTab } from '@datahub/data-models/constants/entity/dataset/tab-properties/properties';
+import { DatasetTab } from '@datahub/data-models/constants/entity/dataset/tabs';
+
+/**
+ * Properties for dataset tabs
+ */
+export const TabProperties: Array<ITabProperties> = [
+  {
+    id: DatasetTab.Schema,
+    title: 'Schema',
+    contentComponent: 'datasets/containers/dataset-schema'
+  },
+  {
+    id: DatasetTab.Status,
+    title: 'Status',
+    contentComponent: 'datasets/containers/dataset-properties'
+  },
+  {
+    id: DatasetTab.Access,
+    title: 'ACL Access',
+    contentComponent: 'jit-acl/containers/jit-acl-access-container',
+    lazyRender: true
+  },
+  {
+    id: DatasetTab.Ownership,
+    title: 'Ownership',
+    contentComponent: 'datasets/containers/dataset-ownership'
+  },
+  {
+    id: DatasetTab.Compliance,
+    title: 'Compliance',
+    contentComponent: 'datasets/containers/compliance-main'
+  },
+  {
+    id: DatasetTab.DatasetGroups,
+    title: 'Dataset Groups',
+    contentComponent: 'datasets/core/containers/dataset-groups',
+    lazyRender: true
+  },
+  /*
+   ** Todo : META-9512 datasets - relationships view is unable to handle big payloads
+   ** Adding lazy render as a workaround, so as to unblock rest of the tabs on the page.
+   */ {
+    id: DatasetTab.Relationships,
+    title: 'Relationships',
+    contentComponent: 'datasets/dataset-relationships',
+    lazyRender: true
+  },
+  {
+    id: DatasetTab.Health,
+    title: 'Health',
+    contentComponent: 'health/entity-detail',
+    lazyRender: true
+  },
+  DatasetPropertiesTab,
+  ...CommonTabProperties
+];

--- a/datahub-web/@datahub/data-models/addon/constants/entity/dataset/tab-properties/properties.ts
+++ b/datahub-web/@datahub/data-models/addon/constants/entity/dataset/tab-properties/properties.ts
@@ -1,0 +1,34 @@
+import { ITabProperties } from '@datahub/data-models/types/entity/rendering/entity-render-props';
+import { DatasetTab } from '@datahub/data-models/constants/entity/dataset/tabs';
+import { INachoTableConfigs } from '@nacho-ui/table/types/nacho-table';
+import { DatasetEntity } from '@datahub/data-models/entity/dataset/dataset-entity';
+
+/**
+ * Configurations for the render props for the nacho table dynamic component
+ */
+const tableConfigs: INachoTableConfigs<DatasetEntity> = {
+  labels: ['label', 'value']
+};
+
+/**
+ * Properties for the dataset custom properties tab.
+ */
+export const DatasetPropertiesTab: ITabProperties = {
+  id: DatasetTab.Properties,
+  title: 'Properties',
+  contentComponent: {
+    name: 'entity-page/entity-page-content/content-panel',
+    options: {
+      title: 'Dataset Properties',
+      contentComponent: {
+        // name of the component
+        name: 'entity-page/entity-page-content/nacho-table',
+        options: {
+          propertyName: 'customDatasetProperties',
+          emptyStateMessage: 'We could not find properties for this dataset.',
+          tableConfigs
+        }
+      }
+    }
+  }
+};

--- a/datahub-web/@datahub/data-models/addon/constants/entity/dataset/tabs.ts
+++ b/datahub-web/@datahub/data-models/addon/constants/entity/dataset/tabs.ts
@@ -1,12 +1,10 @@
-import { CommonTabProperties } from '@datahub/data-models/constants/entity/shared/tabs';
-import { ITabProperties } from '@datahub/data-models/types/entity/rendering/entity-render-props';
-
 /**
  * Lists the dataset tabs available
  * @export
  * @enum {string}
  */
 export enum DatasetTab {
+  Status = 'status',
   Properties = 'properties',
   Access = 'access',
   Schema = 'schema',
@@ -16,57 +14,3 @@ export enum DatasetTab {
   Health = 'health',
   DatasetGroups = 'datasetgroups'
 }
-
-/**
- * Properties for dataset tabs
- */
-export const TabProperties: Array<ITabProperties> = [
-  {
-    id: DatasetTab.Schema,
-    title: 'Schema',
-    contentComponent: 'datasets/containers/dataset-schema'
-  },
-  {
-    id: DatasetTab.Properties,
-    title: 'Status',
-    contentComponent: 'datasets/containers/dataset-properties'
-  },
-  {
-    id: DatasetTab.Access,
-    title: 'ACL Access',
-    contentComponent: 'jit-acl/containers/jit-acl-access-container',
-    lazyRender: true
-  },
-  {
-    id: DatasetTab.Ownership,
-    title: 'Ownership',
-    contentComponent: 'datasets/containers/dataset-ownership'
-  },
-  {
-    id: DatasetTab.Compliance,
-    title: 'Compliance',
-    contentComponent: 'datasets/containers/compliance-main'
-  },
-  {
-    id: DatasetTab.DatasetGroups,
-    title: 'Dataset Groups',
-    contentComponent: 'datasets/core/containers/dataset-groups',
-    lazyRender: true
-  },
-  /*
-   ** Todo : META-9512 datasets - relationships view is unable to handle big payloads
-   ** Adding lazy render as a workaround, so as to unblock rest of the tabs on the page.
-   */ {
-    id: DatasetTab.Relationships,
-    title: 'Relationships',
-    contentComponent: 'datasets/dataset-relationships',
-    lazyRender: true
-  },
-  {
-    id: DatasetTab.Health,
-    title: 'Health',
-    contentComponent: 'health/entity-detail',
-    lazyRender: true
-  },
-  ...CommonTabProperties
-];

--- a/datahub-web/@datahub/data-models/addon/entity/dataset/dataset-entity.ts
+++ b/datahub-web/@datahub/data-models/addon/entity/dataset/dataset-entity.ts
@@ -208,6 +208,28 @@ export class DatasetEntity extends BaseEntity<Com.Linkedin.Dataset.Dataset> {
   healthScore?: number;
 
   /**
+   * For open source support only, creates a reference to the customProperties, which can be found as an aspect of the
+   * dataset entity. This helps to display various properties that may be specific to certain datasets and allows for
+   * flexible display
+   */
+  @oneWay('entity.customProperties')
+  customProperties?: Com.Linkedin.Dataset.DatasetProperties['customProperties'];
+
+  /**
+   * Computes the custom dataset properties as a list of label and values rather than object mapping
+   */
+  @computed('customProperties')
+  get customDatasetProperties(): Array<{ label: string; value: string }> | void {
+    const { customProperties } = this;
+    if (customProperties) {
+      return Object.keys(customProperties).map((key): { label: string; value: string } => ({
+        label: key,
+        value: customProperties[key]
+      }));
+    }
+  }
+
+  /**
    * Platform native type, for example it can be TABLE or VIEW for Hive.
    */
   @reads('entity.platformNativeType')

--- a/datahub-web/@datahub/datasets-core/addon/components/datasets/containers/dataset-main.ts
+++ b/datahub-web/@datahub/datasets-core/addon/components/datasets/containers/dataset-main.ts
@@ -18,9 +18,10 @@ import { isNotFoundApiError } from '@datahub/utils/api/shared';
 import Search from '@datahub/shared/services/search';
 import { ISearchEntityRenderProps } from '@datahub/data-models/types/search/search-entity-render-prop';
 import { IAppConfig, IConfigurator } from '@datahub/shared/types/configurator/configurator';
-import { TabProperties, DatasetTab } from '@datahub/data-models/constants/entity/dataset/tabs';
+import { DatasetTab } from '@datahub/data-models/constants/entity/dataset/tabs';
 import { CommonTabProperties } from '@datahub/data-models/constants/entity/shared/tabs';
 import { ITabProperties } from '@datahub/data-models/types/entity/rendering/entity-render-props';
+import { TabProperties } from '@datahub/data-models/constants/entity/dataset/tab-properties/all';
 
 /**
  * Defines the error properties when there is an error in the container
@@ -237,6 +238,7 @@ export default class DatasetMainContainer extends Component {
     const tabs: Array<string> = [
       DatasetTab.Schema,
       DatasetTab.Properties,
+      DatasetTab.Status,
       DatasetTab.Ownership,
       DatasetTab.Relationships
     ];

--- a/datahub-web/@datahub/metadata-types/types/entity/dataset/dataset-entity.d.ts
+++ b/datahub-web/@datahub/metadata-types/types/entity/dataset/dataset-entity.d.ts
@@ -35,4 +35,6 @@ export interface IDatasetEntity {
   uri: string;
   // The health score for the dataset entity
   healthScore: number;
+  // Open source support only, this property accesses a variety of properties of the dataset that are to be presented
+  customProperties?: Com.Linkedin.Dataset.DatasetProperties['customProperties'];
 }

--- a/datahub-web/packages/data-portal/app/templates/components/datasets/dataset-page.hbs
+++ b/datahub-web/packages/data-portal/app/templates/components/datasets/dataset-page.hbs
@@ -80,28 +80,44 @@
         {{#each container.datasetTabs as |tabComponent|}}
           {{#tabs.tabpanel tabComponent.id}}
             <Nacho::NachoTabCacher @lazyRender={{tabComponent.lazyRender}} @id={{tabComponent.id}} @currentTab={{container.tabSelected}}>
-              {{component
-                tabComponent.contentComponent
-                entity=(readonly container.entity)
-                dataset=(readonly container.entity.legacyDataset)
-                snapshot=(readonly container.entity.snapshot)
-                urn=(readonly container.urn)
-                avatarProperties=container.avatarEntityProps
-                jitAclConfig=container.jitAclConfig
-                currentUsername=@userName
-                wikiLinks=container.wikiLinks
-                datasetName=container.entity.name
-                aclMoreInfoLink=container.wikiLinks.jitAcl
-                notifyPiiStatus=(action container.onNotifyPiiStatus)
-                setOwnershipRuleChange=(action container.setOwnershipRuleChange)
-                requestJitAccess=(hash
+
+              {{!-- We presume here that if we have a tabComponent.contentComponent.name then we are using a
+                    component object and not just a string name identifier
+                --}}
+
+              {{#if tabComponent.contentComponent.name}}
+
+                {{component
+                  tabComponent.contentComponent.name
+                  entity=(readonly container.entity)
+                  options=tabComponent.contentComponent.options
+                }}
+
+              {{else}}
+
+                {{component
+                  tabComponent.contentComponent
+                  entity=(readonly container.entity)
+                  dataset=(readonly container.entity.legacyDataset)
+                  snapshot=(readonly container.entity.snapshot)
+                  urn=(readonly container.urn)
+                  avatarProperties=container.avatarEntityProps
                   jitAclConfig=container.jitAclConfig
-                  requestJitUrns=@requestJitUrns
-                  addRequestJitUrn=(fn @addRequestJitUrn)
-                  removeRequestJitUrn=(fn @removeRequestJitUrn)
-                  resetRequestJitUrns=(fn @resetRequestJitUrns)
-                )
-              }}
+                  currentUsername=@userName
+                  wikiLinks=container.wikiLinks
+                  datasetName=container.entity.name
+                  aclMoreInfoLink=container.wikiLinks.jitAcl
+                  notifyPiiStatus=(action container.onNotifyPiiStatus)
+                  setOwnershipRuleChange=(action container.setOwnershipRuleChange)
+                  requestJitAccess=(hash
+                    jitAclConfig=container.jitAclConfig
+                    requestJitUrns=@requestJitUrns
+                    addRequestJitUrn=(fn @addRequestJitUrn)
+                    removeRequestJitUrn=(fn @removeRequestJitUrn)
+                    resetRequestJitUrns=(fn @resetRequestJitUrns)
+                  )
+                }}
+              {{/if}}
             </Nacho::NachoTabCacher>
           {{/tabs.tabpanel}}
         {{/each}}


### PR DESCRIPTION
This PR is the final piece to address a feature request for custom dataset properties. 

Please reference https://github.com/linkedin/datahub/pull/1881 for how the sample data should look when ingested. The presentation is currently a basic table configured to read key value pairs. 

### Issues Addressed
Fixes https://github.com/linkedin/datahub/issues/1730

### Testing done
Will rely on build to ensure that tests still pass. 

Spun up docker images and ensured that application still built and behaved correctly with the mock data. Reference image below:

<img width="1237" alt="Screen Shot 2020-09-29 at 5 02 21 PM" src="https://user-images.githubusercontent.com/16459843/94629344-4fe98580-0277-11eb-9299-19cf9d1aefcc.png">



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
