### PR TITLE
fix(React): Fix broken profile link on ownership and header

### DIFF
--- a/datahub-web-react/src/components/entity/dataset/profile/Ownership.tsx
+++ b/datahub-web-react/src/components/entity/dataset/profile/Ownership.tsx
@@ -95,7 +95,7 @@ export const Ownership: React.FC<Props> = ({
             title: 'LDAP',
             dataIndex: 'ldap',
             render: (text: string, record: any) => (
-                <Link to={`${entityRegistry.getPathName(EntityType.User)}/${record.urn}`}>
+                <Link to={`/${entityRegistry.getPathName(EntityType.User)}/${record.urn}`}>
                     <Avatar
                         style={{
                             marginRight: '15px',

--- a/datahub-web-react/src/components/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/components/shared/ManageAccount.tsx
@@ -17,7 +17,7 @@ const defaultProps = {
 export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink }: Props) => {
     const entityRegistry = useEntityRegistry();
     return (
-        <Link to={`${entityRegistry.getPathName(EntityType.User)}/${_urn}`}>
+        <Link to={`/${entityRegistry.getPathName(EntityType.User)}/${_urn}`}>
             <Avatar
                 style={{
                     marginRight: '15px',


### PR DESCRIPTION
**Scope**
This PR only changes the incubating React app. It is part of the initiative to achieve feature parity with the existing Ember app.

**Changes**
The PR fixes broken profile links on ownership page and header (top right corner). 

Broken links
![image](https://user-images.githubusercontent.com/78824220/107429737-3e03d300-6af2-11eb-940d-f34ab1cfc281.png)
![image](https://user-images.githubusercontent.com/78824220/107429774-4cea8580-6af2-11eb-9da7-cf3cc405327c.png)

After Clicking
![image](https://user-images.githubusercontent.com/78824220/107429810-5f64bf00-6af2-11eb-9210-efd612c528e4.png)

**Status**
Ready for review

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
