### PR TITLE
fix(login): Fix login error when corp user editable information is not present. Fixes #1948

### DIFF
--- a/datahub-dao/src/main/java/com/linkedin/datahub/util/CorpUserUtil.java
+++ b/datahub-dao/src/main/java/com/linkedin/datahub/util/CorpUserUtil.java
@@ -5,9 +5,8 @@ import com.linkedin.datahub.models.table.CompanyUser;
 import com.linkedin.datahub.models.table.User;
 import com.linkedin.datahub.models.table.UserEntity;
 import com.linkedin.identity.CorpUser;
-
-import javax.annotation.Nonnull;
 import java.net.URISyntaxException;
+import javax.annotation.Nonnull;
 
 
 public class CorpUserUtil {
@@ -33,10 +32,14 @@ public class CorpUserUtil {
     @Nonnull
     public static User toCorpUserView(CorpUser corpUser) {
         User user = new User();
-        user.setEmail(corpUser.getInfo().getEmail());
-        user.setName(corpUser.getInfo().getFullName());
         user.setUserName(corpUser.getUsername());
-        user.setPictureLink(corpUser.getEditableInfo().getPictureLink().toString());
+        if (corpUser.hasInfo()) {
+            user.setEmail(corpUser.getInfo().getEmail());
+            user.setName(corpUser.getInfo().getFullName());
+        }
+        if (corpUser.hasEditableInfo()) {
+            user.setPictureLink(corpUser.getEditableInfo().getPictureLink().toString());
+        }
         return user;
     }
 

--- a/datahub-dao/src/main/java/com/linkedin/datahub/util/CorpUserUtil.java
+++ b/datahub-dao/src/main/java/com/linkedin/datahub/util/CorpUserUtil.java
@@ -33,11 +33,11 @@ public class CorpUserUtil {
     public static User toCorpUserView(CorpUser corpUser) {
         User user = new User();
         user.setUserName(corpUser.getUsername());
-        if (corpUser.hasInfo()) {
+        if (corpUser.getInfo() != null) {
             user.setEmail(corpUser.getInfo().getEmail());
             user.setName(corpUser.getInfo().getFullName());
         }
-        if (corpUser.hasEditableInfo()) {
+        if (corpUser.getEditableInfo() != null) {
             user.setPictureLink(corpUser.getEditableInfo().getPictureLink().toString());
         }
         return user;


### PR DESCRIPTION
Check if the aspects are present before extracting the values.

##Testing Done
- Created a test user without corpusereditableinfo
```
curl 'http://localhost:8080/corpUsers?action=ingest' -X POST -H 'X-RestLi-Protocol-Version:2.0.0' --data '{"snapshot": {"aspects": [{"com.linkedin.identity.CorpUserInfo":{"active": true, "displayName": "Bar", "fullName": "Bar", "email": "fbar@linkedin.com"}}], "urn": "urn:li:corpuser:barUser"}}'
```
- login to DataHub as `barUser` works.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
