### PR TITLE
fix: Added transient to connection field. Replace deprecated method.

### DIFF
--- a/metadata-models-generator/src/main/java/com/linkedin/metadata/rythm/StreamTemplateResource.java
+++ b/metadata-models-generator/src/main/java/com/linkedin/metadata/rythm/StreamTemplateResource.java
@@ -15,7 +15,7 @@ import org.rythmengine.resource.TemplateResourceBase;
  */
 public class StreamTemplateResource extends TemplateResourceBase {
   private final String path;
-  private URLConnection connection = null;
+  private transient URLConnection connection = null;
 
   public StreamTemplateResource(String path, StreamResourceLoader loader) {
     super(loader);
@@ -32,7 +32,7 @@ public class StreamTemplateResource extends TemplateResourceBase {
       try {
         final File rythm = new File(path);
         if (rythm.exists()) {
-          connection = rythm.toURL().openConnection();
+          connection = rythm.toURI().toURL().openConnection();
         }
       } catch (IOException ex) {
         throw new RuntimeException("Get template resource failed", ex);


### PR DESCRIPTION
The connection  field with type URLConnection is not Serializable. An allegedly Serializable object with non-transient, non-serializable data members could cause program crashes. Method toURL() of URL class is deprecated.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
