### PR TITLE
Fix for Kafka-UI Connectivity Error with Kafka-Rest Proxy

### DIFF
--- a/docker/kafka-topics-ui/env/docker.env
+++ b/docker/kafka-topics-ui/env/docker.env
@@ -1,2 +1,2 @@
-KAFKA_REST_PROXY_URL="http://kafkarestproxy:8082/"
+KAFKA_REST_PROXY_URL="http://kafka-rest-proxy:8082/"
 PROXY="true"


### PR DESCRIPTION
Fixes error when acessing http://localhost:18000 where the Kafka-UI was unable to connect to Rest Proxy



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
