### PR TITLE
fix(docker): Run as non-root user in docker

### DIFF
--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -13,7 +13,11 @@ RUN cd datahub-src && ./gradlew :datahub-frontend:dist \
 
 FROM openjdk:8-jre-alpine
 
+RUN addgroup -S datahub && adduser -S datahub -G datahub
+
 COPY --from=builder /datahub-frontend /datahub-frontend/
+RUN chown -R datahub:datahub /datahub-frontend && chmod 755 /datahub-frontend
+USER datahub
 EXPOSE 9001
 
 ENV JAVA_OPTS=" \
@@ -23,5 +27,6 @@ ENV JAVA_OPTS=" \
 	-Dconfig.file=datahub-frontend/conf/application.conf \
 	-Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf \
 	-Dlogback.configurationFile=datahub-frontend/conf/logback.xml \
-	-Dlogback.debug=true"
+	-Dlogback.debug=true \
+	-Dpidfile.path=/datahub-frontend/play.pid"
 CMD ["datahub-frontend/bin/playBinary"]

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -23,6 +23,9 @@ FROM base as dev-install
 
 FROM ${APP_ENV}-install as final
 
+RUN addgroup -S datahub && adduser -S datahub -G datahub
+USER datahub
+
 EXPOSE 8080
 
 CMD /datahub/datahub-gms/scripts/start.sh

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -29,6 +29,9 @@ FROM base as dev-install
 
 FROM ${APP_ENV}-install as final
 
+RUN addgroup -S datahub && adduser -S datahub -G datahub
+USER datahub
+
 EXPOSE 9090
 
 CMD /datahub/datahub-mae-consumer/scripts/start.sh

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -29,6 +29,9 @@ FROM base as dev-install
 
 FROM ${APP_ENV}-install as final
 
+RUN addgroup -S datahub && adduser -S datahub -G datahub
+USER datahub
+
 EXPOSE 9090
 
 CMD /datahub/datahub-mce-consumer/scripts/start.sh


### PR DESCRIPTION
This PR fixes the issue of the services being run as root, which is suboptimal as the code executed in the container can get root access on the host machine. We add a `datahub` user and group in the Docker images, and the services are run using that user.  

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
