### PR TITLE
feat(React): Serve React via Docker

### DIFF
--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -54,6 +54,4 @@ jobs:
           repository: linkedin/datahub-frontend
           tags: ${{ needs.setup.outputs.tag }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
-          build-args: |
-            ENABLE_REACT=true
-            PORT=9002
+          build_args: ENABLE_REACT=true,PORT=9002

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -11,7 +11,7 @@ on:
       - master
     paths:
       - 'docker/**'
-      - '.github/workflows/docker-frontend.yml'
+      - '.github/workflows/docker-frontend-react.yml'
     paths_ignore:
       - '**.md'
       - '**.env'

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -1,4 +1,4 @@
-name: datahub-frontend-react docker
+name: datahub-frontend docker
 on:
   push:
     branches:
@@ -11,7 +11,7 @@ on:
       - master
     paths:
       - 'docker/**'
-      - '.github/workflows/docker-frontend-react.yml'
+      - '.github/workflows/docker-frontend.yml'
     paths_ignore:
       - '**.md'
       - '**.env'
@@ -29,7 +29,7 @@ jobs:
       - id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          TAG=react-$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub:
+  build-and-publish-dockerhub-react:
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -51,26 +51,9 @@ jobs:
           dockerfile: ./docker/datahub-frontend/Dockerfile
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-frontend-react
+          repository: linkedin/datahub-frontend
           tags: ${{ needs.setup.outputs.tag }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
           build-args: |
             ENABLE_REACT=true
-            PORT=9091
-  build-and-publish-github:
-    runs-on: ubuntu-latest
-    if: ${{ needs.setup.outputs.publish == 'true' }}
-    needs: setup
-    steps:
-      - uses: actions/checkout@v2
-      - uses: VaultVulp/gp-docker-action@1.1.6
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/datahub-frontend/Dockerfile
-          image-name: datahub-frontend-react
-          image-tag: ${{ needs.setup.outputs.tag }}
-          build-args: |
-            ENABLE_REACT=true
-            PORT=9091
+            PORT=9002

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -1,0 +1,76 @@
+name: datahub-frontend-react docker
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-frontend-react.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
+  release:
+    types: [published, edited]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: tag
+        run: |
+          echo "GITHUB_REF: $GITHUB_REF"
+          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          echo "tag=$TAG"
+          echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  build-and-publish-dockerhub:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v1
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          dockerfile: ./docker/datahub-frontend/Dockerfile
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: linkedin/datahub-frontend-react
+          tags: ${{ needs.setup.outputs.tag }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}
+          build-args: |
+            ENABLE_REACT=true
+            PORT=9091
+  build-and-publish-github:
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: VaultVulp/gp-docker-action@1.1.6
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: ./docker/datahub-frontend/Dockerfile
+          image-name: datahub-frontend-react
+          image-tag: ${{ needs.setup.outputs.tag }}
+          build-args: |
+            ENABLE_REACT=true
+            PORT=9091

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -1,4 +1,4 @@
-name: datahub-frontend docker
+name: datahub-frontend-react docker
 on:
   push:
     branches:

--- a/datahub-frontend/play.gradle
+++ b/datahub-frontend/play.gradle
@@ -13,7 +13,11 @@ configurations {
 }
 
 dependencies {
-  assets project(path: ':datahub-web', configuration: 'assets')
+  if (project.hasProperty('enableReact') && project.getProperty('enableReact').toBoolean()) {
+    assets project(path: ':datahub-web-react', configuration: 'assets')
+  } else {
+    assets project(path: ':datahub-web', configuration: 'assets')
+  }
 
   play project(":datahub-dao")
   play project(":datahub-graphql-core")

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -1,3 +1,6 @@
+# Server Port
+PORT=9001
+
 # Secret Key
 DATAHUB_SECRET="YouKnowNothing"
 

--- a/datahub-frontend/run/run-local-frontend
+++ b/datahub-frontend/run/run-local-frontend
@@ -9,9 +9,10 @@ source frontend.env
 set +a
 
 export JAVA_OPTS="
+  -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
 	-Xms512m
 	-Xmx1024m
-	-Dhttp.port=9001
+	-Dhttp.port=$PORT
 	-Dconfig.file=$CONF_DIR/application.conf
 	-Djava.security.auth.login.config=$CONF_DIR/jaas.conf
 	-Dlogback.configurationFile=$CURRENT_DIR/logback.xml

--- a/datahub-web-react/.env
+++ b/datahub-web-react/.env
@@ -1,0 +1,1 @@
+PUBLIC_URL=/assets

--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
+        "@ant-design/colors": "^5.0.0",
         "@ant-design/icons": "^4.3.0",
         "@apollo/client": "^3.3.6",
         "@storybook/react": "^6.1.11",
@@ -18,10 +19,13 @@
         "@types/react-router-dom": "^5.1.6",
         "antd": "^4.9.4",
         "graphql": "^15.4.0",
+        "history": "^5.0.0",
         "js-cookie": "^2.2.1",
         "query-string": "^6.13.8",
+        "rc-table": "^7.13.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
+        "react-icons": "^4.2.0",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.1.6",
         "react-scripts": "4.0.1",
@@ -36,7 +40,8 @@
         "eject": "react-scripts eject",
         "storybook": "start-storybook -p 6006 -s public",
         "build-storybook": "build-storybook -s public",
-        "generate": "graphql-codegen --config codegen.yml"
+        "generate": "graphql-codegen --config codegen.yml",
+        "lint": "eslint . --ext .ts,.tsx --quiet"
     },
     "eslintConfig": {
         "extends": [
@@ -81,5 +86,8 @@
         "eslint-plugin-react": "^7.21.5",
         "prettier": "^2.2.1"
     },
-    "proxy": "http://localhost:9002"
+    "proxy": "http://localhost:9002",
+    "resolutions": {
+      "@ant-design/colors": "5.0.0"
+    }
 }

--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -3,7 +3,6 @@
     "version": "0.1.0",
     "private": true,
     "dependencies": {
-        "@ant-design/colors": "^5.0.0",
         "@ant-design/icons": "^4.3.0",
         "@apollo/client": "^3.3.6",
         "@storybook/react": "^6.1.11",
@@ -19,13 +18,10 @@
         "@types/react-router-dom": "^5.1.6",
         "antd": "^4.9.4",
         "graphql": "^15.4.0",
-        "history": "^5.0.0",
         "js-cookie": "^2.2.1",
         "query-string": "^6.13.8",
-        "rc-table": "^7.13.1",
         "react": "^17.0.0",
         "react-dom": "^17.0.0",
-        "react-icons": "^4.2.0",
         "react-router": "^5.2.0",
         "react-router-dom": "^5.1.6",
         "react-scripts": "4.0.1",
@@ -40,8 +36,7 @@
         "eject": "react-scripts eject",
         "storybook": "start-storybook -p 6006 -s public",
         "build-storybook": "build-storybook -s public",
-        "generate": "graphql-codegen --config codegen.yml",
-        "lint": "eslint . --ext .ts,.tsx --quiet"
+        "generate": "graphql-codegen --config codegen.yml"
     },
     "eslintConfig": {
         "extends": [
@@ -86,8 +81,5 @@
         "eslint-plugin-react": "^7.21.5",
         "prettier": "^2.2.1"
     },
-    "proxy": "http://localhost:9001",
-    "resolutions": {
-      "@ant-design/colors": "5.0.0"
-    }
+    "proxy": "http://localhost:9002"
 }

--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -17,7 +17,7 @@ const MOCK_MODE = false;
     Construct Apollo Client 
 */
 const client = new ApolloClient({
-    uri: 'http://localhost:3000/api/v2/graphql',
+    uri: '/api/v2/graphql',
     cache: new InMemoryCache({
         typePolicies: {
             Dataset: {

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,3 +55,56 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -p datahub build
 
 This is because we're relying on builtkit for multistage builds. It does not hurt also set `DATAHUB_VERSION` to
 something unique.
+
+## React
+You may wish to serve the incubating React UI instead of the Ember UI. To do so, follow the instructions below.
+
+> **Before continuing**: If you've already run a deploy script, don't forget to clear containers using `docker container prune`
+
+### Serving React Only
+
+#### All Containers 
+
+Use the `quickstart-react.sh` script to launch all containers in DataHub, including a frontend server that returns a React UI
+```
+./quickstart-react.sh
+```
+
+#### The Bare Minimum
+Run the following command to launch only the React server and its required dependencies
+
+```
+docker-compose -f docker-compose.react.yml -f docker-compose.yml -f docker-compose.override.yml up datahub-frontend-react
+```
+
+Once complete, navigate to `localhost:9002/` in your browser to see the React app.
+
+### Serving React + Ember
+If you'd like to serve the React and Ember UIs side-by-side, you can deploy the `datahub-frontend-react` container manually.
+
+#### All Containers
+
+To deploy all DataHub containers, run the quickstart script:
+```
+./quickstart.sh
+```
+
+Next, deploy the container that serves the React UI:
+
+```
+docker-compose -f docker-compose.react.yml -f docker-compose.yml -f docker-compose.override.yml up --no-deps datahub-frontend-react
+```
+
+#### The Bare Minimum
+First, start the Ember frontend server & its required dependencies:
+
+```
+docker-compose up datahub-frontend
+```
+
+Then, start the React frontend server & its required dependencies: 
+```
+docker-compose -f docker-compose.react.yml -f docker-compose.yml -f docker-compose.override.yml up datahub-frontend-react
+```
+
+Navigate to `localhost:9001/` to view the Ember app & `localhost:9002/` to view the React app. 

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,7 +57,7 @@ This is because we're relying on builtkit for multistage builds. It does not hur
 something unique.
 
 ## React
-You may wish to serve the incubating React UI instead of the Ember UI. To do so, follow the instructions below.
+To serve the incubating React UI, follow the instructions below.
 
 > **Before continuing**: If you've already run a deploy script, don't forget to clear containers using `docker container prune`
 

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:8 as builder
 
+ARG ENABLE_REACT
+ARG PORT
+
 RUN apt-get update && apt-get install -y wget \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
     && apt-get -y install ./google-chrome-stable_current_amd64.deb
@@ -7,7 +10,7 @@ RUN apt-get update && apt-get install -y wget \
 ENV CI=true
 
 COPY . datahub-src
-RUN cd datahub-src && ./gradlew :datahub-frontend:dist \
+RUN cd datahub-src && ./gradlew :datahub-frontend:dist -PenableReact=${ENABLE_REACT} \
     && cp datahub-frontend/build/distributions/datahub-frontend.zip ../datahub-frontend.zip \
     && cd .. && rm -rf datahub-src && unzip datahub-frontend.zip
 
@@ -18,12 +21,12 @@ RUN addgroup -S datahub && adduser -S datahub -G datahub
 COPY --from=builder /datahub-frontend /datahub-frontend/
 RUN chown -R datahub:datahub /datahub-frontend && chmod 755 /datahub-frontend
 USER datahub
-EXPOSE 9001
+EXPOSE ${PORT:-9001}
 
 ENV JAVA_OPTS=" \
 	-Xms512m \
 	-Xmx1024m \
-	-Dhttp.port=9001 \
+	-Dhttp.port=${PORT:-9001} \
 	-Dconfig.file=datahub-frontend/conf/application.conf \
 	-Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf \
 	-Dlogback.configurationFile=datahub-frontend/conf/logback.xml \

--- a/docker/docker-compose.react.yml
+++ b/docker/docker-compose.react.yml
@@ -1,0 +1,20 @@
+# Introduces datahub-frontend-react container to serve the React UI on localhost:9002/
+---
+version: '3.8'
+services:
+  datahub-frontend-react:
+    build:
+      context: ../
+      dockerfile: docker/datahub-frontend/Dockerfile
+      args:
+        ENABLE_REACT: "true"
+        PORT: 9002
+    image: linkedin/datahub-frontend-react:${DATAHUB_VERSION:-latest} # Reuse datahub-frontend image.
+    env_file: datahub-frontend/env/docker.env
+    hostname: datahub-frontend-react
+    container_name: datahub-frontend-react
+    ports:
+      - "9002:9002"
+    depends_on:
+      - datahub-gms
+      -

--- a/docker/docker-compose.react.yml
+++ b/docker/docker-compose.react.yml
@@ -17,4 +17,3 @@ services:
       - "9002:9002"
     depends_on:
       - datahub-gms
-      -

--- a/docker/docker-compose.react.yml
+++ b/docker/docker-compose.react.yml
@@ -9,7 +9,7 @@ services:
       args:
         ENABLE_REACT: "true"
         PORT: 9002
-    image: linkedin/datahub-frontend-react:${DATAHUB_VERSION:-latest} # Reuse datahub-frontend image.
+    image: linkedin/datahub-frontend:react-${DATAHUB_VERSION:-latest}
     env_file: datahub-frontend/env/docker.env
     hostname: datahub-frontend-react
     container_name: datahub-frontend-react

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -141,19 +141,6 @@ services:
       - mysql
       - neo4j
 
-  datahub-gms-graphql-service:
-    build:
-        context: ../
-        dockerfile: docker/datahub-gms-graphql-service/Dockerfile
-    image: linkedin/datahub-gms-graphql-service:${DATAHUB_VERSION:-latest}
-    env_file: datahub-gms-graphql-service/env/docker.env
-    hostname: datahub-gms-graphql-service
-    container_name: datahub-gms-graphql-service
-    ports:
-      - "8091:8091"
-    depends_on:
-      - datahub-gms
-
   datahub-frontend:
     build:
       context: ../

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -141,6 +141,19 @@ services:
       - mysql
       - neo4j
 
+  datahub-gms-graphql-service:
+    build:
+        context: ../
+        dockerfile: docker/datahub-gms-graphql-service/Dockerfile
+    image: linkedin/datahub-gms-graphql-service:${DATAHUB_VERSION:-latest}
+    env_file: datahub-gms-graphql-service/env/docker.env
+    hostname: datahub-gms-graphql-service
+    container_name: datahub-gms-graphql-service
+    ports:
+      - "8091:8091"
+    depends_on:
+      - datahub-gms
+
   datahub-frontend:
     build:
       context: ../

--- a/docker/quickstart-react.sh
+++ b/docker/quickstart-react.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Quickstarts DataHub that serves React app. Notice that this only starts the dependencies required by datahub-frontend-react.
-# Notice that by default we do not launch datahub-frontend (Ember) app.
+# Quickstarts DataHub that serves React app
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR && docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.react.yml pull && docker-compose -p datahub \
     -f docker-compose.yml \

--- a/docker/quickstart-react.sh
+++ b/docker/quickstart-react.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Quickstarts DataHub that serves React app
+# Quickstarts a React-serving variant of DataHub by pulling all images from dockerhub and then running the containers locally.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR && docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.react.yml pull && docker-compose -p datahub \
     -f docker-compose.yml \

--- a/docker/quickstart-react.sh
+++ b/docker/quickstart-react.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Quickstarts DataHub that serves React app. Notice that this only starts the dependencies required by datahub-frontend-react.
+# Notice that by default we do not launch datahub-frontend (Ember) app.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR && docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.react.yml pull && docker-compose -p datahub \
+    -f docker-compose.yml \
+    -f docker-compose.override.yml \
+    -f docker-compose.react.yml \
+    up \
+    --scale datahub-frontend=0


### PR DESCRIPTION
**Scope**
This PR introduces a new Docker compose extension file (docker-compose.react.yml) that can be used to deploy a version of `datahub-frontend` configured for serving the incubating React app. All changes are backward compatible. 

**Details**
As background: we'd like to enable the following flows: 

1. Spin up all of datahub system with react ui (quickstart script)
2. Spin up datahub-system with *both* react and ember app 
3. Spin up only datahub react and required dependencies (docker-compose)

So that folks can more easily contribute to the React App as well as perform side-by-side deployment of React & Ember. 

To support this, I have introduced an optional container called `datahub-frontend-react` that is defined within a compose extension file `docker-compose.react.yml`. 

Specific instructions about how to deploy the React-serving frontend server can be found in the updated README. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
