### PR TITLE
feat(helm): add extraInitContainers

### DIFF
--- a/contrib/kubernetes/datahub/charts/datahub-frontend/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+      {{- .Values.extraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
@@ -69,6 +69,8 @@ extraVolumeMounts: []
   #   mountPath: /usr/share/extras
   #   readOnly: true
 
+extraInitContainers: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+      {{- .Values.extraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
@@ -68,6 +68,7 @@ extraVolumeMounts: []
   #   mountPath: /usr/share/extras
   #   readOnly: true
 
+extraInitContainers: []
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+      {{- .Values.extraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
@@ -69,6 +69,8 @@ extraVolumeMounts: []
   #   mountPath: /usr/share/extras
   #   readOnly: true
 
+extraInitContainers: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
+      initContainers:
+      {{- if .Values.extraInitContainers }}
+      {{- .Values.extraInitContainers | toYaml | nindent 6 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
@@ -69,6 +69,8 @@ extraVolumeMounts: []
   #   mountPath: /usr/share/extras
   #   readOnly: true
 
+extraInitContainers: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
Support optional [initContainers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) to setup extra initialization (for example creating keytab files to be used by `SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG`)
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
