### PR TITLE
fix(GraphQL): Enable Mutation type only in frontend graph

### DIFF
--- a/datahub-frontend/conf/datahub-frontend.graphql
+++ b/datahub-frontend/conf/datahub-frontend.graphql
@@ -1,5 +1,9 @@
 # This will host GQL schema extensions specific to the frontend.
 
-extend type Mutation {
+extend schema {
+    mutation: Mutation
+}
+
+type Mutation {
     logIn(username: String!, password: String!): CorpUser
 }


### PR DESCRIPTION
Upon check-in of [Arun's PR](https://github.com/linkedin/datahub/commit/84e952e13831033aaada9bc0582d3498f222fb95 
), we disabled the base Mutation type in datahub-graphql-core. This PR ensure that the `datahub-frontend` graph still works, removing the assumption that the Mutation type had already been registered. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
