### PR TITLE
feat(jobs): Add DataFlow and DataJob models

### DIFF
--- a/li-utils/src/main/javaPegasus/com/linkedin/common/urn/DataFlowUrn.java
+++ b/li-utils/src/main/javaPegasus/com/linkedin/common/urn/DataFlowUrn.java
@@ -1,0 +1,79 @@
+package com.linkedin.common.urn;
+
+import com.linkedin.data.template.Custom;
+import com.linkedin.data.template.DirectCoercer;
+import com.linkedin.data.template.TemplateOutputCastException;
+import java.net.URISyntaxException;
+
+
+public final class DataFlowUrn extends Urn {
+
+  public static final String ENTITY_TYPE = "dataFlow";
+
+  private final String _orchestrator;
+  private final String _flowId;
+  private final String _cluster;
+
+  public DataFlowUrn(String orchestrator, String flowId, String cluster) {
+    super(ENTITY_TYPE, TupleKey.create(orchestrator, flowId, cluster));
+    this._orchestrator = orchestrator;
+    this._flowId = flowId;
+    this._cluster = cluster;
+  }
+
+  public String getOrchestratorEntity() {
+    return _orchestrator;
+  }
+
+  public String getFlowIdEntity() {
+    return _flowId;
+  }
+
+  public String getClusterEntity() {
+    return _cluster;
+  }
+
+  public static DataFlowUrn createFromString(String rawUrn) throws URISyntaxException {
+    return createFromUrn(Urn.createFromString(rawUrn));
+  }
+
+  public static DataFlowUrn createFromUrn(Urn urn) throws URISyntaxException {
+    if (!"li".equals(urn.getNamespace())) {
+      throw new URISyntaxException(urn.toString(), "Urn namespace type should be 'li'.");
+    } else if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Urn entity type should be 'dataFlow'.");
+    } else {
+      TupleKey key = urn.getEntityKey();
+      if (key.size() != 3) {
+        throw new URISyntaxException(urn.toString(), "Invalid number of keys.");
+      } else {
+        try {
+          return new DataFlowUrn((String) key.getAs(0, String.class), (String) key.getAs(1, String.class),
+              (String) key.getAs(2, String.class));
+        } catch (Exception e) {
+          throw new URISyntaxException(urn.toString(), "Invalid URN Parameter: '" + e.getMessage());
+        }
+      }
+    }
+  }
+
+  public static DataFlowUrn deserialize(String rawUrn) throws URISyntaxException {
+    return createFromString(rawUrn);
+  }
+
+  static {
+    Custom.registerCoercer(new DirectCoercer<DataFlowUrn>() {
+      public Object coerceInput(DataFlowUrn object) throws ClassCastException {
+        return object.toString();
+      }
+
+      public DataFlowUrn coerceOutput(Object object) throws TemplateOutputCastException {
+        try {
+          return DataFlowUrn.createFromString((String) object);
+        } catch (URISyntaxException e) {
+          throw new TemplateOutputCastException("Invalid URN syntax: " + e.getMessage(), e);
+        }
+      }
+    }, DataFlowUrn.class);
+  }
+}

--- a/li-utils/src/main/javaPegasus/com/linkedin/common/urn/DataJobUrn.java
+++ b/li-utils/src/main/javaPegasus/com/linkedin/common/urn/DataJobUrn.java
@@ -1,0 +1,74 @@
+package com.linkedin.common.urn;
+
+import com.linkedin.data.template.Custom;
+import com.linkedin.data.template.DirectCoercer;
+import com.linkedin.data.template.TemplateOutputCastException;
+import java.net.URISyntaxException;
+
+
+public final class DataJobUrn extends Urn {
+
+  public static final String ENTITY_TYPE = "dataJob";
+
+  private final DataFlowUrn _flow;
+  private final String _jobId;
+
+  public DataJobUrn(DataFlowUrn flow, String jobId) {
+    super(ENTITY_TYPE, TupleKey.create(flow, jobId));
+    this._flow = flow;
+    this._jobId = jobId;
+  }
+
+  public DataFlowUrn getFlowEntity() {
+    return _flow;
+  }
+
+  public String getJobIdEntity() {
+    return _jobId;
+  }
+
+  public static DataJobUrn createFromString(String rawUrn) throws URISyntaxException {
+    return createFromUrn(Urn.createFromString(rawUrn));
+  }
+
+  public static DataJobUrn createFromUrn(Urn urn) throws URISyntaxException {
+    if (!"li".equals(urn.getNamespace())) {
+      throw new URISyntaxException(urn.toString(), "Urn namespace type should be 'li'.");
+    } else if (!ENTITY_TYPE.equals(urn.getEntityType())) {
+      throw new URISyntaxException(urn.toString(), "Urn entity type should be 'dataJob'.");
+    } else {
+      TupleKey key = urn.getEntityKey();
+      if (key.size() != 2) {
+        throw new URISyntaxException(urn.toString(), "Invalid number of keys.");
+      } else {
+        try {
+          return new DataJobUrn((DataFlowUrn) key.getAs(0, DataFlowUrn.class),
+              (String) key.getAs(1, String.class));
+        } catch (Exception e) {
+          throw new URISyntaxException(urn.toString(), "Invalid URN Parameter: '" + e.getMessage());
+        }
+      }
+    }
+  }
+
+  public static DataJobUrn deserialize(String rawUrn) throws URISyntaxException {
+    return createFromString(rawUrn);
+  }
+
+  static {
+    Custom.initializeCustomClass(DataFlowUrn.class);
+    Custom.registerCoercer(new DirectCoercer<DataJobUrn>() {
+      public Object coerceInput(DataJobUrn object) throws ClassCastException {
+        return object.toString();
+      }
+
+      public DataJobUrn coerceOutput(Object object) throws TemplateOutputCastException {
+        try {
+          return DataJobUrn.createFromString((String) object);
+        } catch (URISyntaxException e) {
+          throw new TemplateOutputCastException("Invalid URN syntax: " + e.getMessage(), e);
+        }
+      }
+    }, DataJobUrn.class);
+  }
+}

--- a/li-utils/src/main/pegasus/com/linkedin/common/DataFlowUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/DataFlowUrn.pdl
@@ -1,0 +1,34 @@
+namespace com.linkedin.common
+
+/**
+ * Standardized data processing flow identifier.
+ */
+@java.class = "com.linkedin.common.urn.DataFlowUrn"
+@validate.`com.linkedin.common.validator.TypedUrnValidator` = {
+  "accessible" : true,
+  "owningTeam" : "urn:li:internalTeam:datahub",
+  "entityType" : "dataFlow",
+  "constructable" : true,
+  "namespace" : "li",
+  "name" : "DataFlow",
+  "doc" : "Standardized data processing flow identifier.",
+  "owners" : [ "urn:li:corpuser:fbar", "urn:li:corpuser:bfoo" ],
+  "fields" : [ {
+    "name" : "orchestrator",
+    "doc" : "Workflow manager like azkaban, airflow which orchestrates the flow",
+    "type" : "string",
+    "maxLength" : 50
+  }, {
+    "name" : "flowId",
+    "doc" : "Unique Identifier of the data flow",
+    "type" : "string",
+    "maxLength" : 200
+  }{
+    "name" : "cluster",
+    "doc" : "Cluster where the flow is executed",
+    "type" : "string",
+    "maxLength" : 100
+  } ],
+  "maxLength" : 373
+}
+typeref DataFlowUrn = string

--- a/li-utils/src/main/pegasus/com/linkedin/common/DataJobUrn.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/DataJobUrn.pdl
@@ -1,0 +1,28 @@
+namespace com.linkedin.common
+
+/**
+ * Standardized data processing job identifier.
+ */
+@java.class = "com.linkedin.common.urn.DataJobUrn"
+@validate.`com.linkedin.common.validator.TypedUrnValidator` = {
+  "accessible" : true,
+  "owningTeam" : "urn:li:internalTeam:datahub",
+  "entityType" : "dataJob",
+  "constructable" : true,
+  "namespace" : "li",
+  "name" : "DataJob",
+  "doc" : "Standardized data processing job identifier.",
+  "owners" : [ "urn:li:corpuser:fbar", "urn:li:corpuser:bfoo" ],
+  "fields" : [ {
+    "type" : "com.linkedin.common.urn.DataFlowUrn",
+    "name" : "flow",
+    "doc" : "Standardized data processing flow urn representing the flow for the job"
+  }, {
+    "name" : "jobID",
+    "doc" : "Unique identifier of the data job",
+    "type" : "string",
+    "maxLength" : 200
+  } ],
+  "maxLength" : 594
+}
+typeref DataJobUrn = string

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataFlowInfo.pdl
@@ -1,0 +1,23 @@
+namespace com.linkedin.datajob
+
+
+/**
+ * Information about a Data processing flow
+ */
+record DataFlowInfo {
+
+  /**
+   * Flow name
+   */
+  name: string
+
+  /**
+   * Flow description
+   */
+  description: optional string
+
+  /**
+   * Optional project/namespace associated with the flow
+   */
+  project: optional string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInfo.pdl
@@ -1,0 +1,25 @@
+namespace com.linkedin.datajob
+
+import com.linkedin.datajob.azkaban.AzkabanJobType
+
+
+/**
+ * Information about a Data processing job
+ */
+record DataJobInfo {
+
+  /**
+   * Job name
+   */
+  name: string
+
+  /**
+   * Job description
+   */
+  description: optional string
+
+  /**
+   * Datajob type
+   */
+  type: union[AzkabanJobType]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInputOutput.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/DataJobInputOutput.pdl
@@ -1,0 +1,20 @@
+namespace com.linkedin.datajob
+
+import com.linkedin.common.DatasetUrn
+
+
+/**
+ * Information about the inputs and outputs of a Data processing job
+ */
+record DataJobInputOutput {
+
+  /**
+   * Input datasets consumed by the data job during processing
+   */
+  inputDatasets: array[DatasetUrn]
+
+  /**
+   * Output datasets produced by the data job during processing
+   */
+  outputDatasets: array[DatasetUrn]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/azkaban/AzkabanJobType.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/azkaban/AzkabanJobType.pdl
@@ -1,0 +1,40 @@
+namespace com.linkedin.datajob.azkaban
+
+/**
+ * The various types of support azkaban jobs
+ */
+enum AzkabanJobType {
+
+  /**
+   * The command job type is one of the basic built-in types. It runs multiple UNIX commands using java processbuilder.
+   * Upon execution, Azkaban spawns off a process to run the command.
+   */
+  COMMAND
+
+  /**
+   * Runs a java program with ability to access Hadoop cluster.
+   * https://azkaban.readthedocs.io/en/latest/jobTypes.html#java-job-type
+   */
+  HADOOP_JAVA
+
+  /**
+   * In large part, this is the same Command type. The difference is its ability to talk to a Hadoop cluster
+   * securely, via Hadoop tokens.
+   */
+  HADOOP_SHELL
+
+  /**
+   * Hive type is for running Hive jobs.
+   */
+  HIVE
+
+  /**
+   * Pig type is for running Pig jobs.
+   */
+  PIG
+
+  /**
+   * SQL is for running Presto, mysql queries etc
+   */
+  SQL
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataFlowAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataFlowAspect.pdl
@@ -1,0 +1,9 @@
+namespace com.linkedin.metadata.aspect
+
+import com.linkedin.common.Ownership
+import com.linkedin.datajob.DataFlowInfo
+
+/**
+ * A union of all supported metadata aspects for a Data flow
+ */
+typeref DataFlowAspect = union[DataFlowInfo, Ownership]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataJobAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataJobAspect.pdl
@@ -1,0 +1,10 @@
+namespace com.linkedin.metadata.aspect
+
+import com.linkedin.common.Ownership
+import com.linkedin.datajob.DataJobInfo
+import com.linkedin.datajob.DataJobInputOutput
+
+/**
+ * A union of all supported metadata aspects for a Data job
+ */
+typeref DataJobAspect = union[DataJobInfo, DataJobInputOutput, Ownership]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataFlowSnapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataFlowSnapshot.pdl
@@ -1,0 +1,20 @@
+namespace com.linkedin.metadata.snapshot
+
+import com.linkedin.common.DataFlowUrn
+import com.linkedin.metadata.aspect.DataFlowAspect
+
+/**
+ * A metadata snapshot for a specific DataFlow entity.
+ */
+record DataFlowSnapshot {
+
+  /**
+   * URN for the entity the metadata snapshot is associated with.
+   */
+  urn: DataFlowUrn
+
+  /**
+   * The list of metadata aspects associated with the data flow. Depending on the use case, this can either be all, or a selection, of supported aspects.
+   */
+  aspects: array[DataFlowAspect]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataJobSnapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataJobSnapshot.pdl
@@ -1,0 +1,20 @@
+namespace com.linkedin.metadata.snapshot
+
+import com.linkedin.common.DataJobUrn
+import com.linkedin.metadata.aspect.DataJobAspect
+
+/**
+ * A metadata snapshot for a specific DataJob entity.
+ */
+record DataJobSnapshot {
+
+  /**
+   * URN for the entity the metadata snapshot is associated with.
+   */
+  urn: DataJobUrn
+
+  /**
+   * The list of metadata aspects associated with the data job. Depending on the use case, this can either be all, or a selection, of supported aspects.
+   */
+  aspects: array[DataJobAspect]
+}


### PR DESCRIPTION
Add DataFlow and DataJob urn and aspect models.
The aspects include metadata associated with Data processing flow and job entities,
associated inputs and outputs of a job based on RFC #1820 


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
