### PR TITLE
(refactor): Convert dataPlatforms to GMA aspect models and associated resource to GMA resource.

### DIFF
--- a/gms/README.md
+++ b/gms/README.md
@@ -66,6 +66,26 @@ curl 'http://localhost:8080/charts?action=ingest' -X POST -H 'X-RestLi-Protocol-
 curl 'http://localhost:8080/dashboards?action=ingest' -X POST -H 'X-RestLi-Protocol-Version:2.0.0' --data '{"snapshot":{"aspects":[{"com.linkedin.dashboard.DashboardInfo":{"title":"Baz Dashboard","description":"Baz Dashboard","charts":["urn:li:chart:(looker,baz1)","urn:li:chart:(looker,baz2)"],"lastModified":{"created":{"time":0,"actor":"urn:li:corpuser:jdoe"},"lastModified":{"time":0,"actor":"urn:li:corpuser:datahub"}}}}],"urn":"urn:li:dashboard:(looker,baz)"}}'
 ```
 
+### Get all dataplatforms 
+
+```
+curl -H 'X-RestLi-Protocol-Version:2.0.0' -H 'X-RestLi-Method: get_all' 'http://localhost:8080/dataPlatforms' | jq
+```
+
+### Get dataplatform
+
+```
+curl 'http://localhost:8080/dataPlatforms/hdfs?aspects=List(com.linkedin.dataplatform.DataPlatformInfo)' -H 'X-RestLi-Protocol-Version:2.0.0' -s | jq
+{
+  "name": "hdfs",
+  "dataPlatformInfo": {
+    "name": "hdfs",
+    "type": "FILE_SYSTEM",
+    "datasetNameDelimiter": "/"
+  }
+}
+```
+
 ### Get user
 ```
 curl 'http://localhost:8080/corpUsers/($params:(),name:fbar)' -H 'X-RestLi-Protocol-Version:2.0.0' -s | jq

--- a/gms/api/src/main/idl/com.linkedin.dataplatform.dataPlatforms.restspec.json
+++ b/gms/api/src/main/idl/com.linkedin.dataplatform.dataPlatforms.restspec.json
@@ -12,23 +12,24 @@
     "supports" : [ "get", "get_all" ],
     "methods" : [ {
       "method" : "get",
-      "doc" : "Get data platform",
+      "doc" : "Get data platform.",
       "parameters" : [ {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-        "doc" : "list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms"
+        "doc" : "list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms."
       } ]
     }, {
       "method" : "get_all",
+      "doc" : "Get all data platforms.",
       "pagingSupported" : true
     } ],
     "actions" : [ {
       "name" : "getSnapshot",
-      "doc" : "Get the snapshot of data platform\nService Returns: Snapshot of data platform with the requested aspects.",
+      "doc" : "Get the snapshot of data platform.\nService Returns: Snapshot of data platform with the requested aspects.",
       "parameters" : [ {
         "name" : "urn",
         "type" : "string",
-        "doc" : "data platform urn"
+        "doc" : "data platform urn."
       }, {
         "name" : "aspects",
         "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
@@ -36,12 +37,6 @@
         "doc" : "list of aspects to be returned. null, when all aspects are to be returned."
       } ],
       "returns" : "com.linkedin.metadata.snapshot.DataPlatformSnapshot"
-    }, {
-      "name" : "ingest",
-      "parameters" : [ {
-        "name" : "snapshot",
-        "type" : "com.linkedin.metadata.snapshot.DataPlatformSnapshot"
-      } ]
     } ],
     "entity" : {
       "path" : "/dataPlatforms/{platformName}"

--- a/gms/api/src/main/idl/com.linkedin.dataplatform.dataPlatforms.restspec.json
+++ b/gms/api/src/main/idl/com.linkedin.dataplatform.dataPlatforms.restspec.json
@@ -2,7 +2,7 @@
   "name" : "dataPlatforms",
   "namespace" : "com.linkedin.dataplatform",
   "path" : "/dataPlatforms",
-  "schema" : "com.linkedin.dataplatform.DataPlatformInfo",
+  "schema" : "com.linkedin.dataPlatforms.DataPlatform",
   "doc" : "Resource provides information about various data platforms.\n\ngenerated from: com.linkedin.metadata.resources.dataplatform.DataPlatforms",
   "collection" : {
     "identifier" : {
@@ -11,10 +11,37 @@
     },
     "supports" : [ "get", "get_all" ],
     "methods" : [ {
-      "method" : "get"
+      "method" : "get",
+      "doc" : "Get data platform",
+      "parameters" : [ {
+        "name" : "aspects",
+        "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
+        "doc" : "list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms"
+      } ]
     }, {
       "method" : "get_all",
       "pagingSupported" : true
+    } ],
+    "actions" : [ {
+      "name" : "getSnapshot",
+      "doc" : "Get the snapshot of data platform\nService Returns: Snapshot of data platform with the requested aspects.",
+      "parameters" : [ {
+        "name" : "urn",
+        "type" : "string",
+        "doc" : "data platform urn"
+      }, {
+        "name" : "aspects",
+        "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
+        "optional" : true,
+        "doc" : "list of aspects to be returned. null, when all aspects are to be returned."
+      } ],
+      "returns" : "com.linkedin.metadata.snapshot.DataPlatformSnapshot"
+    }, {
+      "name" : "ingest",
+      "parameters" : [ {
+        "name" : "snapshot",
+        "type" : "com.linkedin.metadata.snapshot.DataPlatformSnapshot"
+      } ]
     } ],
     "entity" : {
       "path" : "/dataPlatforms/{platformName}"

--- a/gms/api/src/main/pegasus/com/linkedin/dataPlatforms/DataPlatform.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dataPlatforms/DataPlatform.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.dataPlatforms
+
+import com.linkedin.dataplatform.DataPlatformInfo
+
+/**
+ * Value Class for DataPlatform resource
+ */
+record DataPlatform {
+
+  /**
+   * Name of the data platform
+   */
+  name: string
+
+  /**
+   * Metadata associated with a dataplatform information
+   */
+  dataPlatformInfo: optional DataPlatformInfo
+}

--- a/gms/api/src/main/snapshot/com.linkedin.dataplatform.dataPlatforms.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataplatform.dataPlatforms.snapshot.json
@@ -1,49 +1,115 @@
 {
   "models" : [ {
+    "type" : "typeref",
+    "name" : "DataPlatformUrn",
+    "namespace" : "com.linkedin.common",
+    "doc" : "Standardized data platforms available",
+    "ref" : "string",
+    "java" : {
+      "class" : "com.linkedin.common.urn.DataPlatformUrn"
+    },
+    "validate" : {
+      "com.linkedin.common.validator.TypedUrnValidator" : {
+        "accessible" : true,
+        "constructable" : true,
+        "doc" : "Standardized data platforms available",
+        "entityType" : "dataPlatform",
+        "fields" : [ {
+          "doc" : "data platform name i.e. hdfs, oracle, espresso",
+          "maxLength" : 25,
+          "name" : "platformName",
+          "type" : "string"
+        } ],
+        "maxLength" : 45,
+        "name" : "DataPlatform",
+        "namespace" : "li",
+        "owners" : [ "urn:li:corpuser:fbar", "urn:li:corpuser:bfoo" ],
+        "owningTeam" : "urn:li:internalTeam:wherehows"
+      }
+    }
+  }, {
     "type" : "record",
-    "name" : "DataPlatformInfo",
-    "namespace" : "com.linkedin.dataplatform",
-    "doc" : "Information about a data platform",
+    "name" : "DataPlatform",
+    "namespace" : "com.linkedin.dataPlatforms",
+    "doc" : "Value Class for DataPlatform resource",
     "fields" : [ {
       "name" : "name",
       "type" : "string",
-      "doc" : "Name of the data platform",
-      "validate" : {
-        "strlen" : {
-          "max" : 15
-        }
-      }
+      "doc" : "Name of the data platform"
     }, {
-      "name" : "type",
+      "name" : "dataPlatformInfo",
       "type" : {
-        "type" : "enum",
-        "name" : "PlatformType",
-        "doc" : "Platform types available at LinkedIn",
-        "symbols" : [ "FILE_SYSTEM", "KEY_VALUE_STORE", "MESSAGE_BROKER", "OBJECT_STORE", "OLAP_DATASTORE", "OTHERS", "QUERY_ENGINE", "RELATIONAL_DB", "SEARCH_ENGINE" ],
-        "symbolDocs" : {
-          "FILE_SYSTEM" : "Value for a file system, e.g. hdfs",
-          "KEY_VALUE_STORE" : "Value for a key value store, e.g. espresso, voldemort",
-          "MESSAGE_BROKER" : "Value for a message broker, e.g. kafka",
-          "OBJECT_STORE" : "Value for an object store, e.g. ambry",
-          "OLAP_DATASTORE" : "Value for an OLAP datastore, e.g. pinot",
-          "OTHERS" : "Value for other platforms, e.g salesforce, dovetail",
-          "QUERY_ENGINE" : "Value for a query engine, e.g. presto",
-          "RELATIONAL_DB" : "Value for a relational database, e.g. oracle, mysql",
-          "SEARCH_ENGINE" : "Value for a search engine, e.g seas"
-        }
+        "type" : "record",
+        "name" : "DataPlatformInfo",
+        "namespace" : "com.linkedin.dataplatform",
+        "doc" : "Information about a data platform",
+        "fields" : [ {
+          "name" : "name",
+          "type" : "string",
+          "doc" : "Name of the data platform",
+          "validate" : {
+            "strlen" : {
+              "max" : 15
+            }
+          }
+        }, {
+          "name" : "type",
+          "type" : {
+            "type" : "enum",
+            "name" : "PlatformType",
+            "doc" : "Platform types available at LinkedIn",
+            "symbols" : [ "FILE_SYSTEM", "KEY_VALUE_STORE", "MESSAGE_BROKER", "OBJECT_STORE", "OLAP_DATASTORE", "OTHERS", "QUERY_ENGINE", "RELATIONAL_DB", "SEARCH_ENGINE" ],
+            "symbolDocs" : {
+              "FILE_SYSTEM" : "Value for a file system, e.g. hdfs",
+              "KEY_VALUE_STORE" : "Value for a key value store, e.g. espresso, voldemort",
+              "MESSAGE_BROKER" : "Value for a message broker, e.g. kafka",
+              "OBJECT_STORE" : "Value for an object store, e.g. ambry",
+              "OLAP_DATASTORE" : "Value for an OLAP datastore, e.g. pinot",
+              "OTHERS" : "Value for other platforms, e.g salesforce, dovetail",
+              "QUERY_ENGINE" : "Value for a query engine, e.g. presto",
+              "RELATIONAL_DB" : "Value for a relational database, e.g. oracle, mysql",
+              "SEARCH_ENGINE" : "Value for a search engine, e.g seas"
+            }
+          },
+          "doc" : "Platform type this data platform describes"
+        }, {
+          "name" : "datasetNameDelimiter",
+          "type" : "string",
+          "doc" : "The delimiter in the dataset names on the data platform, e.g. '/' for HDFS and '.' for Oracle"
+        } ]
       },
-      "doc" : "Platform type this data platform describes"
-    }, {
-      "name" : "datasetNameDelimiter",
-      "type" : "string",
-      "doc" : "The delimiter in the dataset names on the data platform, e.g. '/' for HDFS and '.' for Oracle"
+      "doc" : "Metadata associated with a dataplatform information",
+      "optional" : true
     } ]
-  }, "com.linkedin.dataplatform.PlatformType" ],
+  }, "com.linkedin.dataplatform.DataPlatformInfo", "com.linkedin.dataplatform.PlatformType", {
+    "type" : "typeref",
+    "name" : "DataPlatformAspect",
+    "namespace" : "com.linkedin.metadata.aspect",
+    "doc" : "A union of all supported metadata aspects for a Data Platform",
+    "ref" : [ "com.linkedin.dataplatform.DataPlatformInfo" ]
+  }, {
+    "type" : "record",
+    "name" : "DataPlatformSnapshot",
+    "namespace" : "com.linkedin.metadata.snapshot",
+    "doc" : "A metadata snapshot for a specific dataplatform entity.",
+    "fields" : [ {
+      "name" : "urn",
+      "type" : "com.linkedin.common.DataPlatformUrn",
+      "doc" : "URN for the entity the metadata snapshot is associated with."
+    }, {
+      "name" : "aspects",
+      "type" : {
+        "type" : "array",
+        "items" : "com.linkedin.metadata.aspect.DataPlatformAspect"
+      },
+      "doc" : "The list of metadata aspects associated with the data platform. Depending on the use case, this can either be all, or a selection, of supported aspects."
+    } ]
+  } ],
   "schema" : {
     "name" : "dataPlatforms",
     "namespace" : "com.linkedin.dataplatform",
     "path" : "/dataPlatforms",
-    "schema" : "com.linkedin.dataplatform.DataPlatformInfo",
+    "schema" : "com.linkedin.dataPlatforms.DataPlatform",
     "doc" : "Resource provides information about various data platforms.\n\ngenerated from: com.linkedin.metadata.resources.dataplatform.DataPlatforms",
     "collection" : {
       "identifier" : {
@@ -52,10 +118,31 @@
       },
       "supports" : [ "get", "get_all" ],
       "methods" : [ {
-        "method" : "get"
+        "method" : "get",
+        "doc" : "Get data platform",
+        "parameters" : [ {
+          "name" : "aspects",
+          "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
+          "doc" : "list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms"
+        } ]
       }, {
         "method" : "get_all",
         "pagingSupported" : true
+      } ],
+      "actions" : [ {
+        "name" : "getSnapshot",
+        "doc" : "Get the snapshot of data platform\nService Returns: Snapshot of data platform with the requested aspects.",
+        "parameters" : [ {
+          "name" : "urn",
+          "type" : "string",
+          "doc" : "data platform urn"
+        }, {
+          "name" : "aspects",
+          "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
+          "optional" : true,
+          "doc" : "list of aspects to be returned. null, when all aspects are to be returned."
+        } ],
+        "returns" : "com.linkedin.metadata.snapshot.DataPlatformSnapshot"
       } ],
       "entity" : {
         "path" : "/dataPlatforms/{platformName}"

--- a/gms/api/src/main/snapshot/com.linkedin.dataplatform.dataPlatforms.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataplatform.dataPlatforms.snapshot.json
@@ -119,23 +119,24 @@
       "supports" : [ "get", "get_all" ],
       "methods" : [ {
         "method" : "get",
-        "doc" : "Get data platform",
+        "doc" : "Get data platform.",
         "parameters" : [ {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
-          "doc" : "list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms"
+          "doc" : "list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms."
         } ]
       }, {
         "method" : "get_all",
+        "doc" : "Get all data platforms.",
         "pagingSupported" : true
       } ],
       "actions" : [ {
         "name" : "getSnapshot",
-        "doc" : "Get the snapshot of data platform\nService Returns: Snapshot of data platform with the requested aspects.",
+        "doc" : "Get the snapshot of data platform.\nService Returns: Snapshot of data platform with the requested aspects.",
         "parameters" : [ {
           "name" : "urn",
           "type" : "string",
-          "doc" : "data platform urn"
+          "doc" : "data platform urn."
         }, {
           "name" : "aspects",
           "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",

--- a/gms/client/src/main/java/com/linkedin/dataplatform/client/DataPlatforms.java
+++ b/gms/client/src/main/java/com/linkedin/dataplatform/client/DataPlatforms.java
@@ -1,13 +1,16 @@
 package com.linkedin.dataplatform.client;
 
-import com.linkedin.metadata.restli.BaseClient;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.dataPlatforms.DataPlatform;
 import com.linkedin.dataplatform.DataPlatformInfo;
 import com.linkedin.dataplatform.DataPlatformsRequestBuilders;
+import com.linkedin.metadata.restli.BaseClient;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.restli.client.Client;
 import com.linkedin.restli.client.GetAllRequest;
-import com.linkedin.restli.client.Request;
+import com.linkedin.restli.client.GetRequest;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 
@@ -27,8 +30,11 @@ public class DataPlatforms extends BaseClient {
    */
   @Nonnull
   public DataPlatformInfo getPlatformByName(@Nonnull String platformName) throws RemoteInvocationException {
-    Request<DataPlatformInfo> req = PLATFORMS_REQUEST_BUILDERS.get().id(platformName).build();
-    return _client.sendRequest(req).getResponse().getEntity();
+    final GetRequest<DataPlatform> req = PLATFORMS_REQUEST_BUILDERS.get()
+        .id(platformName)
+        .aspectsParam(new StringArray(DataPlatformInfo.class.getCanonicalName()))
+        .build();
+    return _client.sendRequest(req).getResponse().getEntity().getDataPlatformInfo();
   }
 
   /**
@@ -38,7 +44,13 @@ public class DataPlatforms extends BaseClient {
    */
   @Nonnull
   public List<DataPlatformInfo> getAllPlatforms() throws RemoteInvocationException {
-    GetAllRequest<DataPlatformInfo> req = PLATFORMS_REQUEST_BUILDERS.getAll().build();
-    return _client.sendRequest(req).getResponse().getEntity().getElements();
+    final GetAllRequest<DataPlatform> req = PLATFORMS_REQUEST_BUILDERS.getAll().build();
+    return _client.sendRequest(req)
+        .getResponse()
+        .getEntity()
+        .getElements()
+        .stream()
+        .map(e -> e.getDataPlatformInfo())
+        .collect(Collectors.toList());
   }
 }

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataplatform/DataPlatforms.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataplatform/DataPlatforms.java
@@ -49,12 +49,11 @@ public class DataPlatforms extends BaseEntityResource<
   private BaseLocalDAO<DataPlatformAspect, DataPlatformUrn> _localDAO;
 
   /**
-   * Get data platform
+   * Get data platform.
    *
-   * @param platformName name of the platform
-   * @param aspectNames list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms
-   *
-   * @return {@link DataPlatform} data platform value
+   * @param platformName name of the platform.
+   * @param aspectNames list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms.
+   * @return {@link DataPlatform} data platform value.
    */
   @Nonnull
   @Override
@@ -64,6 +63,12 @@ public class DataPlatforms extends BaseEntityResource<
     return super.get(platformName, aspectNames);
   }
 
+  /**
+   * Get all data platforms.
+   *
+   * @param pagingContext paging context used for paginating through the results.
+   * @return list of all data platforms.
+   */
   @RestMethod.GetAll
   public Task<List<DataPlatformInfo>> getAllDataPlatforms(
       @Nonnull @PagingContextParam(defaultCount = 100) PagingContext pagingContext) {
@@ -72,11 +77,10 @@ public class DataPlatforms extends BaseEntityResource<
   }
 
   /**
-   * Get the snapshot of data platform
+   * Get the snapshot of data platform.
    *
-   * @param urnString data platform urn
+   * @param urnString data platform urn.
    * @param aspectNames list of aspects to be returned. null, when all aspects are to be returned.
-   *
    * @return snapshot of data platform with the requested aspects.
    */
   @Action(name = ACTION_GET_SNAPSHOT)

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dataplatform/DataPlatforms.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dataplatform/DataPlatforms.java
@@ -1,40 +1,140 @@
 package com.linkedin.metadata.resources.dataplatform;
 
 import com.linkedin.common.urn.DataPlatformUrn;
+import com.linkedin.dataPlatforms.DataPlatform;
 import com.linkedin.dataplatform.DataPlatformInfo;
 import com.linkedin.metadata.aspect.DataPlatformAspect;
-import com.linkedin.metadata.dao.ImmutableLocalDAO;
-import com.linkedin.metadata.restli.RestliUtils;
+import com.linkedin.metadata.aspect.DataPlatformAspectArray;
+import com.linkedin.metadata.dao.BaseLocalDAO;
+import com.linkedin.metadata.dao.utils.ModelUtils;
+import com.linkedin.metadata.restli.BaseEntityResource;
+import com.linkedin.metadata.snapshot.DataPlatformSnapshot;
 import com.linkedin.parseq.Task;
 import com.linkedin.restli.server.PagingContext;
+import com.linkedin.restli.server.annotations.Action;
+import com.linkedin.restli.server.annotations.ActionParam;
+import com.linkedin.restli.server.annotations.Optional;
 import com.linkedin.restli.server.annotations.PagingContextParam;
+import com.linkedin.restli.server.annotations.QueryParam;
 import com.linkedin.restli.server.annotations.RestLiCollection;
 import com.linkedin.restli.server.annotations.RestMethod;
-import com.linkedin.restli.server.resources.CollectionResourceAsyncTemplate;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
+
+import static com.linkedin.metadata.restli.RestliConstants.*;
 
 
 /**
  * Resource provides information about various data platforms.
  */
 @RestLiCollection(name = "dataPlatforms", namespace = "com.linkedin.dataplatform", keyName = "platformName")
-public class DataPlatforms extends CollectionResourceAsyncTemplate<String, DataPlatformInfo> {
+public class DataPlatforms extends BaseEntityResource<
+    // @formatter:off
+    String,
+    DataPlatform,
+    DataPlatformUrn,
+    DataPlatformSnapshot,
+    DataPlatformAspect> {
+  // @formatter:on
+
+  public DataPlatforms() {
+    super(DataPlatformSnapshot.class, DataPlatformAspect.class);
+  }
 
   @Inject
   @Named("dataPlatformLocalDAO")
-  private ImmutableLocalDAO<DataPlatformAspect, DataPlatformUrn> _localDAO;
+  private BaseLocalDAO<DataPlatformAspect, DataPlatformUrn> _localDAO;
 
+  /**
+   * Get data platform
+   *
+   * @param platformName name of the platform
+   * @param aspectNames list of aspects to be retrieved. Null to retrieve all aspects of the dataPlatforms
+   *
+   * @return {@link DataPlatform} data platform value
+   */
+  @Nonnull
+  @Override
   @RestMethod.Get
-  public Task<DataPlatformInfo> get(@Nonnull final String name) {
-    return RestliUtils.toTaskFromOptional(() -> _localDAO.get(DataPlatformInfo.class, new DataPlatformUrn(name)));
+  public Task<DataPlatform> get(@Nonnull String platformName,
+      @QueryParam(PARAM_ASPECTS) @Nullable String[] aspectNames) {
+    return super.get(platformName, aspectNames);
   }
 
   @RestMethod.GetAll
-  public Task<List<DataPlatformInfo>> getAll(@Nonnull @PagingContextParam(defaultCount = 100) PagingContext pagingContext) {
-    return Task.value(_localDAO.list(DataPlatformInfo.class, pagingContext.getStart(), pagingContext.getCount()).getValues());
+  public Task<List<DataPlatformInfo>> getAllDataPlatforms(
+      @Nonnull @PagingContextParam(defaultCount = 100) PagingContext pagingContext) {
+    return Task.value(
+        _localDAO.list(DataPlatformInfo.class, pagingContext.getStart(), pagingContext.getCount()).getValues());
+  }
+
+  /**
+   * Get the snapshot of data platform
+   *
+   * @param urnString data platform urn
+   * @param aspectNames list of aspects to be returned. null, when all aspects are to be returned.
+   *
+   * @return snapshot of data platform with the requested aspects.
+   */
+  @Action(name = ACTION_GET_SNAPSHOT)
+  @Override
+  @Nonnull
+  public Task<DataPlatformSnapshot> getSnapshot(@ActionParam(PARAM_URN) @Nonnull String urnString,
+      @ActionParam(PARAM_ASPECTS) @Optional @Nullable String[] aspectNames) {
+    return super.getSnapshot(urnString, aspectNames);
+  }
+
+  @Nonnull
+  @Override
+  protected BaseLocalDAO<DataPlatformAspect, DataPlatformUrn> getLocalDAO() {
+    return _localDAO;
+  }
+
+  @Nonnull
+  @Override
+  protected DataPlatformUrn createUrnFromString(@Nonnull String urnString) throws Exception {
+    return DataPlatformUrn.deserialize(urnString);
+  }
+
+  @Nonnull
+  @Override
+  protected DataPlatformUrn toUrn(@Nonnull String platformName) {
+    return new DataPlatformUrn(platformName);
+  }
+
+  @Nonnull
+  @Override
+  protected String toKey(@Nonnull DataPlatformUrn urn) {
+    return urn.getPlatformNameEntity();
+  }
+
+  @Nonnull
+  @Override
+  protected DataPlatform toValue(@Nonnull DataPlatformSnapshot dataPlatformSnapshot) {
+    final DataPlatform dataPlatform = new DataPlatform();
+    dataPlatform.setName(dataPlatformSnapshot.getUrn().getPlatformNameEntity());
+    ModelUtils.getAspectsFromSnapshot(dataPlatformSnapshot).forEach(aspect -> {
+      if (aspect instanceof DataPlatformInfo) {
+        dataPlatform.setDataPlatformInfo((DataPlatformInfo) aspect);
+      }
+    });
+
+    return dataPlatform;
+  }
+
+  @Nonnull
+  @Override
+  protected DataPlatformSnapshot toSnapshot(@Nonnull DataPlatform dataPlatform, @Nonnull DataPlatformUrn urn) {
+    final DataPlatformSnapshot dataPlatformSnapshot = new DataPlatformSnapshot();
+    final DataPlatformAspectArray aspects = new DataPlatformAspectArray();
+    dataPlatformSnapshot.setUrn(urn);
+    dataPlatformSnapshot.setAspects(aspects);
+    if (dataPlatform.getDataPlatformInfo() != null) {
+      aspects.add(ModelUtils.newAspectUnion(DataPlatformAspect.class, dataPlatform.getDataPlatformInfo()));
+    }
+    return dataPlatformSnapshot;
   }
 }
-

--- a/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/DataPlatformActionRequestBuilder.java
+++ b/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/DataPlatformActionRequestBuilder.java
@@ -1,0 +1,18 @@
+
+package com.linkedin.metadata.dao;
+
+import com.linkedin.common.urn.DataPlatformUrn;
+import com.linkedin.metadata.snapshot.DataPlatformSnapshot;
+
+
+/**
+ * An action request builder for data platform entities.
+ */
+public class DataPlatformActionRequestBuilder extends BaseActionRequestBuilder<DataPlatformSnapshot, DataPlatformUrn> {
+
+  private static final String BASE_URI_TEMPLATE = "dataPlatforms";
+
+  public DataPlatformActionRequestBuilder() {
+    super(DataPlatformSnapshot.class, DataPlatformUrn.class, BASE_URI_TEMPLATE);
+  }
+}

--- a/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/RequestBuilders.java
+++ b/metadata-dao-impl/restli-dao/src/main/java/com/linkedin/metadata/dao/RequestBuilders.java
@@ -22,6 +22,7 @@ public class RequestBuilders {
           add(new CorpGroupActionRequestBuilder());
           add(new CorpUserActionRequestBuilder());
           add(new DashboardActionRequestBuilder());
+          add(new DataPlatformActionRequestBuilder());
           add(new DataProcessActionRequestBuilder());
           add(new DatasetActionRequestBuilder());
         }

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataPlatformSnapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataPlatformSnapshot.pdl
@@ -1,0 +1,20 @@
+namespace com.linkedin.metadata.snapshot
+
+import com.linkedin.common.DataPlatformUrn
+import com.linkedin.metadata.aspect.DataPlatformAspect
+
+/**
+ * A metadata snapshot for a specific dataplatform entity.
+ */
+record DataPlatformSnapshot {
+
+  /**
+   * URN for the entity the metadata snapshot is associated with.
+   */
+  urn: DataPlatformUrn
+
+  /**
+   * The list of metadata aspects associated with the data platform. Depending on the use case, this can either be all, or a selection, of supported aspects.
+   */
+  aspects: array[DataPlatformAspect]
+}


### PR DESCRIPTION
Convert dataPlatforms to GMA aspect models and associated resource to GMA resource.

BREAKING CHANGE: /datasets/dataPlatforms API is now changed to become GMA resource. The schema of the resource also changes.

**What breaks**: Get method of /dataset/dataPlatforms will return com.linkedin.dataPlatforms.DataPlatform schema. Earlier the API returns schema com.linkedin.dataplatform.DataPlatformInfo. 
**How to fix for existing readers**: dataPlatformInfo is a field in then new schema returned by the API. This field should be the same as previous response of the API



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
