### PR TITLE
bug(docker): Removing datahub-gms-graphql-service from default docker-compose.yml

### DIFF
--- a/docker/docker-compose.graphql-service.yml
+++ b/docker/docker-compose.graphql-service.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  datahub-gms-graphql-service:
+    build:
+      context: ../
+      dockerfile: docker/datahub-gms-graphql-service/Dockerfile
+    image: linkedin/datahub-gms-graphql-service:${DATAHUB_VERSION:-latest}
+    env_file: datahub-gms-graphql-service/env/docker.env
+    hostname: datahub-gms-graphql-service
+    container_name: datahub-gms-graphql-service
+    ports:
+      - "8091:8091"
+    depends_on:
+      - datahub-gms

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -141,19 +141,6 @@ services:
       - mysql
       - neo4j
 
-  datahub-gms-graphql-service:
-    build:
-        context: ../
-        dockerfile: docker/datahub-gms-graphql-service/Dockerfile
-    image: linkedin/datahub-gms-graphql-service:${DATAHUB_VERSION:-latest}
-    env_file: datahub-gms-graphql-service/env/docker.env
-    hostname: datahub-gms-graphql-service
-    container_name: datahub-gms-graphql-service
-    ports:
-      - "8091:8091"
-    depends_on:
-      - datahub-gms
-
   datahub-frontend:
     build:
       context: ../


### PR DESCRIPTION
`datahub-gms-graphql-service` is a nascent service that exposes a GMS GraphQL API (code under `datahub-graphql-core`). It was added to the default docker-compose.yml file some commits ago ([PR](https://github.com/linkedin/datahub/pull/2071/files)), however there is no registered repo in the LinkedIn Docker Hub so people trying to build `docker-compose.yml` are being forced to build locally. 

Since this is a very new service not on the critical path, we will remove the service from `docker-compose.yml` for now. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
