### PR TITLE
fix(User Search): Fixing CorpUsers Search Bug

### DIFF
--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/config/IndexBuildersConfig.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/config/IndexBuildersConfig.java
@@ -4,6 +4,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.builders.search.BaseIndexBuilder;
 import com.linkedin.metadata.builders.search.ChartIndexBuilder;
 import com.linkedin.metadata.builders.search.CorpGroupIndexBuilder;
+import com.linkedin.metadata.builders.search.CorpUserInfoIndexBuilder;
 import com.linkedin.metadata.builders.search.DashboardIndexBuilder;
 import com.linkedin.metadata.builders.search.DataProcessIndexBuilder;
 import com.linkedin.metadata.builders.search.DatasetIndexBuilder;
@@ -42,6 +43,7 @@ public class IndexBuildersConfig {
     log.debug("restli client {}", restliClient);
     final Set<BaseIndexBuilder<? extends RecordTemplate>> builders = new HashSet<>();
     builders.add(new CorpGroupIndexBuilder());
+    builders.add(new CorpUserInfoIndexBuilder());
     builders.add(new ChartIndexBuilder());
     builders.add(new DatasetIndexBuilder());
     builders.add(new DataProcessIndexBuilder());


### PR DESCRIPTION
Fixing the issue where ingested CorpUsers are not appearing on the frontend. This is because the CorpUsersInfo search index is not being updated, because the index builder is not registered by default. 

This is the PR where the issue was introduced: https://github.com/linkedin/datahub/pull/2024/

https://datahubspace.slack.com/archives/CUMUWQU66/p1611759465003400

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
