### PR TITLE
refactor: Exposing Neo4j Driver Configs

### DIFF
--- a/docs/docker/development.md
+++ b/docs/docker/development.md
@@ -23,7 +23,7 @@ you need to make two small edits (don't check these changes in!).
 - Add the JVM debug flags to the environment file for the service.
 - Assign the port in the docker-compose file.
 
-For example, to debug `dathaub-gms`:
+For example, to debug `datahub-gms`:
 
 ```
 # Add this line to docker/datahub-gms/env/docker.env. You can change the port and/or change suspend=n to y.

--- a/gms/factories/src/main/java/com/linkedin/gms/factory/common/Neo4jDriverFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/gms/factory/common/Neo4jDriverFactory.java
@@ -1,6 +1,9 @@
 package com.linkedin.gms.factory.common;
 
+import java.util.concurrent.TimeUnit;
+
 import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,8 +21,26 @@ public class Neo4jDriverFactory {
   @Value("${NEO4J_URI:bolt://localhost}")
   private String uri;
 
+  @Value("${NEO4J_MAX_CONNECTION_POOL_SIZE:100}")
+  private Integer neo4jMaxConnectionPoolSize;
+
+  @Value("${NEO4J_MAX_CONNECTION_ACQUISITION_TIMEOUT_IN_SECONDS:60}")
+  private Long neo4jMaxConnectionAcquisitionTimeout;
+
+  @Value("${NEO4j_MAX_CONNECTION_LIFETIME_IN_HOURS:1}")
+  private Long neo4jMaxConnectionLifetime;
+
+  @Value("${NEO4J_MAX_TRANSACTION_RETRY_TIME_IN_SECONDS:30}")
+  private Long neo4jMaxTransactionRetryTime;
+
   @Bean(name = "neo4jDriver")
   protected Driver createInstance() {
-    return GraphDatabase.driver(uri, AuthTokens.basic(username, password));
+    Config.ConfigBuilder builder = Config.builder();
+    builder.withMaxConnectionPoolSize(neo4jMaxConnectionPoolSize);
+    builder.withConnectionAcquisitionTimeout(neo4jMaxConnectionAcquisitionTimeout, TimeUnit.SECONDS);
+    builder.withMaxConnectionLifetime(neo4jMaxConnectionLifetime, TimeUnit.HOURS);
+    builder.withMaxTransactionRetryTime(neo4jMaxTransactionRetryTime, TimeUnit.SECONDS);
+
+    return GraphDatabase.driver(uri, AuthTokens.basic(username, password), builder.build());
   }
 }


### PR DESCRIPTION
This PR aims at exposing Neo4j Driver Configs as env variables.

Following Variables have been exposed:
- `NEO4J_MAX_CONNECTION_POOL_SIZE`
- `NEO4J_MAX_CONNECTION_ACQUISITION_TIMEOUT_IN_SECONDS`
- `NEO4j_MAX_CONNECTION_LIFETIME_IN_HOURS`
- `NEO4J_MAX_TRANSACTION_RETRY_TIME_IN_SECONDS`

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
