### PR TITLE
fix(GraphQL): Add schemaMetadata mapping & correctly form path string

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
@@ -107,8 +107,9 @@ public class DatasetType implements SearchableEntityType<Dataset>, BrowsableEnti
                                 int start,
                                 int count) throws Exception {
         final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, FACET_FIELDS);
+        final String pathStr = path.size() > 0 ? BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path) : "";
         final BrowseResult result = _datasetsClient.browse(
-                BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path),
+                pathStr,
                 facetFilters,
                 start,
                 count);

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/DatasetMapper.java
@@ -42,6 +42,7 @@ public class DatasetMapper implements ModelMapper<com.linkedin.dataset.Dataset, 
             if (dataset.getSchemaMetadata().hasDeleted()) {
                 result.setDeleted(AuditStampMapper.map(dataset.getSchemaMetadata().getDeleted()));
             }
+            result.setSchema(SchemaMetadataMapper.map(dataset.getSchemaMetadata()));
         }
         if (dataset.hasPlatformNativeType()) {
             result.setPlatformNativeType(Enum.valueOf(PlatformNativeType.class, dataset.getPlatformNativeType().name()));


### PR DESCRIPTION
This PR contains 2 small fixes to the GraphQL API within `datahub-graphql-core`. 

1. Map the schemaMetadata Pegasus object to the "schema" field in GQL
2. Correct format a "path" string for browse Query Type, specifically do not include "/" when the provided path array is empty. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
