### PR TITLE
fix(search): Fix the unintentional rollback(#2028) of dataset index to search by field paths.

### DIFF
--- a/gms/impl/src/main/resources/index/dataset/mappings.json
+++ b/gms/impl/src/main/resources/index/dataset/mappings.json
@@ -60,6 +60,28 @@
       },
       "normalizer": "my_normalizer"
     },
+    "fieldPaths": {
+      "type": "keyword",
+      "fields": {
+        "field_pattern_ngram": {
+          "type": "text",
+          "analyzer": "field_pattern_ngram"
+        },
+        "delimited": {
+          "type": "text",
+          "analyzer": "delimit"
+        },
+        "ngram": {
+          "type": "text",
+          "analyzer": "custom_ngram"
+        },
+        "pattern": {
+          "type": "text",
+          "analyzer": "field_pattern"
+        }
+      },
+      "normalizer": "my_normalizer"
+    },
     "num_downstream_datasets": {
       "type": "long"
     },

--- a/gms/impl/src/main/resources/index/dataset/settings.json
+++ b/gms/impl/src/main/resources/index/dataset/settings.json
@@ -51,6 +51,13 @@
           "type": "custom",
           "tokenizer": "dataset_pattern"
         },
+        "field_pattern": {
+          "filter": [
+            "lowercase"
+          ],
+          "type": "custom",
+          "tokenizer": "field_pattern"
+        },
         "comma_pattern": {
           "filter": [
             "lowercase"
@@ -102,6 +109,14 @@
           "type": "custom",
           "tokenizer": "dataset_pattern"
         },
+        "field_pattern_ngram": {
+          "filter": [
+            "lowercase",
+            "autocomplete_filter"
+          ],
+          "type": "custom",
+          "tokenizer": "field_pattern"
+        },
         "custom_browse_slash": {
           "filter": [
             "lowercase"
@@ -130,6 +145,10 @@
           "type": "pattern"
         },
         "dataset_pattern": {
+          "pattern": "[./]",
+          "type": "pattern"
+        },
+        "field_pattern": {
           "pattern": "[./]",
           "type": "pattern"
         }


### PR DESCRIPTION
Fix the unintentional rollback(#2028) of dataset index to search by field paths. Fixes #2019

Context: Refer #2019.  Dataset Index mappings defined in #2001 got overriden later by #2028.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
