### PR TITLE
refactor search index builder to store urn parts efficiently (#1937)

### DIFF
--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilder.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.builders.search;
 
 import com.linkedin.common.Ownership;
-import com.linkedin.common.Status;
 import com.linkedin.common.urn.DataProcessUrn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
@@ -42,7 +41,7 @@ public class DataProcessIndexBuilder extends BaseIndexBuilder<DataProcessDocumen
     @Nonnull
     private DataProcessDocument getDocumentToUpdateFromAspect(@Nonnull DataProcessUrn urn, @Nonnull Ownership ownership) {
         final StringArray owners = BuilderUtils.getCorpUserOwners(ownership);
-        return setUrnDerivedFields(urn)
+        return new DataProcessDocument()
             .setHasOwners(!owners.isEmpty())
             .setOwners(owners);
     }
@@ -50,7 +49,7 @@ public class DataProcessIndexBuilder extends BaseIndexBuilder<DataProcessDocumen
     @Nonnull
     private DataProcessDocument getDocumentToUpdateFromAspect(@Nonnull DataProcessUrn urn,
         @Nonnull DataProcessInfo dataProcessInfo) {
-        DataProcessDocument dataProcessDocument = setUrnDerivedFields(urn);
+        final DataProcessDocument dataProcessDocument = new DataProcessDocument();
         if (dataProcessInfo.getInputs() != null) {
             dataProcessDocument.setInputs(dataProcessInfo.getInputs())
                 .setNumInputDatasets(dataProcessInfo.getInputs().size());
@@ -63,15 +62,9 @@ public class DataProcessIndexBuilder extends BaseIndexBuilder<DataProcessDocumen
     }
 
     @Nonnull
-    private DataProcessDocument getDocumentToUpdateFromAspect(@Nonnull DataProcessUrn urn, @Nonnull Status status) {
-        return setUrnDerivedFields(urn)
-            .setRemoved(status.isRemoved());
-    }
-
-    @Nonnull
     private List<DataProcessDocument> getDocumentsToUpdateFromSnapshotType(@Nonnull DataProcessSnapshot dataProcessSnapshot) {
-        DataProcessUrn urn = dataProcessSnapshot.getUrn();
-        return dataProcessSnapshot.getAspects().stream().map(aspect -> {
+        final DataProcessUrn urn = dataProcessSnapshot.getUrn();
+        final List<DataProcessDocument> documents = dataProcessSnapshot.getAspects().stream().map(aspect -> {
             if (aspect.isDataProcessInfo()) {
                 return getDocumentToUpdateFromAspect(urn, aspect.getDataProcessInfo());
             } else if (aspect.isOwnership()) {
@@ -79,6 +72,8 @@ public class DataProcessIndexBuilder extends BaseIndexBuilder<DataProcessDocumen
             }
             return null;
         }).filter(Objects::nonNull).collect(Collectors.toList());
+        documents.add(setUrnDerivedFields(urn));
+        return documents;
     }
 
     @Nullable

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilder.java
@@ -42,6 +42,7 @@ public class DataProcessIndexBuilder extends BaseIndexBuilder<DataProcessDocumen
     private DataProcessDocument getDocumentToUpdateFromAspect(@Nonnull DataProcessUrn urn, @Nonnull Ownership ownership) {
         final StringArray owners = BuilderUtils.getCorpUserOwners(ownership);
         return new DataProcessDocument()
+            .setUrn(urn)
             .setHasOwners(!owners.isEmpty())
             .setOwners(owners);
     }
@@ -49,7 +50,7 @@ public class DataProcessIndexBuilder extends BaseIndexBuilder<DataProcessDocumen
     @Nonnull
     private DataProcessDocument getDocumentToUpdateFromAspect(@Nonnull DataProcessUrn urn,
         @Nonnull DataProcessInfo dataProcessInfo) {
-        final DataProcessDocument dataProcessDocument = new DataProcessDocument();
+        final DataProcessDocument dataProcessDocument = new DataProcessDocument().setUrn(urn);
         if (dataProcessInfo.getInputs() != null) {
             dataProcessDocument.setInputs(dataProcessInfo.getInputs())
                 .setNumInputDatasets(dataProcessInfo.getInputs().size());

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
@@ -52,6 +52,7 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
   private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn, @Nonnull Ownership ownership) {
     final StringArray owners = BuilderUtils.getCorpUserOwners(ownership);
     return new DatasetDocument()
+        .setUrn(urn)
         .setHasOwners(!owners.isEmpty())
         .setOwners(owners);
   }
@@ -59,17 +60,18 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
   @Nonnull
   private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn, @Nonnull Status status) {
     return new DatasetDocument()
+        .setUrn(urn)
         .setRemoved(status.isRemoved());
   }
 
   @Nonnull
   private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn, @Nonnull DatasetDeprecation deprecation) {
-    return new DatasetDocument().setDeprecated(deprecation.isDeprecated());
+    return new DatasetDocument().setUrn(urn).setDeprecated(deprecation.isDeprecated());
   }
 
   @Nonnull
   private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn, @Nonnull DatasetProperties datasetProperties) {
-    final DatasetDocument doc = new DatasetDocument();
+    final DatasetDocument doc = new DatasetDocument().setUrn(urn);
     if (datasetProperties.getDescription() != null) {
       doc.setDescription(datasetProperties.getDescription());
     }
@@ -79,15 +81,18 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
   @Nonnull
   private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn, @Nonnull SchemaMetadata schemaMetadata) {
     return new DatasetDocument()
+        .setUrn(urn)
         .setHasSchema(true);
   }
 
   @Nonnull
-  private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn, @Nonnull UpstreamLineage upstreamLineage) {
-    return new DatasetDocument()
-        .setUpstreams(new DatasetUrnArray(
-            upstreamLineage.getUpstreams().stream().map(upstream -> upstream.getDataset()).collect(Collectors.toList())
-        ));
+  private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn,
+      @Nonnull UpstreamLineage upstreamLineage) {
+    return new DatasetDocument().setUrn(urn)
+        .setUpstreams(new DatasetUrnArray(upstreamLineage.getUpstreams()
+            .stream()
+            .map(upstream -> upstream.getDataset())
+            .collect(Collectors.toList())));
   }
 
   @Nonnull

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilderTest.java
@@ -39,10 +39,9 @@ public class DataProcessIndexBuilderTest {
         new DataProcessSnapshot().setUrn(dataProcessUrn).setAspects(dataProcessAspectArray);
 
     List<DataProcessDocument> actualDocs = new DataProcessIndexBuilder().getDocumentsToUpdate(dataProcessSnapshot);
-    assertEquals(actualDocs.size(), 1);
-    assertEquals(actualDocs.get(0).getUrn(), dataProcessUrn);
+    assertEquals(actualDocs.size(), 2);
     assertEquals(actualDocs.get(0).getInputs().get(0), inputDatasetUrn);
     assertEquals(actualDocs.get(0).getOutputs().get(0), outputDatasetUrn);
-
+    assertEquals(actualDocs.get(1).getUrn(), dataProcessUrn);
   }
 }

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DataProcessIndexBuilderTest.java
@@ -42,6 +42,7 @@ public class DataProcessIndexBuilderTest {
     assertEquals(actualDocs.size(), 2);
     assertEquals(actualDocs.get(0).getInputs().get(0), inputDatasetUrn);
     assertEquals(actualDocs.get(0).getOutputs().get(0), outputDatasetUrn);
+    assertEquals(actualDocs.get(0).getUrn(), dataProcessUrn);
     assertEquals(actualDocs.get(1).getUrn(), dataProcessUrn);
   }
 }

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.testng.Assert.*;
 
 
 public class DatasetIndexBuilderTest {
@@ -42,18 +41,20 @@ public class DatasetIndexBuilderTest {
     final DatasetProperties datasetProperties = new DatasetProperties().setDescription("baz");
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetProperties)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn).setDescription("baz");
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setDescription("baz");
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = _indexBuilder.getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -63,18 +64,20 @@ public class DatasetIndexBuilderTest {
     final DatasetProperties datasetProperties = new DatasetProperties();
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetProperties)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn);
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setDescription("");
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -84,18 +87,20 @@ public class DatasetIndexBuilderTest {
     final DatasetDeprecation datasetDeprecation = new DatasetDeprecation().setDeprecated(true);
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetDeprecation)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn).setDeprecated(true);
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setDeprecated(true);
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -105,18 +110,20 @@ public class DatasetIndexBuilderTest {
     final DatasetDeprecation datasetDeprecation = new DatasetDeprecation().setDeprecated(false);
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, datasetDeprecation)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn).setDeprecated(false);
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setDeprecated(false);
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -129,19 +136,21 @@ public class DatasetIndexBuilderTest {
     final Ownership ownership = new Ownership().setOwners(new OwnerArray(owner));
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, ownership)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 =
+        new DatasetDocument().setUrn(datasetUrn).setHasOwners(true).setOwners(new StringArray("testUser"));
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setHasOwners(true)
-        .setOwners(new StringArray("testUser"));
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -160,19 +169,22 @@ public class DatasetIndexBuilderTest {
     final Ownership ownership = new Ownership().setOwners(new OwnerArray(owner1, owner2, owner3));
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, ownership)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn)
+        .setHasOwners(true)
+        .setOwners(new StringArray("testUser1", "testUser2"));
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setHasOwners(true)
-        .setOwners(new StringArray("testUser1", "testUser2"));
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -182,18 +194,20 @@ public class DatasetIndexBuilderTest {
     final SchemaMetadata schemaMetadata = new SchemaMetadata();
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, schemaMetadata)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn).setHasSchema(true);
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setHasSchema(true);
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -203,18 +217,21 @@ public class DatasetIndexBuilderTest {
     final Status status = new Status().setRemoved(true);
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, status)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn)
+        .setRemoved(true);
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setRemoved(true);
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -224,18 +241,20 @@ public class DatasetIndexBuilderTest {
     final Status status = new Status().setRemoved(false);
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, status)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn).setRemoved(false);
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setRemoved(false);
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 
   @Test
@@ -249,17 +268,20 @@ public class DatasetIndexBuilderTest {
     final UpstreamLineage upstreamLineage = new UpstreamLineage().setUpstreams(new UpstreamArray(upstream1, upstream2));
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, upstreamLineage)));
-    final DatasetDocument expectedDocument = new DatasetDocument().setUrn(datasetUrn)
+    final DatasetDocument expectedDocument1 =
+        new DatasetDocument().setUrn(datasetUrn).setUpstreams(new DatasetUrnArray(upstreamUrn1, upstreamUrn2));
+    final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
         .setName("bar")
-        .setPlatform("foo")
-        .setUpstreams(new DatasetUrnArray(upstreamUrn1, upstreamUrn2));
+        .setPlatform("foo");
 
     // when
     final List<DatasetDocument> actualDocs = new DatasetIndexBuilder().getDocumentsToUpdate(datasetSnapshot);
 
     // then
-    assertThat(actualDocs).containsExactly(expectedDocument);
+    assertThat(actualDocs.size()).isEqualTo(2);
+    assertThat(actualDocs).contains(expectedDocument1);
+    assertThat(actualDocs).contains(expectedDocument2);
   }
 }


### PR DESCRIPTION
Tested the following way
1. Run ./docker/dev.sh with this diff
2. Ingested a new dataset using the following command
`curl 'http://localhost:8080/datasets?action=ingest' -X POST -H 'X-RestLi-Protocol-Version:2.0.0' --data '{"snapshot": {"aspects":[{"com.linkedin.common.Ownership":{"owners":[{"owner":"urn:li:corpuser:fbar","type":"DATAOWNER"}],"lastModified":{"time":0,"actor":"urn:li:corpuser:fbar"}}},{"com.linkedin.dataset.UpstreamLineage":{"upstreams":[{"auditStamp":{"time":0,"actor":"urn:li:corpuser:fbar"},"dataset":"urn:li:dataset:(urn:li:dataPlatform:foo,barUp,PROD)","type":"TRANSFORMED"}]}},{"com.linkedin.common.InstitutionalMemory":{"elements":[{"url":"https://www.linkedin.com","description":"Sample doc","createStamp":{"time":0,"actor":"urn:li:corpuser:fbar"}}]}},{"com.linkedin.schema.SchemaMetadata":{"schemaName":"FooEvent","platform":"urn:li:dataPlatform:foo","version":0,"created":{"time":0,"actor":"urn:li:corpuser:fbar"},"lastModified":{"time":0,"actor":"urn:li:corpuser:fbar"},"hash":"","platformSchema":{"com.linkedin.schema.KafkaSchema":{"documentSchema":"{\"type\":\"record\",\"name\":\"MetadataChangeEvent\",\"namespace\":\"com.linkedin.mxe\",\"doc\":\"Kafka event for proposing a metadata change for an entity.\",\"fields\":[{\"name\":\"auditHeader\",\"type\":{\"type\":\"record\",\"name\":\"KafkaAuditHeader\",\"namespace\":\"com.linkedin.avro2pegasus.events\",\"doc\":\"Header\"}}]}"}},"fields":[{"fieldPath":"foo","description":"Bar","nativeDataType":"string","type":{"type":{"com.linkedin.schema.StringType":{}}}}]}}],"urn":"urn:li:dataset:(urn:li:dataPlatform:foo,mBar,PROD)"}}'`
3. Made sure the dataset is both searchable and browsable.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
