### PR TITLE
Revert "refactor search index builder to store urn parts efficiently …

### DIFF
--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilderTest.java
@@ -39,9 +39,10 @@ public class DataProcessIndexBuilderTest {
         new DataProcessSnapshot().setUrn(dataProcessUrn).setAspects(dataProcessAspectArray);
 
     List<DataProcessDocument> actualDocs = new DataProcessIndexBuilder().getDocumentsToUpdate(dataProcessSnapshot);
-    assertEquals(actualDocs.size(), 2);
+    assertEquals(actualDocs.size(), 1);
+    assertEquals(actualDocs.get(0).getUrn(), dataProcessUrn);
     assertEquals(actualDocs.get(0).getInputs().get(0), inputDatasetUrn);
     assertEquals(actualDocs.get(0).getOutputs().get(0), outputDatasetUrn);
-    assertEquals(actualDocs.get(1).getUrn(), dataProcessUrn);
+
   }
 }

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
@@ -25,16 +25,16 @@ public class DatasetIndexBuilderTest {
     DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetProperties)));
     List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
-    assertEquals(actualDocs.size(), 2);
+    assertEquals(actualDocs.size(), 1);
+    assertEquals(actualDocs.get(0).getUrn(), datasetUrn);
     assertEquals(actualDocs.get(0).getDescription(), "baz");
-    assertEquals(actualDocs.get(1).getUrn(), datasetUrn);
 
     datasetProperties = new DatasetProperties();
     datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetProperties)));
     actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
-    assertEquals(actualDocs.size(), 2);
-    assertNull(actualDocs.get(0).getDescription());
-    assertEquals(actualDocs.get(1).getUrn(), datasetUrn);
+    assertEquals(actualDocs.size(), 1);
+    assertEquals(actualDocs.get(0).getUrn(), datasetUrn);
+    assertEquals(actualDocs.get(0).getDescription(), "");
   }
 }


### PR DESCRIPTION
…(#1937)"

This broke MAE processor because not all documents have urns now.

This reverts commit 5fca512a07cea75480633188e634ba07f49cdb28.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
