### PR TITLE
[BREAKING] feat: Bump to datahub-gma 0.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.pegasusVersion = '28.3.7'
-  ext.gmaVersion = '0.0.1'
+  ext.gmaVersion = '0.1.0'
 
   apply from: './repositories.gradle'
   buildscript.repositories.addAll(project.repositories)

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataprocess/DataProcesses.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataprocess/DataProcesses.java
@@ -44,7 +44,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 @RestLiCollection(name = "dataProcesses", namespace = "com.linkedin.dataprocess", keyName = "dataprocess")
 public class DataProcesses extends BaseSearchableEntityResource<
     // @formatter:off
-    DataProcessKey,
+    ComplexResourceKey<DataProcessKey, EmptyRecord>,
     DataProcess,
     DataProcessUrn,
     DataProcessSnapshot,
@@ -86,17 +86,19 @@ public class DataProcesses extends BaseSearchableEntityResource<
 
     @Nonnull
     @Override
-    protected DataProcessUrn toUrn(@Nonnull DataProcessKey key) {
-        return new DataProcessUrn(key.getOrchestrator(), key.getName(), key.getOrigin());
+    protected DataProcessUrn toUrn(@Nonnull ComplexResourceKey<DataProcessKey, EmptyRecord> key) {
+        return new DataProcessUrn(key.getKey().getOrchestrator(), key.getKey().getName(), key.getKey().getOrigin());
     }
 
     @Nonnull
     @Override
-    protected DataProcessKey toKey(@Nonnull DataProcessUrn urn) {
-        return new DataProcessKey()
+    protected ComplexResourceKey<DataProcessKey, EmptyRecord> toKey(@Nonnull DataProcessUrn urn) {
+        return new ComplexResourceKey<>(
+            new DataProcessKey()
                 .setOrchestrator(urn.getOrchestrator())
                 .setName(urn.getNameEntity())
-                .setOrigin(urn.getOriginEntity());
+                .setOrigin(urn.getOriginEntity()),
+            new EmptyRecord());
     }
 
     @Nonnull

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataset/Datasets.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataset/Datasets.java
@@ -53,7 +53,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 @RestLiCollection(name = "datasets", namespace = "com.linkedin.dataset", keyName = "dataset")
 public final class Datasets extends BaseBrowsableEntityResource<
     // @formatter:off
-        DatasetKey,
+        ComplexResourceKey<DatasetKey, EmptyRecord>,
         Dataset,
         DatasetUrn,
         DatasetSnapshot,
@@ -103,17 +103,19 @@ public final class Datasets extends BaseBrowsableEntityResource<
 
   @Override
   @Nonnull
-  protected DatasetUrn toUrn(@Nonnull DatasetKey key) {
-    return new DatasetUrn(key.getPlatform(), key.getName(), key.getOrigin());
+  protected DatasetUrn toUrn(@Nonnull ComplexResourceKey<DatasetKey, EmptyRecord> key) {
+    return new DatasetUrn(key.getKey().getPlatform(), key.getKey().getName(), key.getKey().getOrigin());
   }
 
   @Override
   @Nonnull
-  protected DatasetKey toKey(@Nonnull DatasetUrn urn) {
-    return new DatasetKey()
-        .setPlatform(urn.getPlatformEntity())
-        .setName(urn.getDatasetNameEntity())
-        .setOrigin(urn.getOriginEntity());
+  protected ComplexResourceKey<DatasetKey, EmptyRecord> toKey(@Nonnull DatasetUrn urn) {
+    return new ComplexResourceKey<>(
+        new DatasetKey()
+            .setPlatform(urn.getPlatformEntity())
+            .setName(urn.getDatasetNameEntity())
+            .setOrigin(urn.getOriginEntity()),
+        new EmptyRecord());
   }
 
   @Override

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpGroups.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpGroups.java
@@ -44,7 +44,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 @RestLiCollection(name = "corpGroups", namespace = "com.linkedin.identity", keyName = "corpGroup")
 public final class CorpGroups extends BaseSearchableEntityResource<
     // @formatter:off
-    CorpGroupKey,
+    ComplexResourceKey<CorpGroupKey, EmptyRecord>,
     CorpGroup,
     CorpGroupUrn,
     CorpGroupSnapshot,
@@ -84,14 +84,14 @@ public final class CorpGroups extends BaseSearchableEntityResource<
 
   @Override
   @Nonnull
-  protected CorpGroupUrn toUrn(@Nonnull CorpGroupKey corpGroupKey) {
-    return new CorpGroupUrn(corpGroupKey.getName());
+  protected CorpGroupUrn toUrn(@Nonnull ComplexResourceKey<CorpGroupKey, EmptyRecord> corpGroupKey) {
+    return new CorpGroupUrn(corpGroupKey.getKey().getName());
   }
 
   @Override
   @Nonnull
-  protected CorpGroupKey toKey(@Nonnull CorpGroupUrn urn) {
-    return new CorpGroupKey().setName(urn.getGroupNameEntity());
+  protected ComplexResourceKey<CorpGroupKey, EmptyRecord> toKey(@Nonnull CorpGroupUrn urn) {
+    return new ComplexResourceKey<>(new CorpGroupKey().setName(urn.getGroupNameEntity()), new EmptyRecord());
   }
 
   @Override

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpUsers.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/identity/CorpUsers.java
@@ -45,7 +45,7 @@ import static com.linkedin.metadata.restli.RestliConstants.*;
 @RestLiCollection(name = "corpUsers", namespace = "com.linkedin.identity", keyName = "corpUser")
 public final class CorpUsers extends BaseSearchableEntityResource<
     // @formatter:off
-    CorpUserKey,
+    ComplexResourceKey<CorpUserKey, EmptyRecord>,
     CorpUser,
     CorpuserUrn,
     CorpUserSnapshot,
@@ -85,14 +85,14 @@ public final class CorpUsers extends BaseSearchableEntityResource<
 
   @Override
   @Nonnull
-  protected CorpuserUrn toUrn(@Nonnull CorpUserKey key) {
-    return new CorpuserUrn(key.getName());
+  protected CorpuserUrn toUrn(@Nonnull ComplexResourceKey<CorpUserKey, EmptyRecord> key) {
+    return new CorpuserUrn(key.getKey().getName());
   }
 
   @Override
   @Nonnull
-  protected CorpUserKey toKey(@Nonnull CorpuserUrn urn) {
-    return new CorpUserKey().setName(urn.getUsernameEntity());
+  protected ComplexResourceKey<CorpUserKey, EmptyRecord> toKey(@Nonnull CorpuserUrn urn) {
+    return new ComplexResourceKey<>(new CorpUserKey().setName(urn.getUsernameEntity()), new EmptyRecord());
   }
 
   @Override


### PR DESCRIPTION
Main purpose of this change is using the latest version of datahub-gma dependency. There is one [breaking](https://github.com/linkedin/datahub-gma/commit/eca6240d110b0de27dbb8e14768e144500bce7e6) change in that version of the dependency that requires us to change the key types which we use in all of the top level resources. In this diff, all available top level resources are changed to benefit from that.

If any fork of this repo does have its own top level resource on their GMS with a complex key, they need to be changed similarly.

Locally tested by running `./docker/dev.sh` to bring up Docker containers. Then used `./docker/ingestion/ingestion.sh` to ingest some sample data. Did monkey tests on DataHub UI and confirmed no functionality is affected.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
