### PR TITLE
feat: upgrade to ES7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.pegasusVersion = '28.3.7'
-  ext.gmaVersion = '0.1.0'
+  ext.gmaVersion = '0.2.13'
 
   apply from: './repositories.gradle'
   buildscript.repositories.addAll(project.repositories)
@@ -37,14 +37,14 @@ project.ext.externalDependency = [
     'commonsLang': 'commons-lang:commons-lang:2.6',
     'ebean': 'io.ebean:ebean:11.33.3',
     'ebeanAgent': 'io.ebean:ebean-agent:11.27.1',
-    'elasticSearchRest': 'org.elasticsearch.client:elasticsearch-rest-high-level-client:5.6.8',
-    'elasticSearchTransport': 'org.elasticsearch.client:transport:5.6.8',
+    'elasticSearchRest': 'org.elasticsearch.client:elasticsearch-rest-high-level-client:7.9.3',
+    'elasticSearchTransport': 'org.elasticsearch.client:transport:7.9.3',
     'findbugsAnnotations': 'com.google.code.findbugs:annotations:3.0.1',
     'gmaCoreModels': "com.linkedin.datahub-gma:core-models-data-template:$gmaVersion",
     'gmaDaoApi': "com.linkedin.datahub-gma:dao-api:$gmaVersion",
     'gmaDaoApiDataTemplate': "com.linkedin.datahub-gma:dao-api-data-template:$gmaVersion",
     'gmaEbeanDao': "com.linkedin.datahub-gma:ebean-dao:$gmaVersion",
-    'gmaElasticsearchDao': "com.linkedin.datahub-gma:elasticsearch-dao:$gmaVersion",
+    'gmaElasticsearchDao': "com.linkedin.datahub-gma:elasticsearch-dao-7:$gmaVersion",
     'gmaNeo4jDao': "com.linkedin.datahub-gma:neo4j-dao:$gmaVersion",
     'gmaRestliResources': "com.linkedin.datahub-gma:restli-resources:$gmaVersion",
     'gmaRestliResourcesDataTemplate': "com.linkedin.datahub-gma:restli-resources-data-template:$gmaVersion",

--- a/docs/advanced/es-7-upgrade.md
+++ b/docs/advanced/es-7-upgrade.md
@@ -6,6 +6,7 @@
 
 
 ### Search query
+The following parameters are/were `optional` and hence automatically populated in the search query. Some tests that expect a certain search query to be sent to ES will change with the ES upgrade.
 - `disable_coord` parameter of the `bool` and `common_terms` queries has been removed (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html))
 - `auto_generate_synonyms_phrase_query` parameter in `match` query is added with a default value of `true` (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/query-dsl-match-query.html))
 

--- a/docs/advanced/es-7-upgrade.md
+++ b/docs/advanced/es-7-upgrade.md
@@ -1,0 +1,14 @@
+# Elasticsearch upgrade from 5.6.8 to 7.9.3: Summary of changes
+
+### Search index mapping & settings
+- Removal of mapping types (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html))
+- Specify the maximum allowed difference between `min_gram` and `max_gram` for NGramTokenizer and NGramTokenFilter by adding property `max_ngram_diff` in index settings, particularly if the difference is greater than 1 (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html))
+
+
+### Search query
+- `disable_coord` parameter of the `bool` and `common_terms` queries has been removed (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html))
+- `auto_generate_synonyms_phrase_query` parameter in `match` query is added with a default value of `true` (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/query-dsl-match-query.html))
+
+### Java High Level Rest Client
+- In 7.9.3, Java High Level Rest Client instance needs a REST low-level client builder to be built. In 5.6.8, the same instance needs REST low-level client
+- Document APIs such as the Index API, Delete API, etc no longer takes the doc `type` as an input

--- a/gms/factories/src/main/java/com/linkedin/gms/factory/common/RestHighLevelClientFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/gms/factory/common/RestHighLevelClientFactory.java
@@ -33,31 +33,30 @@ public class RestHighLevelClientFactory {
   @Nonnull
   protected RestHighLevelClient createInstance() {
     try {
-      RestClient restClient = loadRestHttpClient(
-              elasticSearchHost,
-              elasticSearchPort,
-              elasticSearchThreadCount,
-              elasticSearchConectionRequestTimeout
+      RestClientBuilder restClientBuilder = loadRestHttpClient(
+          elasticSearchHost,
+          elasticSearchPort,
+          elasticSearchThreadCount,
+          elasticSearchConectionRequestTimeout
       );
 
-      return new RestHighLevelClient(restClient);
+      return new RestHighLevelClient(restClientBuilder);
     } catch (Exception e) {
       throw new RuntimeException("Error: RestClient is not properly initialized. " + e.toString());
     }
   }
 
   @Nonnull
-  private static RestClient loadRestHttpClient(@Nonnull String host, int port, int threadCount,
-                                               int connectionRequestTimeout) throws Exception {
+  private static RestClientBuilder loadRestHttpClient(@Nonnull String host, int port, int threadCount,
+      int connectionRequestTimeout) throws Exception {
     RestClientBuilder builder = RestClient.builder(new HttpHost(host, port, "http"))
-            .setHttpClientConfigCallback(httpAsyncClientBuilder ->
-                    httpAsyncClientBuilder.setDefaultIOReactorConfig(IOReactorConfig.custom()
-                            .setIoThreadCount(threadCount).build()));
+        .setHttpClientConfigCallback(httpAsyncClientBuilder ->
+            httpAsyncClientBuilder.setDefaultIOReactorConfig(IOReactorConfig.custom()
+                .setIoThreadCount(threadCount).build()));
 
     builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.
-            setConnectionRequestTimeout(connectionRequestTimeout));
+        setConnectionRequestTimeout(connectionRequestTimeout));
 
-    return builder.build();
+    return builder;
   }
 }
-

--- a/gms/impl/src/test/resources/corpGroupESAutocompleteRequest.json
+++ b/gms/impl/src/test/resources/corpGroupESAutocompleteRequest.json
@@ -7,7 +7,6 @@
   },
   "post_filter" : {
     "bool" : {
-      "disable_coord" : false,
       "adjust_pure_negative" : true,
       "boost" : 1.0
     }

--- a/gms/impl/src/test/resources/corpUserESAutocompleteRequest.json
+++ b/gms/impl/src/test/resources/corpUserESAutocompleteRequest.json
@@ -7,7 +7,6 @@
   },
   "post_filter" : {
     "bool" : {
-      "disable_coord" : false,
       "adjust_pure_negative" : true,
       "boost" : 1.0
     }

--- a/gms/impl/src/test/resources/corpUserESSearchRequest.json
+++ b/gms/impl/src/test/resources/corpUserESSearchRequest.json
@@ -22,18 +22,17 @@
                     "fuzzy_transpositions" : true,
                     "lenient" : false,
                     "zero_terms_query" : "NONE",
+                    "auto_generate_synonyms_phrase_query": true,
                     "boost" : 1.0
                   }
                 }
               }
             ],
-            "disable_coord" : false,
             "adjust_pure_negative" : true,
             "boost" : 1.0
           }
         }
       ],
-      "disable_coord" : false,
       "adjust_pure_negative" : true,
       "boost" : 1.0
     }

--- a/li-utils/src/test/java/com/linkedin/common/urn/DatasetFieldUrnTest.java
+++ b/li-utils/src/test/java/com/linkedin/common/urn/DatasetFieldUrnTest.java
@@ -32,7 +32,7 @@ public class DatasetFieldUrnTest {
   }
 
   @Test
-  public void testCreateUrn() {
+  public void testCreateUrn() throws URISyntaxException {
     final DatasetFieldUrn datasetFieldUrn = new DatasetFieldUrn(PLATFORM, DATASET_NAME, FABRIC_TYPE, FIELD_NAME);
 
     final DatasetUrn datasetUrn = datasetFieldUrn.getDatasetEntity();
@@ -44,7 +44,7 @@ public class DatasetFieldUrnTest {
   }
 
   @Test
-  public void testUrnConstructors() {
+  public void testUrnConstructors() throws URISyntaxException {
     final DatasetFieldUrn datasetFieldUrn1 = new DatasetFieldUrn(PLATFORM, DATASET_NAME, FABRIC_TYPE, FIELD_NAME);
     final DatasetUrn datasetUrn = datasetFieldUrn1.getDatasetEntity();
     final DatasetFieldUrn datasetFieldUrn2 = new DatasetFieldUrn(datasetUrn, FIELD_NAME);

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/MetadataAuditEventsProcessor.java
@@ -38,8 +38,6 @@ import com.linkedin.mxe.Topics;
 @Component
 @EnableKafka
 public class MetadataAuditEventsProcessor {
-  // Doc Type should be updated when ElasticSearch Version is upgraded.
-  private static final String DOC_TYPE = "doc";
 
   private ElasticsearchConnector elasticSearchConnector;
   private SnapshotProcessor snapshotProcessor;
@@ -122,7 +120,6 @@ public class MetadataAuditEventsProcessor {
         continue;
       }
       elasticEvent.setIndex(indexBuilderForDoc.getDocumentType().getSimpleName().toLowerCase());
-      elasticEvent.setType(DOC_TYPE);
       try {
         String urn = indexBuilderForDoc.getDocumentType().getMethod("getUrn").invoke(doc).toString();
         elasticEvent.setId(URLEncoder.encode(urn.toLowerCase(), "UTF-8"));

--- a/metadata-models/src/test/java/com/linkedin/metadata/ModelValidation.java
+++ b/metadata-models/src/test/java/com/linkedin/metadata/ModelValidation.java
@@ -9,6 +9,7 @@ import com.linkedin.metadata.validator.EntityValidator;
 import com.linkedin.metadata.validator.RelationshipValidator;
 import com.linkedin.metadata.validator.SnapshotValidator;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -48,8 +49,12 @@ public class ModelValidation {
     getClassesInPackage("com.linkedin.metadata.snapshot", IGNORED_SNAPSHOT_CLASSES).forEach(
         SnapshotValidator::validateSnapshotSchema);
 
-    SnapshotValidator.validateUniqueUrn(
-        getClassesInPackage("com.linkedin.metadata.snapshot", IGNORED_SNAPSHOT_CLASSES).collect(Collectors.toList()));
+    @SuppressWarnings("unchecked")
+    List<Class<? extends RecordTemplate>> classes =
+        (List<Class<? extends RecordTemplate>>) getClassesInPackage("com.linkedin.metadata.snapshot",
+            IGNORED_SNAPSHOT_CLASSES).collect(Collectors.toList());
+
+    SnapshotValidator.validateUniqueUrn(classes);
   }
 
   @Test
@@ -57,7 +62,7 @@ public class ModelValidation {
     getClassesInPackage("com.linkedin.metadata.delta", IGNORED_DELTA_CLASSES).forEach(DeltaValidator::validateDeltaSchema);
   }
 
-  private Stream<? extends Class> getClassesInPackage(@Nonnull String packageName, @Nonnull Set<Class> ignoreClasses)
+  private Stream<? extends Class> getClassesInPackage(@Nonnull String packageName, @Nonnull Set<Class<? extends RecordTemplate>> ignoreClasses)
       throws IOException {
     return ClassPath.from(ClassLoader.getSystemClassLoader())
         .getTopLevelClasses(packageName)

--- a/metadata-models/src/test/java/com/linkedin/metadata/ModelValidationConstants.java
+++ b/metadata-models/src/test/java/com/linkedin/metadata/ModelValidationConstants.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata;
 
 import com.google.common.collect.ImmutableSet;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.entity.BaseEntity;
 import com.linkedin.metadata.relationship.BaseRelationship;
 import com.linkedin.metadata.search.BaseDocument;
@@ -13,15 +14,15 @@ public class ModelValidationConstants {
     // Util class
   }
 
-  static final Set<Class> IGNORED_ENTITY_CLASSES = ImmutableSet.of(BaseEntity.class);
+  static final Set<Class<? extends RecordTemplate>> IGNORED_ENTITY_CLASSES = ImmutableSet.of(BaseEntity.class);
 
-  static final Set<Class> IGNORED_RELATIONSHIP_CLASSES = ImmutableSet.of(BaseRelationship.class);
+  static final Set<Class<? extends RecordTemplate>> IGNORED_RELATIONSHIP_CLASSES = ImmutableSet.of(BaseRelationship.class);
 
-  static final Set<Class> IGNORED_DOCUMENT_CLASSES = ImmutableSet.of(BaseDocument.class);
+  static final Set<Class<? extends RecordTemplate>> IGNORED_DOCUMENT_CLASSES = ImmutableSet.of(BaseDocument.class);
 
-  static final Set<Class> IGNORED_ASPECT_CLASSES = ImmutableSet.of();
+  static final Set<Class<? extends RecordTemplate>> IGNORED_ASPECT_CLASSES = ImmutableSet.of();
 
-  static final Set<Class> IGNORED_SNAPSHOT_CLASSES = ImmutableSet.of();
+  static final Set<Class<? extends RecordTemplate>> IGNORED_SNAPSHOT_CLASSES = ImmutableSet.of();
 
-  static final Set<Class> IGNORED_DELTA_CLASSES = ImmutableSet.of();
+  static final Set<Class<? extends RecordTemplate>> IGNORED_DELTA_CLASSES = ImmutableSet.of();
 }

--- a/metadata-testing/metadata-test-utils/src/main/java/com/linkedin/metadata/utils/ESTestUtils.java
+++ b/metadata-testing/metadata-test-utils/src/main/java/com/linkedin/metadata/utils/ESTestUtils.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ContextParser;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
@@ -27,8 +28,8 @@ import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
-import org.elasticsearch.search.aggregations.metrics.tophits.ParsedTopHits;
-import org.elasticsearch.search.aggregations.metrics.tophits.TopHitsAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.ParsedTopHits;
+import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 
 
 @Slf4j
@@ -49,12 +50,6 @@ public final class ESTestUtils {
   }
 
   @Nonnull
-  public static String getUnmodifiedQuery(@Nonnull String query) throws IOException {
-    JsonNode jsonNode = _objectMapper.readTree(query);
-    return jsonNode.toString();
-  }
-
-  @Nonnull
   public static SearchResponse getSearchResponseFromJSON(@Nonnull String response) throws Exception {
     SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
     return getSearchResponsefromNamedContents(searchModule.getNamedXContents(), response);
@@ -64,13 +59,9 @@ public final class ESTestUtils {
   private static SearchResponse getSearchResponsefromNamedContents(@Nonnull List<NamedXContentRegistry.Entry> contents,
       @Nonnull String response) throws Exception {
     NamedXContentRegistry registry = new NamedXContentRegistry(contents);
-    XContentParser parser = JsonXContent.jsonXContent.createParser(registry, response);
+    XContentParser parser =
+        JsonXContent.jsonXContent.createParser(registry, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, response);
     return SearchResponse.fromXContent(parser);
-  }
-
-  @Nonnull
-  public static SearchResponse getSearchResponseFromJSONWithAgg(@Nonnull String response) throws Exception {
-    return getSearchResponsefromNamedContents(getDefaultNamedXContents(), response);
   }
 
   @Nonnull

--- a/metadata-testing/metadata-test-utils/src/main/java/com/linkedin/metadata/utils/TestUtils.java
+++ b/metadata-testing/metadata-test-utils/src/main/java/com/linkedin/metadata/utils/TestUtils.java
@@ -13,7 +13,9 @@ public final class TestUtils {
 
   @Nonnull
   public static String loadJsonFromResource(@Nonnull String resourceName) throws IOException {
-    return IOUtils.toString(ClassLoader.getSystemResourceAsStream(resourceName), Charset.defaultCharset());
+    final String jsonStr =
+        IOUtils.toString(ClassLoader.getSystemResourceAsStream(resourceName), Charset.defaultCharset());
+    return jsonStr.replaceAll("\\s+", "");
   }
 }
 

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/MCEElasticEvent.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/elasticsearch/MCEElasticEvent.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.utils.elasticsearch;
 
 import com.linkedin.data.template.RecordTemplate;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import com.linkedin.metadata.dao.utils.RecordUtils;
@@ -26,7 +27,8 @@ public class MCEElasticEvent extends ElasticEvent {
     try {
       String jsonString = RecordUtils.toJsonString(this._doc);
       builder = XContentFactory.jsonBuilder().prettyPrint();
-      XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, jsonString);
+      XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+          .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, jsonString);
       builder.copyCurrentStructure(parser);
     } catch (IOException e) {
       e.printStackTrace();


### PR DESCRIPTION
Tested by ingesting data using the ingest action method for datasets and corp users. Successfully ingested the data into GMS and was able to search for the same in DH UI. Also called the search endpoint to verify that the documents are indeed in search index

Request:
`curl http://localhost:9200/datasetdocument/_search -H 'Content-Type: application/json' -d '{"query": {"match_all": {}}}' | jq`

Response:
``{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 2,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "datasetdocument",
        "_type": "_doc",
        "_id": "urn%3Ali%3Adataset%3A%28urn%3Ali%3Adataplatform%3Akafka%2Csamplekafkadataset%2Cprod%29",
        "_score": 1,
        "_source": {
          "urn": "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)",
          "browsePaths": [
            "/prod/kafka/samplekafkadataset"
          ],
          "origin": "PROD",
          "name": "SampleKafkaDataset",
          "platform": "kafka",
          "hasSchema": true
        }
      },
      {
        "_index": "datasetdocument",
        "_type": "_doc",
        "_id": "urn%3Ali%3Adataset%3A%28urn%3Ali%3Adataplatform%3Afoo%2Cbar%2Cprod%29",
        "_score": 1,
        "_source": {
          "urn": "urn:li:dataset:(urn:li:dataPlatform:foo,bar,PROD)",
          "hasOwners": true,
          "owners": [
            "jdoe",
            "datahub"
          ],
          "browsePaths": [
            "/prod/foo/bar"
          ],
          "origin": "PROD",
          "name": "bar",
          "platform": "foo",
          "upstreams": [
            "urn:li:dataset:(urn:li:dataPlatform:foo,barUp,PROD)"
          ],
          "hasSchema": true
        }
      }
    ]
  }
}``

Request:
`curl http://localhost:9200/corpuserinfodocument/_search -H 'Content-Type: application/json' -d '{"query": {"match_all": {}}}' | jq`

Response:
``
{
  "took": 1,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "corpuserinfodocument",
        "_type": "_doc",
        "_id": "urn%3Ali%3Acorpuser%3Afbar",
        "_score": 1,
        "_source": {
          "urn": "urn:li:corpuser:fbar",
          "emails": [
            "fbar@linkedin.com"
          ],
          "ldap": "fbar",
          "managerLdap": "",
          "fullName": "Foo Bar",
          "active": true,
          "title": "",
          "skills": [],
          "teams": [],
          "aboutMe": ""
        }
      }
    ]
  }
}
``

Also verified by calling the following rest APIs
Search:
`curl "http://localhost:8080/datasets?q=search&input=bar" -X GET -H 'X-RestLi-Protocol-Version: 2.0.0' -H 'X-RestLi-Method: finder' | jq`
Typeahead:
`curl "http://localhost:8080/datasets?action=autocomplete" -d '{"query": "bar", "field": "name", "limit": 10, "filter": {"criteria": []}}' -X POST -H 'X-RestLi-Protocol-Version: 2.0.0' | jq`
Browse:
`curl "http://localhost:8080/datasets?action=browse" -d '{"path": "/prod", "start": 0, "limit": 10}' -X POST -H 'X-RestLi-Protocol-Version: 2.0.0' | jq`

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
