### PR TITLE
feat(React): Avatar dropdown menu and logout function

### DIFF
--- a/datahub-web-react/src/app/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/app/shared/ManageAccount.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Avatar } from 'antd';
-import { Link } from 'react-router-dom';
+import Cookies from 'js-cookie';
+import { Menu, Avatar, Dropdown } from 'antd';
+import { Link, Redirect } from 'react-router-dom';
 import defaultAvatar from '../../images/default_avatar.png';
 import { EntityType } from '../../types.generated';
 import { useEntityRegistry } from '../useEntityRegistry';
+import { isLoggedInVar, checkAuthStatus } from '../auth/checkAuthStatus';
 
 interface Props {
     urn: string;
@@ -16,17 +18,43 @@ const defaultProps = {
 
 export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink }: Props) => {
     const entityRegistry = useEntityRegistry();
+
+    const isLoggedIn = checkAuthStatus();
+
+    const handleLogout = () => {
+        Cookies.remove('PLAY_SESSION');
+        Cookies.remove('IS_LOGGED_IN');
+        localStorage.removeItem('userUrn');
+        isLoggedInVar(false);
+    };
+
+    const menu = (
+        <Menu>
+            <Menu.Item danger>
+                <div tabIndex={0} role="button" onClick={handleLogout} onKeyDown={handleLogout}>
+                    Log out
+                </div>
+            </Menu.Item>
+        </Menu>
+    );
+
+    if (!isLoggedIn) {
+        return <Redirect to="/login" />;
+    }
+
     return (
-        <Link to={`${entityRegistry.getPathName(EntityType.CorpUser)}/${_urn}`}>
-            <Avatar
-                style={{
-                    marginRight: '15px',
-                    color: '#f56a00',
-                    backgroundColor: '#fde3cf',
-                }}
-                src={_pictureLink || defaultAvatar}
-            />
-        </Link>
+        <Dropdown overlay={menu}>
+            <Link to={`/${entityRegistry.getPathName(EntityType.CorpUser)}/${_urn}`}>
+                <Avatar
+                    style={{
+                        marginRight: '15px',
+                        color: '#f56a00',
+                        backgroundColor: '#fde3cf',
+                    }}
+                    src={_pictureLink || defaultAvatar}
+                />
+            </Link>
+        </Dropdown>
     );
 };
 

--- a/datahub-web-react/src/app/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/app/shared/ManageAccount.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Cookies from 'js-cookie';
 import { Menu, Avatar, Dropdown } from 'antd';
-import { Link, Redirect } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import defaultAvatar from '../../images/default_avatar.png';
 import { EntityType } from '../../types.generated';
 import { useEntityRegistry } from '../useEntityRegistry';
-import { isLoggedInVar, checkAuthStatus } from '../auth/checkAuthStatus';
+import { isLoggedInVar } from '../auth/checkAuthStatus';
 
 interface Props {
     urn: string;
@@ -19,10 +19,7 @@ const defaultProps = {
 export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink }: Props) => {
     const entityRegistry = useEntityRegistry();
 
-    const isLoggedIn = checkAuthStatus();
-
     const handleLogout = () => {
-        Cookies.remove('PLAY_SESSION');
         Cookies.remove('IS_LOGGED_IN');
         localStorage.removeItem('userUrn');
         isLoggedInVar(false);
@@ -37,10 +34,6 @@ export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink }: Props) =
             </Menu.Item>
         </Menu>
     );
-
-    if (!isLoggedIn) {
-        return <Redirect to="/login" />;
-    }
 
     return (
         <Dropdown overlay={menu}>


### PR DESCRIPTION
**Scope**
This PR changes all page that includes the header bar. 

**Changes**
This PR adds new feature which pops up a menu when hovering on profile on top right corner of the page. Currently, there is only 1 option, that is to log out. After this option is clicked, user session is cleared and users are redirected to the login page. 

_This PR also contains a overwritten changes in https://github.com/linkedin/datahub/pull/2095 where multiple clicking on the profile will redirect users to url like "user/user/user/user/..."_
![Screenshot from 2021-02-17 16-39-54](https://user-images.githubusercontent.com/78824220/108271847-6ec1b900-713f-11eb-86f6-94fa4f124a38.png)


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
