### PR TITLE
fix(integ test): Bumping GMA to 0.2.40

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.junitJupiterVersion = '5.6.1'
-  ext.gmaVersion = '0.2.35'
+  ext.gmaVersion = '0.2.40'
   ext.pegasusVersion = '28.3.7'
 
   apply from: './repositories.gradle'


### PR DESCRIPTION
Title says it. Bumping GMA to get the changes in 0.2.40 release: https://github.com/linkedin/datahub-gma/releases/tag/v0.2.40. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
