### PR TITLE
feat(dashboard): Dashboard models update

### DIFF
--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/Chart.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/Chart.pdl
@@ -1,0 +1,32 @@
+namespace com.linkedin.dashboard
+
+import com.linkedin.chart.ChartInfo
+import com.linkedin.chart.ChartQuery
+import com.linkedin.common.Ownership
+import com.linkedin.common.Status
+
+/**
+ * Metadata for a chart
+ */
+record Chart includes ChartKey {
+
+  /**
+   * Basic chart information
+   */
+  info: optional ChartInfo
+
+  /**
+   * Information for the chart query which is used for getting data of the chart
+   */
+  query: optional ChartQuery
+
+  /**
+   * Ownership information for the chart
+   */
+  ownership: optional Ownership
+
+  /**
+   * Status information for the chart such as removed or not
+   */
+  status: optional Status
+}

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/ChartKey.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/ChartKey.pdl
@@ -1,0 +1,26 @@
+namespace com.linkedin.dashboard
+
+import com.linkedin.common.Url
+
+/**
+ * Key for chart resource
+ */
+record ChartKey {
+  /**
+   * The name of the dashboard tool such as looker, redash etc.
+   */
+  @validate.strlen = {
+    "max" : 20,
+    "min" : 1
+  }
+  tool: string
+
+  /**
+   * URL for the specific chart such as looker.linkedin.com/looks/1234
+   */
+  @validate.strlen = {
+    "max" : 200,
+    "min" : 1
+  }
+  chartUrl: Url
+}

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/ChartKey.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/ChartKey.pdl
@@ -1,6 +1,5 @@
 namespace com.linkedin.dashboard
 
-import com.linkedin.common.Url
 
 /**
  * Key for chart resource
@@ -16,11 +15,11 @@ record ChartKey {
   tool: string
 
   /**
-   * URL for the specific chart such as looker.linkedin.com/looks/1234
+   * Unique id for the chart. This id should be globally unique for a dashboarding tool even when there are multiple deployments of it. As an example, chart URL could be used here for Looker such as 'looker.linkedin.com/looks/1234'
    */
   @validate.strlen = {
     "max" : 200,
     "min" : 1
   }
-  chartUrl: Url
+  chartId: string
 }

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/Dashboard.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/Dashboard.pdl
@@ -1,0 +1,25 @@
+namespace com.linkedin.dashboard
+
+import com.linkedin.common.Ownership
+import com.linkedin.common.Status
+
+/**
+ * Metadata for a dashboard
+ */
+record Dashboard includes DashboardKey {
+
+  /**
+   * Basic dashboard information
+   */
+  info: optional DashboardInfo
+
+  /**
+   * Ownership information for the dashboard
+   */
+  ownership: optional Ownership
+
+  /**
+   * Status information for the dashboard such as removed or not
+   */
+  status: optional Status
+}

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/DashboardKey.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/DashboardKey.pdl
@@ -1,0 +1,26 @@
+namespace com.linkedin.dashboard
+
+import com.linkedin.common.Url
+
+/**
+ * Key for dashboard resource
+ */
+record DashboardKey {
+  /**
+   * The name of the dashboard tool such as looker, redash etc.
+   */
+  @validate.strlen = {
+    "max" : 20,
+    "min" : 1
+  }
+  tool: string
+
+  /**
+   * URL for the specific dashboard such as looker.linkedin.com/dashboards/1234
+   */
+  @validate.strlen = {
+    "max" : 200,
+    "min" : 1
+  }
+  dashboardUrl: Url
+}

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/DashboardKey.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/DashboardKey.pdl
@@ -1,6 +1,5 @@
 namespace com.linkedin.dashboard
 
-import com.linkedin.common.Url
 
 /**
  * Key for dashboard resource
@@ -16,11 +15,11 @@ record DashboardKey {
   tool: string
 
   /**
-   * URL for the specific dashboard such as looker.linkedin.com/dashboards/1234
+   * Unique id for the dashboard. This id should be globally unique for a dashboarding tool even when there are multiple deployments of it. As an example, dashboard URL could be used here for Looker such as 'looker.linkedin.com/dashboards/1234'
    */
   @validate.strlen = {
     "max" : 200,
     "min" : 1
   }
-  dashboardUrl: Url
+  dashboardId: string
 }

--- a/li-utils/src/main/javaPegasus/com/linkedin/common/urn/ChartUrn.java
+++ b/li-utils/src/main/javaPegasus/com/linkedin/common/urn/ChartUrn.java
@@ -11,7 +11,6 @@ public final class ChartUrn extends Urn {
   public static final String ENTITY_TYPE = "chart";
 
   private final String _dashboardTool;
-
   private final String _chartId;
 
   public ChartUrn(String dashboardTool, String chartId) {

--- a/li-utils/src/main/pegasus/com/linkedin/common/ChartUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/ChartUrn.pdl
@@ -25,6 +25,6 @@ namespace com.linkedin.common
     "type" : "string",
     "maxLength" : 200
   }],
-  "maxLength" : 235
+  "maxLength" : 236
 }
 typeref ChartUrn = string

--- a/li-utils/src/main/pegasus/com/linkedin/common/ChartUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/ChartUrn.pdl
@@ -19,12 +19,12 @@ namespace com.linkedin.common
     "type" : "string",
     "maxLength" : 20
   },
-    {
-      "name" : "chartId",
-      "doc" : "Unique id of the chart assigned by the specific dashboard tool",
-      "type" : "string",
-      "maxLength" : 20
-    }],
-  "maxLength" : 36
+  {
+    "name" : "chartUrl",
+    "doc" : "URL for the specific chart such as looker.linkedin.com/looks/1234",
+    "type" : "Url",
+    "maxLength" : 200
+  }],
+  "maxLength" : 235
 }
 typeref ChartUrn = string

--- a/li-utils/src/main/pegasus/com/linkedin/common/ChartUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/ChartUrn.pdl
@@ -20,9 +20,9 @@ namespace com.linkedin.common
     "maxLength" : 20
   },
   {
-    "name" : "chartUrl",
-    "doc" : "URL for the specific chart such as looker.linkedin.com/looks/1234",
-    "type" : "Url",
+    "name" : "chartId",
+    "doc" : "Unique id for the chart. This id should be globally unique for a dashboarding tool even when there are multiple deployments of it. As an example, chart URL could be used here for Looker such as 'looker.linkedin.com/looks/1234'",
+    "type" : "string",
     "maxLength" : 200
   }],
   "maxLength" : 235

--- a/li-utils/src/main/pegasus/com/linkedin/common/DashboardUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/DashboardUrn.pdl
@@ -20,9 +20,9 @@ namespace com.linkedin.common
     "maxLength" : 20
   },
   {
-    "name" : "dashboardUrl",
-    "doc" : "URL for the specific dashboard such as looker.linkedin.com/dashboards/1234",
-    "type" : "Url",
+    "name" : "dashboardId",
+    "doc" : "Unique id for the dashboard. This id should be globally unique for a dashboarding tool even when there are multiple deployments of it. As an example, dashboard URL could be used here for Looker such as 'looker.linkedin.com/dashboards/1234'",
+    "type" : "string",
     "maxLength" : 200
   }],
   "maxLength" : 239

--- a/li-utils/src/main/pegasus/com/linkedin/common/DashboardUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/DashboardUrn.pdl
@@ -25,6 +25,6 @@ namespace com.linkedin.common
     "type" : "string",
     "maxLength" : 200
   }],
-  "maxLength" : 239
+  "maxLength" : 240
 }
 typeref DashboardUrn = string

--- a/li-utils/src/main/pegasus/com/linkedin/common/DashboardUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/DashboardUrn.pdl
@@ -20,11 +20,11 @@ namespace com.linkedin.common
     "maxLength" : 20
   },
   {
-    "name" : "dashboardId",
-    "doc" : "Unique id of the dashboard assigned by the specific dashboard tool",
-    "type" : "string",
-    "maxLength" : 20
+    "name" : "dashboardUrl",
+    "doc" : "URL for the specific dashboard such as looker.linkedin.com/dashboards/1234",
+    "type" : "Url",
+    "maxLength" : 200
   }],
-  "maxLength" : 36
+  "maxLength" : 239
 }
 typeref DashboardUrn = string

--- a/metadata-models/src/main/pegasus/com/linkedin/chart/ChartInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/chart/ChartInfo.pdl
@@ -3,6 +3,7 @@ namespace com.linkedin.chart
 import com.linkedin.common.AccessLevel
 import com.linkedin.common.ChangeAuditStamps
 import com.linkedin.common.Time
+import com.linkedin.common.Url
 
 /**
  * Information about a chart
@@ -23,6 +24,11 @@ record ChartInfo {
    * Captures information about who created/last modified/deleted this chart and when
    */
   lastModified: ChangeAuditStamps
+
+  /**
+   * URL for the chart. This could be used as an external link on DataHub to allow users access/view the chart
+   */
+  chartUrl: Url
 
   /**
    * Data sources for the chart

--- a/metadata-models/src/main/pegasus/com/linkedin/chart/ChartQuery.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/chart/ChartQuery.pdl
@@ -13,16 +13,5 @@ record ChartQuery {
   /**
    * Chart query type
    */
-  type: enum ChartQueryType {
-
-    /**
-     * LookML queries
-     */
-    LOOKML
-
-    /**
-     * SQL type queries
-     */
-    SQL
-  }
+  type: ChartQueryType
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/chart/ChartQueryType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/chart/ChartQueryType.pdl
@@ -1,0 +1,14 @@
+namespace com.linkedin.chart
+
+enum ChartQueryType {
+
+  /**
+   * LookML queries
+   */
+  LOOKML
+
+  /**
+   * SQL type queries
+   */
+  SQL
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/dashboard/DashboardInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dashboard/DashboardInfo.pdl
@@ -4,6 +4,7 @@ import com.linkedin.common.AccessLevel
 import com.linkedin.common.ChangeAuditStamps
 import com.linkedin.common.ChartUrn
 import com.linkedin.common.Time
+import com.linkedin.common.Url
 
 /**
  * Information about a dashboard
@@ -29,6 +30,11 @@ record DashboardInfo {
    * Captures information about who created/last modified/deleted this dashboard and when
    */
   lastModified: ChangeAuditStamps
+
+  /**
+   * URL for the dashboard. This could be used as an external link on DataHub to allow users access/view the dashboard
+   */
+  dashboardUrl: Url
 
   /**
    * Access level for the dashboard

--- a/metadata-models/src/main/pegasus/com/linkedin/dashboard/DashboardInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dashboard/DashboardInfo.pdl
@@ -34,7 +34,7 @@ record DashboardInfo {
   /**
    * URL for the dashboard. This could be used as an external link on DataHub to allow users access/view the dashboard
    */
-  dashboardUrl: Url
+  dashboardUrl: optional Url
 
   /**
    * Access level for the dashboard

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/ChartDocument.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/ChartDocument.pdl
@@ -1,7 +1,9 @@
 namespace com.linkedin.metadata.search
 
+import com.linkedin.chart.ChartQueryType
+import com.linkedin.chart.ChartType
+import com.linkedin.common.AccessLevel
 import com.linkedin.common.ChartUrn
-import com.linkedin.common.DatasetUrn
 
 /**
  * Data model for Chart entity search
@@ -29,14 +31,9 @@ record ChartDocument includes BaseDocument {
   tool: optional string
 
   /**
-   * Input datasets for the chart
-   */
-  inputs: optional array[DatasetUrn]
-
-  /**
    * Chart query type
    */
-  queryType: optional string
+  queryType: optional ChartQueryType
 
   /**
    * LDAP usernames of corp users who are the owners of this chart
@@ -46,10 +43,10 @@ record ChartDocument includes BaseDocument {
   /**
    * Type of the chart
    */
-  type: optional string
+  type: optional ChartType
 
   /**
    * Access level for the chart
    */
-  access: optional string
+  access: optional AccessLevel
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/DashboardDocument.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/DashboardDocument.pdl
@@ -1,6 +1,6 @@
 namespace com.linkedin.metadata.search
 
-import com.linkedin.common.ChartUrn
+import com.linkedin.common.AccessLevel
 import com.linkedin.common.DashboardUrn
 
 /**
@@ -29,11 +29,6 @@ record DashboardDocument includes BaseDocument {
   tool: optional string
 
   /**
-   * Ids of the charts in the dashboard
-   */
-  chartIds: optional array[string]
-
-  /**
    * LDAP usernames of corp users who are the owners of this dashboard
    */
   owners: optional array[string]
@@ -41,5 +36,5 @@ record DashboardDocument includes BaseDocument {
   /**
    * Access level for the dashboard
    */
-  access: optional string
+  access: optional AccessLevel
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/Snapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/Snapshot.pdl
@@ -4,8 +4,10 @@ namespace com.linkedin.metadata.snapshot
  * A union of all supported metadata snapshot types.
  */
 typeref Snapshot = union[
+  ChartSnapshot,
   CorpGroupSnapshot,
   CorpUserSnapshot,
+  DashboardSnapshot,
   DatasetSnapshot,
   DataProcessSnapshot,
   MLModelSnapshot,


### PR DESCRIPTION
Changes in this PR are as below:

- Adding rest.li API models & resource key models
- Make ChartQueryType a separate model instead of an inline model
- Add Chart & Dashboard snapshots to Snapshot.pdl
- Make fields in chart & dashboard search document models strongly typed by using enum models instead of primitive types (we support enums in search document models)
- Remove fields which help to find relationships between dataset-chart-dashboard from search document models because we ideally surface relationships and serve relationship queries through graph not search
- Add `chartUrl` and `dashboardUrl` into chartInfo & dashboardInfo aspects 

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
