### PR TITLE
fix(dataset): Use platform delimiter to compose the browse paths

### DIFF
--- a/docker/datahub-mae-consumer/env/docker.env
+++ b/docker/datahub-mae-consumer/env/docker.env
@@ -6,3 +6,5 @@ NEO4J_HOST=neo4j:7474
 NEO4J_URI=bolt://neo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=datahub
+GMS_HOST=datahub-gms
+GMS_PORT=8080

--- a/metadata-builders/build.gradle
+++ b/metadata-builders/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java'
 dependencies {
   compile externalDependency.gmaDaoApi
   compile externalDependency.gmaDaoApiDataTemplate
+  compile project(':metadata-dao-impl:restli-dao')
   compile project(':metadata-models')
 
   compileOnly externalDependency.lombok

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
@@ -30,11 +30,18 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
 
 @Slf4j
 public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
   private static RestliRemoteDAO<DataPlatformSnapshot, DataPlatformAspect, DataPlatformUrn> dataPlatformDAO;
 
+  /**
+   * Constructor for invoking dataset search index builder.
+   *
+   * @param restliClient restli client used to interact with other services to build dataset search documents.
+   */
   public DatasetIndexBuilder(@Nonnull Client restliClient) {
     super(Collections.singletonList(DatasetSnapshot.class), DatasetDocument.class);
     dataPlatformDAO = new RestliRemoteDAO<>(DataPlatformSnapshot.class, DataPlatformAspect.class, restliClient);
@@ -50,7 +57,7 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
 
               return dataPlatformDAO.get(DataPlatformInfo.class, platformUrn)
                   .map(DataPlatformInfo::getDatasetNameDelimiter)
-                  .orElse("");
+                  .orElse(StringUtils.EMPTY);
             }
           });
 

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/config/IndexBuildersConfig.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/config/IndexBuildersConfig.java
@@ -43,7 +43,7 @@ public class IndexBuildersConfig {
     final Set<BaseIndexBuilder<? extends RecordTemplate>> builders = new HashSet<>();
     builders.add(new CorpGroupIndexBuilder());
     builders.add(new ChartIndexBuilder());
-    builders.add(new DatasetIndexBuilder());
+    builders.add(new DatasetIndexBuilder(restliClient));
     builders.add(new DataProcessIndexBuilder());
     builders.add(new DashboardIndexBuilder());
     return builders;


### PR DESCRIPTION
fix(dataset): Use platform delimiter to compose the browse paths. Fixes #1956 

RestliClient is passed to the dataset index builder.  Hence it can call the /datasetPlatform API to get the platform delimiter when constructing browse paths. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
