### PR TITLE
feat(React Incubation): adding lineage page with sample data

### DIFF
--- a/datahub-web-react/src/components/auth/LogIn.stories.tsx
+++ b/datahub-web-react/src/components/auth/LogIn.stories.tsx
@@ -3,6 +3,7 @@ import { Story, Meta } from '@storybook/react';
 
 import { MockedProvider } from '@apollo/client/testing';
 import { LogIn, LogInProps } from './LogIn';
+import TestPageContainer from '../../utils/test-utils/TestPageContainer';
 
 export default {
     title: 'DataHub/LogIn',
@@ -16,7 +17,9 @@ LogInScreen.args = {};
 LogInScreen.decorators = [
     (InnerStory) => (
         <MockedProvider mocks={[]}>
-            <InnerStory />
+            <TestPageContainer>
+                <InnerStory />
+            </TestPageContainer>
         </MockedProvider>
     ),
 ];

--- a/datahub-web-react/src/components/entity/dataset/profile/Lineage.tsx
+++ b/datahub-web-react/src/components/entity/dataset/profile/Lineage.tsx
@@ -1,0 +1,34 @@
+import { List, Space, Typography } from 'antd';
+import React from 'react';
+import { Dataset, EntityType } from '../../../../types.generated';
+import { useEntityRegistry } from '../../../useEntityRegistry';
+import { PreviewType } from '../../Entity';
+
+export type Props = {
+    upstreamEntities: Dataset[];
+    downstreamEntities: Dataset[];
+};
+
+export default function Lineage({ upstreamEntities, downstreamEntities }: Props) {
+    const entityRegistry = useEntityRegistry();
+    return (
+        <Space direction="vertical" style={{ width: '100%' }} size="large">
+            <List
+                bordered
+                dataSource={upstreamEntities}
+                header={<Typography.Title level={3}>Upstream</Typography.Title>}
+                renderItem={(item) => {
+                    return entityRegistry.renderPreview(EntityType.Dataset, PreviewType.PREVIEW, item);
+                }}
+            />
+            <List
+                bordered
+                dataSource={downstreamEntities}
+                header={<Typography.Title level={3}>Downstream</Typography.Title>}
+                renderItem={(item) => {
+                    return entityRegistry.renderPreview(EntityType.Dataset, PreviewType.PREVIEW, item);
+                }}
+            />
+        </Space>
+    );
+}

--- a/datahub-web-react/src/components/entity/dataset/profile/__tests__/Lineage.test.tsx
+++ b/datahub-web-react/src/components/entity/dataset/profile/__tests__/Lineage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getByText, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import Lineage from '../Lineage';
 import { sampleUpstreamEntities, sampleDownstreamEntities } from '../stories/lineageEntities';
 import TestPageContainer from '../../../../../utils/test-utils/TestPageContainer';

--- a/datahub-web-react/src/components/entity/dataset/profile/__tests__/Lineage.test.tsx
+++ b/datahub-web-react/src/components/entity/dataset/profile/__tests__/Lineage.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { getByText, render } from '@testing-library/react';
+import Lineage from '../Lineage';
+import { sampleUpstreamEntities, sampleDownstreamEntities } from '../stories/lineageEntities';
+import TestPageContainer from '../../../../../utils/test-utils/TestPageContainer';
+
+describe('Lineage', () => {
+    it('renders', () => {
+        const { getByText } = render(
+            <TestPageContainer>
+                <Lineage upstreamEntities={sampleUpstreamEntities} downstreamEntities={sampleDownstreamEntities} />,
+            </TestPageContainer>,
+        );
+        expect(getByText('Upstream HiveDataset')).toBeInTheDocument();
+        expect(getByText('Downstream HiveDataset')).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/components/entity/dataset/profile/stories/Lineage.stories.tsx
+++ b/datahub-web-react/src/components/entity/dataset/profile/stories/Lineage.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+
+import TestPageContainer from '../../../../../utils/test-utils/TestPageContainer';
+import Lineage, { Props } from '../Lineage';
+import { sampleUpstreamEntities, sampleDownstreamEntities } from './lineageEntities';
+
+export default {
+    title: 'Dataset Profile / Lineage',
+    component: Lineage,
+} as Meta;
+
+const Template: Story<Props> = (args) => <Lineage {...args} />;
+
+export const UpstreamAndDownstream = Template.bind({});
+UpstreamAndDownstream.args = { upstreamEntities: sampleUpstreamEntities, downstreamEntities: sampleDownstreamEntities };
+UpstreamAndDownstream.decorators = [
+    (InnerStory) => (
+        <TestPageContainer>
+            <InnerStory />
+        </TestPageContainer>
+    ),
+];

--- a/datahub-web-react/src/components/entity/dataset/profile/stories/lineageEntities.ts
+++ b/datahub-web-react/src/components/entity/dataset/profile/stories/lineageEntities.ts
@@ -1,0 +1,51 @@
+import { FabricType, PlatformNativeType } from '../../../../../types.generated';
+
+export const sampleUpstreamEntities = [
+    {
+        name: 'Upstream HiveDataset',
+        urn: 'abc',
+        origin: FabricType.Prod,
+        description: 'this is a dataset',
+        platformNativeType: PlatformNativeType.Table,
+        platform: 'table',
+        tags: [],
+        createdTime: 0,
+        modifiedTime: 0,
+    },
+    {
+        name: 'Upstream KafkaDataset',
+        urn: 'abc',
+        origin: FabricType.Prod,
+        description: 'this is a dataset',
+        platformNativeType: PlatformNativeType.Table,
+        platform: 'table',
+        tags: [],
+        createdTime: 0,
+        modifiedTime: 0,
+    },
+];
+
+export const sampleDownstreamEntities = [
+    {
+        name: 'Downstream HiveDataset',
+        urn: 'abc',
+        origin: FabricType.Prod,
+        description: 'this is a dataset',
+        platformNativeType: PlatformNativeType.Table,
+        platform: 'table',
+        tags: [],
+        createdTime: 0,
+        modifiedTime: 0,
+    },
+    {
+        name: 'Downstream KafkaDataset',
+        urn: 'abc',
+        origin: FabricType.Prod,
+        description: 'this is a dataset',
+        platformNativeType: PlatformNativeType.Table,
+        platform: 'table',
+        tags: [],
+        createdTime: 0,
+        modifiedTime: 0,
+    },
+];


### PR DESCRIPTION
Upcoming: wire this into the graphql endpoint

<img width="1529" alt="Screen Shot 2021-02-08 at 12 07 27 PM" src="https://user-images.githubusercontent.com/2455694/107275171-3ebf3b00-6a06-11eb-91b4-c3ae2dcf2b1b.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
