### PR TITLE
fix: Add placeholder for logging call parameter

### DIFF
--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
@@ -127,7 +127,7 @@ public class MetadataAuditEventsProcessor {
         String urn = indexBuilderForDoc.getDocumentType().getMethod("getUrn").invoke(doc).toString();
         elasticEvent.setId(URLEncoder.encode(urn.toLowerCase(), "UTF-8"));
       } catch (UnsupportedEncodingException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-        log.error("Failed to encode the urn with error ", e.toString());
+        log.error("Failed to encode the urn with error: {}", e.toString());
         continue;
       }
       elasticEvent.setActionType(ChangeType.UPDATE);


### PR DESCRIPTION
The error message was passed as a parameter for the log call but the lack of the `{}` placeholder was, as a matter of fact, excluding it from the resulting log line.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
