### PR TITLE
feat: enable default restli documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ project.ext.spec = [
             'generator': 'com.linkedin.pegasus:generator:' + pegasusVersion,
             'restliCommon' : 'com.linkedin.pegasus:restli-common:' + pegasusVersion,
             'restliClient' : 'com.linkedin.pegasus:restli-client:' + pegasusVersion,
+            'restliDocgen' : 'com.linkedin.pegasus:restli-docgen:' + pegasusVersion,
             'restliServer' : 'com.linkedin.pegasus:restli-server:' + pegasusVersion,
             'restliSpringBridge': 'com.linkedin.pegasus:restli-spring-bridge:' + pegasusVersion,
         ]

--- a/gms/war/build.gradle
+++ b/gms/war/build.gradle
@@ -11,6 +11,7 @@ dependencies {
   runtime externalDependency.mysqlConnector
   runtime externalDependency.postgresql
 
+  runtime spec.product.pegasus.restliDocgen
   runtime spec.product.pegasus.restliSpringBridge
 }
 

--- a/gms/war/src/main/webapp/WEB-INF/beans.xml
+++ b/gms/war/src/main/webapp/WEB-INF/beans.xml
@@ -10,6 +10,8 @@
     must be instantiated via spring and then passed into rest.li -->
     <bean id="injectResourceFactory" class="com.linkedin.restli.server.spring.SpringInjectResourceFactory" />
 
+    <bean id="defaultDocumentationRequestHandler" class="com.linkedin.restli.docgen.DefaultDocumentationRequestHandler" />
+
     <!--
       In web.xml, HttpRequestHandlerServlet loads this "restliRequestHandler" spring bean as a servlet.  For details, see:
       http://static.springsource.org/spring-framework/docs/3.2.0.RC1/api/org/springframework/web/context/support/HttpRequestHandlerServlet.html
@@ -18,6 +20,7 @@
         <constructor-arg>
             <bean class="com.linkedin.restli.server.RestLiConfig">
                 <property name="resourcePackageNames" value="com.linkedin.metadata.resources" />
+                <property name="documentationRequestHandler" ref="defaultDocumentationRequestHandler" />
             </bean>
         </constructor-arg>
         <constructor-arg ref="injectResourceFactory" />


### PR DESCRIPTION
Fixes https://github.com/linkedin/datahub/issues/1966

Verified that doc page shows at http://localhost:8080/restli/docs

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
