### PR TITLE
fix(metadata-ingestion): Fix auditStamp unix timestamp format in sql etl ingestion

### DIFF
--- a/metadata-ingestion/sql-etl/common.py
+++ b/metadata-ingestion/sql-etl/common.py
@@ -45,7 +45,7 @@ def build_dataset_mce(platform, dataset_name, columns):
     """
     Creates MetadataChangeEvent for the dataset.
     """
-    actor, sys_time = "urn:li:corpuser:etl", int(time.time())
+    actor, sys_time = "urn:li:corpuser:etl", int(time.time()) * 1000
 
     fields = []
     for column in columns:


### PR DESCRIPTION
Datahub was expecting this timestamp to be in milliseconds since epoch, not seconds. This change makes the lastModified timestamp render correctly in the UI when it is converted to a datetime string.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable). Not applicable.
- [x] Tests for the changes have been added/updated (if applicable). Not applicable.
- [x] Docs related to the changes have been added/updated (if applicable). Not applicable.