### PR TITLE
Revert "fix: validate entity type for an urn (#1958)"

### DIFF
--- a/li-utils/src/main/java/com/linkedin/common/urn/AzkabanFlowUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/AzkabanFlowUrn.java
@@ -38,7 +38,6 @@ public final class AzkabanFlowUrn extends Urn {
   }
 
   public static AzkabanFlowUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String content = new Urn(rawUrn).getContent();
     String[] parts = content.substring(1, content.length() - 1).split(",");
     return new AzkabanFlowUrn(parts[0], parts[1], parts[2]);

--- a/li-utils/src/main/java/com/linkedin/common/urn/AzkabanJobUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/AzkabanJobUrn.java
@@ -31,7 +31,6 @@ public final class AzkabanJobUrn extends Urn {
   }
 
   public static AzkabanJobUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String content = new Urn(rawUrn).getContent();
     String flowParts = content.substring(1, content.lastIndexOf(",") + 1);
     String[] parts = content.substring(1, content.length() - 1).split(",");

--- a/li-utils/src/main/java/com/linkedin/common/urn/ChartUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/ChartUrn.java
@@ -31,8 +31,9 @@ public final class ChartUrn extends Urn {
   }
 
   public static ChartUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
-    String[] urnParts = new Urn(rawUrn).getContent().split(",");
+    Urn urn = new Urn(rawUrn);
+    validateUrn(urn, ENTITY_TYPE);
+    String[] urnParts = urn.getContent().split(",");
     return new ChartUrn(urnParts[0], urnParts[1]);
   }
 

--- a/li-utils/src/main/java/com/linkedin/common/urn/CorpGroupUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/CorpGroupUrn.java
@@ -25,13 +25,14 @@ public final class CorpGroupUrn extends Urn {
   }
 
   public static CorpGroupUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String groupName = new Urn(rawUrn).getContent();
     return new CorpGroupUrn(groupName);
   }
 
   public static CorpGroupUrn createFromUrn(Urn urn) throws URISyntaxException {
-    validateUrn(urn, ENTITY_TYPE);
+    if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Can't cast URN to CorpGroupUrn, not same ENTITY");
+    }
 
     Matcher matcher = URN_PATTERN.matcher(urn.toString());
     if (matcher.find()) {

--- a/li-utils/src/main/java/com/linkedin/common/urn/CorpuserUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/CorpuserUrn.java
@@ -26,13 +26,14 @@ public final class CorpuserUrn extends Urn {
   }
 
   public static CorpuserUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String username = new Urn(rawUrn).getContent();
     return new CorpuserUrn(username);
   }
 
   public static CorpuserUrn createFromUrn(Urn urn) throws URISyntaxException {
-    validateUrn(urn, ENTITY_TYPE);
+    if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Can't cast URN to CorpuserUrn, not same ENTITY");
+    }
 
     Matcher matcher = URN_PATTERN.matcher(urn.toString());
     if (matcher.find()) {

--- a/li-utils/src/main/java/com/linkedin/common/urn/DashboardUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/DashboardUrn.java
@@ -31,8 +31,9 @@ public final class DashboardUrn extends Urn {
   }
 
   public static DashboardUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
-    String[] urnParts = new Urn(rawUrn).getContent().split(",");
+    Urn urn = new Urn(rawUrn);
+    validateUrn(urn, ENTITY_TYPE);
+    String[] urnParts = urn.getContent().split(",");
     return new DashboardUrn(urnParts[0], urnParts[1]);
   }
 

--- a/li-utils/src/main/java/com/linkedin/common/urn/DataPlatformUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/DataPlatformUrn.java
@@ -23,7 +23,6 @@ public final class DataPlatformUrn extends Urn {
   }
 
   public static DataPlatformUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String platformName = new Urn(rawUrn).getContent();
     return new DataPlatformUrn(platformName);
   }

--- a/li-utils/src/main/java/com/linkedin/common/urn/DataProcessUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/DataProcessUrn.java
@@ -40,7 +40,6 @@ public class DataProcessUrn extends Urn {
     }
 
     public static DataProcessUrn createFromString(String rawUrn) throws URISyntaxException {
-        validateUrn(rawUrn, ENTITY_TYPE);
         String content = new Urn(rawUrn).getContent();
         String[] parts = content.substring(1, content.length() - 1).split(",");
         return new DataProcessUrn(parts[0], parts[1], toFabricType(parts[2]));

--- a/li-utils/src/main/java/com/linkedin/common/urn/DatasetUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/DatasetUrn.java
@@ -41,7 +41,6 @@ public final class DatasetUrn extends Urn {
   }
 
   public static DatasetUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String content = new Urn(rawUrn).getContent();
     String[] parts = content.substring(1, content.length() - 1).split(",");
     return new DatasetUrn(DataPlatformUrn.createFromString(parts[0]), parts[1], toFabricType(parts[2]));

--- a/li-utils/src/main/java/com/linkedin/common/urn/MLModelUrn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/MLModelUrn.java
@@ -39,7 +39,6 @@ public final class MLModelUrn extends Urn {
   }
 
   public static MLModelUrn createFromString(String rawUrn) throws URISyntaxException {
-    validateUrn(rawUrn, ENTITY_TYPE);
     String content = new Urn(rawUrn).getContent();
     String[] parts = content.substring(1, content.length() - 1).split(",");
     return new MLModelUrn(DataPlatformUrn.createFromString(parts[0]), parts[1], toFabricType(parts[2]));

--- a/li-utils/src/main/java/com/linkedin/common/urn/Urn.java
+++ b/li-utils/src/main/java/com/linkedin/common/urn/Urn.java
@@ -91,12 +91,6 @@ public class Urn {
     return createFromString(rawUrn);
   }
 
-  public static void validateUrn(@Nonnull String rawUrn, @Nonnull String entityType)
-      throws URISyntaxException {
-    final Urn urn = new Urn(rawUrn);
-    validateUrn(urn, entityType);
-  }
-
   public static void validateUrn(@Nonnull Urn urn, @Nonnull String entityType)
       throws URISyntaxException {
     if (!entityType.equals(urn.getEntityType())) {


### PR DESCRIPTION
This change should've been made in datahub-gma instead.

This reverts commit 127d84e3f9bc8b0638df535a594f21d8e34a508b.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
