### PR TITLE
feat: upgrade Neo4j to 4.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       - elasticsearch
 
   neo4j:
-    image: neo4j:3.5.7
+    image: neo4j:4.0.6
     env_file: neo4j/env/docker.env
     hostname: neo4j
     container_name: neo4j

--- a/docker/neo4j/env/docker.env
+++ b/docker/neo4j/env/docker.env
@@ -1,1 +1,3 @@
 NEO4J_AUTH=neo4j/datahub
+NEO4J_dbms_default__database=graph.db
+NEO4J_dbms_allow__upgrade=true

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -13,7 +13,7 @@ c267c287a235        landoop/schema-registry-ui:latest                     "/run.
 4b38899cc29a        confluentinc/cp-schema-registry:5.2.1                 "/etc/confluent/dock…"   10 hours ago        Up 10 hours         0.0.0.0:8081->8081/tcp                                     schema-registry
 37c29781a263        confluentinc/cp-kafka:5.2.1                           "/etc/confluent/dock…"   10 hours ago        Up 10 hours         0.0.0.0:9092->9092/tcp, 0.0.0.0:29092->29092/tcp           broker
 15440d99a510        docker.elastic.co/kibana/kibana:5.6.8                 "/bin/bash /usr/loca…"   10 hours ago        Up 10 hours         0.0.0.0:5601->5601/tcp                                     kibana
-943e60f9b4d0        neo4j:3.5.7                                           "/sbin/tini -g -- /d…"   10 hours ago        Up 10 hours         0.0.0.0:7474->7474/tcp, 7473/tcp, 0.0.0.0:7687->7687/tcp   neo4j
+943e60f9b4d0        neo4j:4.0.6                                           "/sbin/tini -g -- /d…"   10 hours ago        Up 10 hours         0.0.0.0:7474->7474/tcp, 7473/tcp, 0.0.0.0:7687->7687/tcp   neo4j
 6d79b6f02735        confluentinc/cp-zookeeper:5.2.1                       "/etc/confluent/dock…"   10 hours ago        Up 10 hours         2888/tcp, 0.0.0.0:2181->2181/tcp, 3888/tcp                 zookeeper
 491d9f2b2e9e        docker.elastic.co/elasticsearch/elasticsearch:5.6.8   "/bin/bash bin/es-do…"   10 hours ago        Up 10 hours         0.0.0.0:9200->9200/tcp, 9300/tcp                           elasticsearch
 ce14b9758eb3        mysql:5.7


### PR DESCRIPTION
LinkedIn internally migrated to Neo4j 4.0. To better serve OSS, it's better to upgrade Neo4j to 4.0 here as well. The Java clients are already on 4.0 and they are compatible with 3.5 and 4.0. In this change, only Neo4j server is being upgraded from 3.5 to 4.0. If a user already has a Neo4j docker volume with a graph db created with Neo4j 3.5, with this change, that will be auto upgraded to 4.0 without any extra work.

## Tests

### Test1: In-place DB upgrade 3.5 -> 4.0
1. Run ./docker/dev.sh without this diff (Neo4j 3.5 running). 
2. Run ./docker/ingestion/ingestion.sh to ingest sample data.
3. Stopped all containers.
4. Run ./docker/dev.sh with this diff (Neo4j 4.0 running).
5. Did tests using Neo4j browser and also confirmed that relationship tab for datasets (served by graph) is working as expected.

### Test2: 4.0
1. Removed all Docker containers, volumes and networks.
2. Run ./docker/dev.sh with this diff (Neo4j 4.0 running).
3. Run ./docker/ingestion/ingestion.sh to ingest sample data.
4. Did tests using Neo4j browser and also confirmed that relationship tab for datasets (served by graph) is working as expected.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
