### PR TITLE
feat(GraphQL API): GQL implementation of Charts + Dashboards

### DIFF
--- a/datahub-frontend/run/run-local-frontend
+++ b/datahub-frontend/run/run-local-frontend
@@ -9,7 +9,6 @@ source frontend.env
 set +a
 
 export JAVA_OPTS="
-  -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
 	-Xms512m
 	-Xmx1024m
 	-Dhttp.port=$PORT

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsClientFactory.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsClientFactory.java
@@ -1,5 +1,7 @@
 package com.linkedin.datahub.graphql;
 
+import com.linkedin.chart.client.Charts;
+import com.linkedin.dashboard.client.Dashboards;
 import com.linkedin.dataplatform.client.DataPlatforms;
 import com.linkedin.dataset.client.Datasets;
 import com.linkedin.dataset.client.Lineages;
@@ -27,6 +29,8 @@ public class GmsClientFactory {
 
     private static CorpUsers _corpUsers;
     private static Datasets _datasets;
+    private static Dashboards _dashboards;
+    private static Charts _charts;
     private static DataPlatforms _dataPlatforms;
     private static Lineages _lineages;
 
@@ -52,6 +56,28 @@ public class GmsClientFactory {
             }
         }
         return _datasets;
+    }
+
+    public static Dashboards getDashboardsClient() {
+        if (_dashboards == null) {
+            synchronized (GmsClientFactory.class) {
+                if (_dashboards == null) {
+                    _dashboards = new Dashboards(REST_CLIENT);
+                }
+            }
+        }
+        return _dashboards;
+    }
+
+    public static Charts getChartsClient() {
+        if (_charts == null) {
+            synchronized (GmsClientFactory.class) {
+                if (_charts == null) {
+                    _charts = new Charts(REST_CLIENT);
+                }
+            }
+        }
+        return _charts;
     }
 
     public static DataPlatforms getDataPlatformsClient() {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/LoadableTypeBatchResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/load/LoadableTypeBatchResolver.java
@@ -1,0 +1,39 @@
+package com.linkedin.datahub.graphql.resolvers.load;
+
+import com.linkedin.datahub.graphql.types.LoadableType;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import org.dataloader.DataLoader;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/**
+ * Generic GraphQL resolver responsible for
+ *
+ *    1. Retrieving a batch of urns.
+ *    2. Resolving a single {@link LoadableType}.
+ *
+ *  Note that this resolver expects that {@link DataLoader}s were registered
+ *  for the provided {@link LoadableType} under the name provided by {@link LoadableType#name()}
+ *
+ * @param <T> the generated GraphQL POJO corresponding to the resolved type.
+ */
+public class LoadableTypeBatchResolver<T> implements DataFetcher<CompletableFuture<List<T>>> {
+
+    private final LoadableType<T> _loadableType;
+    private final Function<DataFetchingEnvironment, List<String>> _urnProvider;
+
+    public LoadableTypeBatchResolver(final LoadableType<T> loadableType, final Function<DataFetchingEnvironment, List<String>> urnProvider) {
+        _loadableType = loadableType;
+        _urnProvider = urnProvider;
+    }
+
+    @Override
+    public CompletableFuture<List<T>> get(DataFetchingEnvironment environment) {
+        final List<String> urns = _urnProvider.apply(environment);
+        final DataLoader<String, T> loader = environment.getDataLoaderRegistry().getDataLoader(_loadableType.name());
+        return loader.loadMany(urns);
+    }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -1,0 +1,101 @@
+package com.linkedin.datahub.graphql.types.chart;
+
+import com.linkedin.chart.client.Charts;
+import com.linkedin.common.urn.ChartUrn;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.Chart;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.datahub.graphql.types.mappers.ChartMapper;
+import com.linkedin.datahub.graphql.types.mappers.SearchResultsMapper;
+import com.linkedin.metadata.configs.ChartSearchConfig;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.restli.common.CollectionResponse;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ChartType implements SearchableEntityType<Chart> {
+
+    private final Charts _chartsClient;
+    private static final ChartSearchConfig CHART_SEARCH_CONFIG = new ChartSearchConfig();
+
+    public ChartType(final Charts chartsClient) {
+        _chartsClient = chartsClient;
+    }
+
+    @Override
+    public EntityType type() {
+        return EntityType.CHART;
+    }
+
+    @Override
+    public Class<Chart> objectClass() {
+        return Chart.class;
+    }
+
+    @Override
+    public List<Chart> batchLoad(@Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+        final List<ChartUrn> chartUrns = urns.stream()
+                .map(this::getChartUrn)
+                .collect(Collectors.toList());
+
+        try {
+            final Map<ChartUrn, com.linkedin.dashboard.Chart> chartMap = _chartsClient.batchGet(chartUrns
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet()));
+
+            final List<com.linkedin.dashboard.Chart> gmsResults = new ArrayList<>();
+            for (ChartUrn urn : chartUrns) {
+                gmsResults.add(chartMap.getOrDefault(urn, null));
+            }
+            return gmsResults.stream()
+                    .map(gmsDataset -> gmsDataset == null ? null : ChartMapper.map(gmsDataset))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to batch load Charts", e);
+        }
+    }
+
+    @Override
+    public SearchResults search(@Nonnull String query,
+                                @Nullable List<FacetFilterInput> filters,
+                                int start,
+                                int count,
+                                @Nonnull QueryContext context) throws Exception {
+        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, CHART_SEARCH_CONFIG.getFacetFields());
+        final CollectionResponse<com.linkedin.dashboard.Chart> searchResult = _chartsClient.search(query, null, facetFilters, null, start, count);
+        return SearchResultsMapper.map(searchResult, ChartMapper::map);
+    }
+
+    @Override
+    public AutoCompleteResults autoComplete(@Nonnull String query,
+                                            @Nullable String field,
+                                            @Nullable List<FacetFilterInput> filters,
+                                            int limit,
+                                            @Nonnull QueryContext context) throws Exception {
+        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, CHART_SEARCH_CONFIG.getFacetFields());
+        final AutoCompleteResult result = _chartsClient.autocomplete(query, field, facetFilters, limit);
+        return AutoCompleteResultsMapper.map(result);
+    }
+
+    private ChartUrn getChartUrn(String urnStr) {
+        try {
+            return ChartUrn.createFromString(urnStr);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(String.format("Failed to retrieve chart with urn %s, invalid urn", urnStr));
+        }
+    }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -1,0 +1,102 @@
+package com.linkedin.datahub.graphql.types.dashboard;
+
+import com.linkedin.common.urn.DashboardUrn;
+import com.linkedin.dashboard.client.Dashboards;
+import com.linkedin.datahub.graphql.QueryContext;
+import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.Dashboard;
+import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.datahub.graphql.generated.FacetFilterInput;
+import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.SearchableEntityType;
+import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.datahub.graphql.types.mappers.DashboardMapper;
+import com.linkedin.datahub.graphql.types.mappers.SearchResultsMapper;
+import com.linkedin.metadata.configs.DashboardSearchConfig;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.restli.common.CollectionResponse;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class DashboardType implements SearchableEntityType<Dashboard> {
+
+    private final Dashboards _dashboardsClient;
+    private static final DashboardSearchConfig DASHBOARDS_SEARCH_CONFIG = new DashboardSearchConfig();
+
+    public DashboardType(final Dashboards dashboardsClient) {
+        _dashboardsClient = dashboardsClient;
+    }
+
+    @Override
+    public EntityType type() {
+        return EntityType.DASHBOARD;
+    }
+
+    @Override
+    public Class<Dashboard> objectClass() {
+        return Dashboard.class;
+    }
+
+    @Override
+    public List<Dashboard> batchLoad(@Nonnull List<String> urns, @Nonnull QueryContext context) throws Exception {
+        final List<DashboardUrn> dashboardUrns = urns.stream()
+                .map(this::getDashboardUrn)
+                .collect(Collectors.toList());
+
+        try {
+            final Map<DashboardUrn, com.linkedin.dashboard.Dashboard> dashboardMap = _dashboardsClient.batchGet(dashboardUrns
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet()));
+
+            final List<com.linkedin.dashboard.Dashboard> gmsResults = new ArrayList<>();
+            for (DashboardUrn urn : dashboardUrns) {
+                gmsResults.add(dashboardMap.getOrDefault(urn, null));
+            }
+            return gmsResults.stream()
+                    .map(gmsDataset -> gmsDataset == null ? null : DashboardMapper.map(gmsDataset))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to batch load Dashboards", e);
+        }
+    }
+
+    @Override
+    public SearchResults search(@Nonnull String query,
+                                @Nullable List<FacetFilterInput> filters,
+                                int start,
+                                int count,
+                                @Nonnull QueryContext context) throws Exception {
+        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, DASHBOARDS_SEARCH_CONFIG.getFacetFields());
+        final CollectionResponse<com.linkedin.dashboard.Dashboard> searchResult = _dashboardsClient.search(query, null, facetFilters, null, start, count);
+        return SearchResultsMapper.map(searchResult, DashboardMapper::map);
+    }
+
+    @Override
+    public AutoCompleteResults autoComplete(@Nonnull String query,
+                                            @Nullable String field,
+                                            @Nullable List<FacetFilterInput> filters,
+                                            int limit,
+                                            @Nonnull QueryContext context) throws Exception {
+        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, DASHBOARDS_SEARCH_CONFIG.getFacetFields());
+        final AutoCompleteResult result = _dashboardsClient.autocomplete(query, field, facetFilters, limit);
+        return AutoCompleteResultsMapper.map(result);
+    }
+
+    private com.linkedin.common.urn.DashboardUrn getDashboardUrn(String urnStr) {
+        try {
+            return DashboardUrn.createFromString(urnStr);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(String.format("Failed to retrieve dashboard with urn %s, invalid urn", urnStr));
+        }
+    }
+
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
@@ -59,6 +59,11 @@ public class DatasetType implements SearchableEntityType<Dataset>, BrowsableEnti
     }
 
     @Override
+    public Class<DatasetUpdateInput> inputClass() {
+        return DatasetUpdateInput.class;
+    }
+
+    @Override
     public EntityType type() {
         return EntityType.DATASET;
     }
@@ -141,11 +146,6 @@ public class DatasetType implements SearchableEntityType<Dataset>, BrowsableEnti
     public List<BrowsePath> browsePaths(@Nonnull String urn, @Nonnull final QueryContext context) throws Exception {
         final StringArray result = _datasetsClient.getBrowsePaths(DatasetUtils.getDatasetUrn(urn));
         return BrowsePathsMapper.map(result);
-    }
-
-    @Override
-    public Class<DatasetUpdateInput> inputClass() {
-        return DatasetUpdateInput.class;
     }
 
     @Override

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/ChartMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/ChartMapper.java
@@ -1,0 +1,75 @@
+package com.linkedin.datahub.graphql.types.mappers;
+
+import com.linkedin.datahub.graphql.generated.AccessLevel;
+import com.linkedin.datahub.graphql.generated.Chart;
+import com.linkedin.datahub.graphql.generated.ChartInfo;
+import com.linkedin.datahub.graphql.generated.ChartQuery;
+import com.linkedin.datahub.graphql.generated.ChartQueryType;
+import com.linkedin.datahub.graphql.generated.Dataset;
+import com.linkedin.datahub.graphql.generated.EntityType;
+
+import javax.annotation.Nonnull;
+import java.util.stream.Collectors;
+
+public class ChartMapper implements ModelMapper<com.linkedin.dashboard.Chart, Chart> {
+
+    public static final ChartMapper INSTANCE = new ChartMapper();
+
+    public static Chart map(@Nonnull final com.linkedin.dashboard.Chart chart) {
+        return INSTANCE.apply(chart);
+    }
+
+    @Override
+    public Chart apply(@Nonnull final com.linkedin.dashboard.Chart chart) {
+        final Chart result = new Chart();
+        result.setUrn(chart.getUrn().toString());
+        result.setType(EntityType.CHART);
+        result.setChartId(chart.getChartId());
+        result.setTool(chart.getTool());
+        if (chart.hasInfo()) {
+            result.setInfo(mapChartInfo(chart.getInfo()));
+        }
+        if (chart.hasQuery()) {
+            result.setQuery(mapChartQuery(chart.getQuery()));
+        }
+        if (chart.hasOwnership()) {
+            result.setOwnership(OwnershipMapper.map(chart.getOwnership()));
+        }
+        if (chart.hasStatus()) {
+            result.setStatus(StatusMapper.map(chart.getStatus()));
+        }
+        return result;
+    }
+
+    private ChartInfo mapChartInfo(final com.linkedin.chart.ChartInfo info) {
+        final ChartInfo result = new ChartInfo();
+        result.setDescription(info.getDescription());
+        result.setTitle(info.getTitle());
+        result.setLastRefreshed(info.getLastRefreshed());
+        result.setInputs(info.getInputs().stream().map(input -> {
+            final Dataset dataset = new Dataset();
+            dataset.setUrn(input.getDatasetUrn().toString());
+            return dataset;
+        }).collect(Collectors.toList()));
+
+        if (info.hasAccess()) {
+            result.setAccess(AccessLevel.valueOf(info.getAccess().toString()));
+        }
+        if (info.hasChartUrl()) {
+            result.setUrl(info.getChartUrl().toString());
+        }
+        result.setLastModified(AuditStampMapper.map(info.getLastModified().getLastModified()));
+        result.setCreated(AuditStampMapper.map(info.getLastModified().getCreated()));
+        if (info.getLastModified().hasDeleted()) {
+            result.setDeleted(AuditStampMapper.map(info.getLastModified().getDeleted()));
+        }
+        return result;
+    }
+
+    private ChartQuery mapChartQuery(final com.linkedin.chart.ChartQuery query) {
+        final ChartQuery result = new ChartQuery();
+        result.setRawQuery(query.getRawQuery());
+        result.setType(ChartQueryType.valueOf(query.getType().toString()));
+        return result;
+    }
+}

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/DashboardMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/DashboardMapper.java
@@ -1,0 +1,63 @@
+package com.linkedin.datahub.graphql.types.mappers;
+
+import com.linkedin.datahub.graphql.generated.AccessLevel;
+import com.linkedin.datahub.graphql.generated.Chart;
+import com.linkedin.datahub.graphql.generated.Dashboard;
+import com.linkedin.datahub.graphql.generated.DashboardInfo;
+import com.linkedin.datahub.graphql.generated.EntityType;
+
+import javax.annotation.Nonnull;
+import java.util.stream.Collectors;
+
+public class DashboardMapper implements ModelMapper<com.linkedin.dashboard.Dashboard, Dashboard> {
+
+    public static final DashboardMapper INSTANCE = new DashboardMapper();
+
+    public static Dashboard map(@Nonnull final com.linkedin.dashboard.Dashboard dashboard) {
+        return INSTANCE.apply(dashboard);
+    }
+
+    @Override
+    public Dashboard apply(@Nonnull final com.linkedin.dashboard.Dashboard dashboard) {
+        final Dashboard result = new Dashboard();
+        result.setUrn(dashboard.getUrn().toString());
+        result.setType(EntityType.DASHBOARD);
+        result.setDashboardId(dashboard.getDashboardId());
+        result.setTool(dashboard.getTool());
+        if (dashboard.hasInfo()) {
+            result.setInfo(mapDashboardInfo(dashboard.getInfo()));
+        }
+        if (dashboard.hasOwnership()) {
+            result.setOwnership(OwnershipMapper.map(dashboard.getOwnership()));
+        }
+        if (dashboard.hasStatus()) {
+            result.setStatus(StatusMapper.map(dashboard.getStatus()));
+        }
+        return result;
+    }
+
+    private DashboardInfo mapDashboardInfo(final com.linkedin.dashboard.DashboardInfo info) {
+        final DashboardInfo result = new DashboardInfo();
+        result.setDescription(info.getDescription());
+        result.setTitle(info.getTitle());
+        result.setLastRefreshed(info.getLastRefreshed());
+        result.setCharts(info.getCharts().stream().map(urn -> {
+            final Chart chart = new Chart();
+            chart.setUrn(urn.toString());
+            return chart;
+        }).collect(Collectors.toList()));
+
+        if (info.hasAccess()) {
+            result.setAccess(AccessLevel.valueOf(info.getAccess().toString()));
+        }
+        if (info.hasDashboardUrl()) {
+            result.setUrl(info.getDashboardUrl().toString());
+        }
+        result.setLastModified(AuditStampMapper.map(info.getLastModified().getLastModified()));
+        result.setCreated(AuditStampMapper.map(info.getLastModified().getCreated()));
+        if (info.getLastModified().hasDeleted()) {
+            result.setDeleted(AuditStampMapper.map(info.getLastModified().getDeleted()));
+        }
+        return result;
+    }
+}

--- a/datahub-graphql-core/src/main/resources/gms.graphql
+++ b/datahub-graphql-core/src/main/resources/gms.graphql
@@ -1153,9 +1153,19 @@ type DashboardInfo {
     lastRefreshed: Long
 
     """
+    An AuditStamp corresponding to the creation of this dashboard
+    """
+    created: AuditStamp!
+
+    """
     An AuditStamp corresponding to the modification of this dashboard
     """
     lastModified: AuditStamp!
+
+    """
+    An optional AuditStamp corresponding to the deletion of this dashboard
+    """
+    deleted: AuditStamp
 }
 
 enum AccessLevel {
@@ -1249,9 +1259,19 @@ type ChartInfo {
     lastRefreshed: Long
 
     """
+    An AuditStamp corresponding to the creation of this chart
+    """
+    created: AuditStamp!
+
+    """
     An AuditStamp corresponding to the modification of this chart
     """
     lastModified: AuditStamp!
+
+    """
+    An optional AuditStamp corresponding to the deletion of this chart
+    """
+    deleted: AuditStamp
 }
 
 enum ChartType {

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/Chart.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/Chart.pdl
@@ -1,5 +1,6 @@
 namespace com.linkedin.dashboard
 
+import com.linkedin.common.ChartUrn
 import com.linkedin.chart.ChartInfo
 import com.linkedin.chart.ChartQuery
 import com.linkedin.common.Ownership
@@ -9,6 +10,11 @@ import com.linkedin.common.Status
  * Metadata for a chart
  */
 record Chart includes ChartKey {
+
+  /**
+   * Chart urn
+   */
+  urn: ChartUrn
 
   /**
    * Basic chart information

--- a/gms/api/src/main/pegasus/com/linkedin/dashboard/Dashboard.pdl
+++ b/gms/api/src/main/pegasus/com/linkedin/dashboard/Dashboard.pdl
@@ -1,5 +1,6 @@
 namespace com.linkedin.dashboard
 
+import com.linkedin.common.DashboardUrn
 import com.linkedin.common.Ownership
 import com.linkedin.common.Status
 
@@ -7,6 +8,11 @@ import com.linkedin.common.Status
  * Metadata for a dashboard
  */
 record Dashboard includes DashboardKey {
+
+  /**
+   * Dashboard urn
+   */
+  urn: DashboardUrn
 
   /**
    * Basic dashboard information

--- a/gms/api/src/main/snapshot/com.linkedin.chart.charts.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.chart.charts.snapshot.json
@@ -342,6 +342,10 @@
       } ]
     } ],
     "fields" : [ {
+      "name" : "urn",
+      "type" : "com.linkedin.common.ChartUrn",
+      "doc" : "Chart urn"
+    }, {
       "name" : "info",
       "type" : "com.linkedin.chart.ChartInfo",
       "doc" : "Basic chart information",

--- a/gms/api/src/main/snapshot/com.linkedin.dashboard.dashboards.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dashboard.dashboards.snapshot.json
@@ -254,6 +254,10 @@
       } ]
     } ],
     "fields" : [ {
+      "name" : "urn",
+      "type" : "com.linkedin.common.DashboardUrn",
+      "doc" : "Dashboard urn"
+    }, {
       "name" : "info",
       "type" : {
         "type" : "record",

--- a/gms/client/src/main/java/com/linkedin/chart/client/Charts.java
+++ b/gms/client/src/main/java/com/linkedin/chart/client/Charts.java
@@ -1,0 +1,124 @@
+package com.linkedin.chart.client;
+
+import com.linkedin.chart.ChartsDoAutocompleteRequestBuilder;
+import com.linkedin.chart.ChartsFindBySearchRequestBuilder;
+import com.linkedin.chart.ChartsRequestBuilders;
+import com.linkedin.common.urn.ChartUrn;
+import com.linkedin.dashboard.Chart;
+import com.linkedin.dashboard.ChartKey;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.configs.ChartSearchConfig;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.metadata.restli.BaseSearchableClient;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.BatchGetEntityRequest;
+import com.linkedin.restli.client.Client;
+import com.linkedin.restli.client.GetRequest;
+import com.linkedin.restli.common.CollectionResponse;
+import com.linkedin.restli.common.ComplexResourceKey;
+import com.linkedin.restli.common.EmptyRecord;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+
+public class Charts extends BaseSearchableClient<Chart> {
+
+    private static final ChartsRequestBuilders CHARTS_REQUEST_BUILDERS = new ChartsRequestBuilders();
+    private static final ChartSearchConfig CHARTS_SEARCH_CONFIG = new ChartSearchConfig();
+
+    public Charts(@Nonnull Client restliClient) {
+        super(restliClient);
+    }
+
+    @Nonnull
+    public Chart get(@Nonnull ChartUrn urn)
+            throws RemoteInvocationException {
+        GetRequest<Chart> getRequest = CHARTS_REQUEST_BUILDERS.get()
+                .id(new ComplexResourceKey<>(toChartKey(urn), new EmptyRecord()))
+                .build();
+
+        return _client.sendRequest(getRequest).getResponse().getEntity();
+    }
+
+    @Nonnull
+    public Map<ChartUrn, Chart> batchGet(@Nonnull Set<ChartUrn> urns)
+            throws RemoteInvocationException {
+        BatchGetEntityRequest<ComplexResourceKey<ChartKey, EmptyRecord>, Chart> batchGetRequest
+                = CHARTS_REQUEST_BUILDERS.batchGet()
+                .ids(urns.stream().map(this::getKeyFromUrn).collect(Collectors.toSet()))
+                .build();
+
+        return _client.sendRequest(batchGetRequest).getResponseEntity().getResults()
+                .entrySet().stream().collect(Collectors.toMap(
+                        entry -> getUrnFromKey(entry.getKey()),
+                        entry -> entry.getValue().getEntity())
+                );
+    }
+
+    @Nonnull
+    @Override
+    public CollectionResponse<Chart> search(@Nonnull String input,
+                                                @Nullable StringArray aspectNames,
+                                                @Nullable Map<String, String> requestFilters,
+                                                @Nullable SortCriterion sortCriterion,
+                                                int start,
+                                                int count)
+            throws RemoteInvocationException {
+        final ChartsFindBySearchRequestBuilder requestBuilder = CHARTS_REQUEST_BUILDERS.findBySearch()
+                .aspectsParam(aspectNames)
+                .inputParam(input)
+                .sortParam(sortCriterion)
+                .paginate(start, count);
+        if (requestFilters != null) {
+            requestBuilder.filterParam(newFilter(requestFilters));
+        }
+        return _client.sendRequest(requestBuilder.build()).getResponse().getEntity();
+    }
+
+    @Nonnull
+    public CollectionResponse<Chart> search(@Nonnull String input, int start, int count)
+            throws RemoteInvocationException {
+        return search(input, null, null, start, count);
+    }
+
+    @Nonnull
+    @Override
+    public AutoCompleteResult autocomplete(@Nonnull String query, @Nullable String field, @Nonnull Map<String, String> requestFilters, int limit)
+            throws RemoteInvocationException {
+        final String autocompleteField = (field != null) ? field : CHARTS_SEARCH_CONFIG.getDefaultAutocompleteField();
+        ChartsDoAutocompleteRequestBuilder requestBuilder = CHARTS_REQUEST_BUILDERS
+                .actionAutocomplete()
+                .queryParam(query)
+                .fieldParam(autocompleteField)
+                .filterParam(newFilter(requestFilters))
+                .limitParam(limit);
+
+        return _client.sendRequest(requestBuilder.build()).getResponse().getEntity();
+    }
+
+    @Nonnull
+    private ComplexResourceKey<ChartKey, EmptyRecord> getKeyFromUrn(@Nonnull ChartUrn urn) {
+        return new ComplexResourceKey<>(toChartKey(urn), new EmptyRecord());
+    }
+
+    @Nonnull
+    private ChartUrn getUrnFromKey(@Nonnull ComplexResourceKey<ChartKey, EmptyRecord> key) {
+        return toChartUrn(key.getKey());
+    }
+
+    @Nonnull
+    private ChartKey toChartKey(@Nonnull ChartUrn urn) {
+        return new ChartKey().setTool(urn.getDashboardToolEntity()).setChartId(urn.getChartIdEntity());
+    }
+
+    @Nonnull
+    private ChartUrn toChartUrn(@Nonnull ChartKey key) {
+        return new ChartUrn(key.getTool(), key.getChartId());
+    }
+}

--- a/gms/client/src/main/java/com/linkedin/dashboard/client/Dashboards.java
+++ b/gms/client/src/main/java/com/linkedin/dashboard/client/Dashboards.java
@@ -1,0 +1,124 @@
+package com.linkedin.dashboard.client;
+
+import com.linkedin.common.urn.DashboardUrn;
+import com.linkedin.dashboard.Dashboard;
+import com.linkedin.dashboard.DashboardKey;
+import com.linkedin.dashboard.DashboardsDoAutocompleteRequestBuilder;
+import com.linkedin.dashboard.DashboardsFindBySearchRequestBuilder;
+import com.linkedin.dashboard.DashboardsRequestBuilders;
+import com.linkedin.data.template.StringArray;
+import com.linkedin.metadata.configs.DashboardSearchConfig;
+import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.SortCriterion;
+import com.linkedin.metadata.restli.BaseSearchableClient;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.BatchGetEntityRequest;
+import com.linkedin.restli.client.Client;
+import com.linkedin.restli.client.GetRequest;
+import com.linkedin.restli.common.CollectionResponse;
+import com.linkedin.restli.common.ComplexResourceKey;
+import com.linkedin.restli.common.EmptyRecord;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+
+public class Dashboards extends BaseSearchableClient<Dashboard> {
+
+    private static final DashboardsRequestBuilders DASHBOARDS_REQUEST_BUILDERS = new DashboardsRequestBuilders();
+    private static final DashboardSearchConfig DASHBOARDS_SEARCH_CONFIG = new DashboardSearchConfig();
+
+    public Dashboards(@Nonnull Client restliClient) {
+        super(restliClient);
+    }
+
+    @Nonnull
+    public Dashboard get(@Nonnull DashboardUrn urn)
+            throws RemoteInvocationException {
+        GetRequest<Dashboard> getRequest = DASHBOARDS_REQUEST_BUILDERS.get()
+                .id(new ComplexResourceKey<>(toDashboardsKey(urn), new EmptyRecord()))
+                .build();
+
+        return _client.sendRequest(getRequest).getResponse().getEntity();
+    }
+
+    @Nonnull
+    public Map<DashboardUrn, Dashboard> batchGet(@Nonnull Set<DashboardUrn> urns)
+            throws RemoteInvocationException {
+        BatchGetEntityRequest<ComplexResourceKey<DashboardKey, EmptyRecord>, Dashboard> batchGetRequest
+                = DASHBOARDS_REQUEST_BUILDERS.batchGet()
+                .ids(urns.stream().map(this::getKeyFromUrn).collect(Collectors.toSet()))
+                .build();
+
+        return _client.sendRequest(batchGetRequest).getResponseEntity().getResults()
+                .entrySet().stream().collect(Collectors.toMap(
+                        entry -> getUrnFromKey(entry.getKey()),
+                        entry -> entry.getValue().getEntity())
+                );
+    }
+
+    @Nonnull
+    @Override
+    public CollectionResponse<Dashboard> search(@Nonnull String input,
+                                                @Nullable StringArray aspectNames,
+                                                @Nullable Map<String, String> requestFilters,
+                                                @Nullable SortCriterion sortCriterion,
+                                                int start,
+                                                int count)
+            throws RemoteInvocationException {
+        final DashboardsFindBySearchRequestBuilder requestBuilder = DASHBOARDS_REQUEST_BUILDERS.findBySearch()
+                .aspectsParam(aspectNames)
+                .inputParam(input)
+                .sortParam(sortCriterion)
+                .paginate(start, count);
+        if (requestFilters != null) {
+            requestBuilder.filterParam(newFilter(requestFilters));
+        }
+        return _client.sendRequest(requestBuilder.build()).getResponse().getEntity();
+    }
+
+    @Nonnull
+    public CollectionResponse<Dashboard> search(@Nonnull String input, int start, int count)
+            throws RemoteInvocationException {
+        return search(input, null, null, start, count);
+    }
+
+    @Nonnull
+    @Override
+    public AutoCompleteResult autocomplete(@Nonnull String query, @Nullable String field, @Nonnull Map<String, String> requestFilters, int limit)
+            throws RemoteInvocationException {
+        final String autocompleteField = (field != null) ? field : DASHBOARDS_SEARCH_CONFIG.getDefaultAutocompleteField();
+        DashboardsDoAutocompleteRequestBuilder requestBuilder = DASHBOARDS_REQUEST_BUILDERS
+                .actionAutocomplete()
+                .queryParam(query)
+                .fieldParam(autocompleteField)
+                .filterParam(newFilter(requestFilters))
+                .limitParam(limit);
+
+        return _client.sendRequest(requestBuilder.build()).getResponse().getEntity();
+    }
+
+    @Nonnull
+    private ComplexResourceKey<DashboardKey, EmptyRecord> getKeyFromUrn(@Nonnull DashboardUrn urn) {
+        return new ComplexResourceKey<>(toDashboardsKey(urn), new EmptyRecord());
+    }
+
+    @Nonnull
+    private DashboardUrn getUrnFromKey(@Nonnull ComplexResourceKey<DashboardKey, EmptyRecord> key) {
+        return toDashboardsUrn(key.getKey());
+    }
+
+    @Nonnull
+    private DashboardKey toDashboardsKey(@Nonnull DashboardUrn urn) {
+        return new DashboardKey().setTool(urn.getDashboardToolEntity()).setDashboardId(urn.getDashboardIdEntity());
+    }
+
+    @Nonnull
+    private DashboardUrn toDashboardsUrn(@Nonnull DashboardKey key) {
+        return new DashboardUrn(key.getTool(), key.getDashboardId());
+    }
+}

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dashboard/Charts.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dashboard/Charts.java
@@ -105,6 +105,7 @@ public class Charts extends BaseSearchableEntityResource<
   @Override
   protected Chart toValue(@Nonnull ChartSnapshot snapshot) {
     final Chart value = new Chart()
+        .setUrn(snapshot.getUrn())
         .setTool(snapshot.getUrn().getDashboardToolEntity())
         .setChartId(snapshot.getUrn().getChartIdEntity());
     ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/dashboard/Dashboards.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/dashboard/Dashboards.java
@@ -104,6 +104,7 @@ public class Dashboards extends BaseSearchableEntityResource<
   @Override
   protected Dashboard toValue(@Nonnull DashboardSnapshot snapshot) {
     final Dashboard value = new Dashboard()
+        .setUrn(snapshot.getUrn())
         .setTool(snapshot.getUrn().getDashboardToolEntity())
         .setDashboardId(snapshot.getUrn().getDashboardIdEntity());
     ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {

--- a/metadata-ingestion-examples/mce-cli/example-bootstrap.json
+++ b/metadata-ingestion-examples/mce-cli/example-bootstrap.json
@@ -411,6 +411,109 @@
           ]
         }
       }
+    },
+    {
+      "proposedSnapshot": {
+        "com.linkedin.metadata.snapshot.ChartSnapshot": {
+          "urn": "urn:li:chart:(Looker,1)",
+          "aspects": [
+            {
+              "com.linkedin.chart.ChartInfo": {
+                "title": "Sample Looker Chart",
+                "description": "This chart contains sample data from Kafka",
+                "lastModified": {
+                  "lastModified": {
+                    "time": 1581407189000,
+                    "actor": "urn:li:corpuser:datahub"
+                  },
+                  "created": {
+                    "time": 1581407189000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                "inputs": [
+                  {
+                    "string": "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"
+                  }
+                ],
+                "chartUrl": "https://www.looker.com",
+                "type": "BAR",
+                "access": "PUBLIC"
+              }
+            },
+            {
+              "com.linkedin.chart.ChartQuery": {
+                "rawQuery": "SELECT * FROM SampleTable",
+                "type": "SQL"
+              }
+            },
+            {
+              "com.linkedin.common.Ownership": {
+                "owners": [
+                  {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "STAKEHOLDER"
+                  },
+                  {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "DATAOWNER"
+                  }
+                ],
+                "lastModified": {
+                  "time": 1581407589000,
+                  "actor": "urn:li:corpuser:datahub"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "proposedSnapshot": {
+        "com.linkedin.metadata.snapshot.DashboardSnapshot": {
+          "urn": "urn:li:dashboard:(Looker,0)",
+          "aspects": [
+            {
+              "com.linkedin.dashboard.DashboardInfo": {
+                "title": "Sample Looker Dashboard",
+                "description": "This dashboard shows charts about user retention.",
+                "lastModified": {
+                  "lastModified": {
+                    "time": 1581407139000,
+                    "actor": "urn:li:corpuser:datahub"
+                  },
+                  "created": {
+                    "time": 1581404189000,
+                    "actor": "urn:li:corpuser:jdoe"
+                  }
+                },
+                "charts": [ "urn:li:chart:(Looker,1)" ],
+                "dashboardUrl": "https://www.looker.com",
+                "access": "PUBLIC"
+              }
+            },
+            {
+              "com.linkedin.common.Ownership": {
+                "owners": [
+                  {
+                    "owner": "urn:li:corpuser:datahub",
+                    "type": "DATAOWNER"
+                  },
+                  {
+                    "owner": "urn:li:corpuser:jdoe",
+                    "type": "STAKEHOLDER"
+                  }
+                ],
+                "lastModified": {
+                  "time": 1581407389000,
+                  "actor": "urn:li:corpuser:jdoe"
+                }
+              }
+            }
+          ]
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
**Scope**
This PR primarily is scoped to the GQL API within`datahub-graphql-core`. 

However, there are a few changes at GMS layer: 
- updated value PDLs for Chart + Dashboard to add their respective URNs. Other value models do include urns, so I've added for consistency (and to avoid the client having to know how to construct urns). 
- implemented gms "client" classes for Dashboards and Charts.

**Changes**
1. Added GraphQL implementation in datahub-graphql-core. 
2. Added Dashboards GMS client
3. Added Charts GMS client
4. Added URN field to Dashboard.pdl and Chart.pdl (These models are not available via the frontend and had no client previously so I don't think anyone is actively using them)
5. Added mock entity dashboard / chart entities to the ingestion example dataset. 

**Validation**
Tested via manual post requests. See examples below. 

**Dashboards**
Query:
```
query dashboard($urn: String!) {
    dashboard(urn: $urn) {
        urn
        type
        tool
        dashboardId
        tool
        info {
            title
            description
            charts {
                urn
                info {
                    title 
                    description
                }
            }
            url
            access
            lastRefreshed
            created {
                time
            }
            lastModified {
                time
            }
        }
        ownership {
            owners {
                owner {
                    urn
                }
                type
                source {
                    type
                    url
                }
            }
            lastModified {
                time
            }
        }
    }
}
```

variables: 
```
{
    "urn": "urn:li:dashboard:(Looker,0)"
}
```

result: 
```
{"data":{"dashboard":{"urn":"urn:li:dashboard:(Looker,0)","type":"DASHBOARD","tool":"Looker","dashboardId":"0","info":{"title":"Sample Looker Dashboard","description":"This dashboard shows charts about user retention.","charts":[{"urn":"urn:li:chart:(Looker,1)","info":{"title":"Sample Looker Chart","description":"This chart contains sample data from Kafka"}}],"url":"https://www.looker.com","access":"PUBLIC","lastRefreshed":null,"created":{"time":1581404189000},"lastModified":{"time":1581407139000}},"ownership":{"owners":[{"owner":{"urn":"urn:li:corpuser:datahub"},"type":"DATAOWNER","source":null},{"owner":{"urn":"urn:li:corpuser:jdoe"},"type":"STAKEHOLDER","source":null}],"lastModified":{"time":1581407389000}}}}}
```

**Charts**
Query
```
query chart($urn: String!) {
    chart(urn: $urn) {
        urn
        type
        tool
        chartId
        info {
            title
            description
            inputs {
                urn
                name
            }
            url
            type
            access
            lastRefreshed
            lastModified {
                time
            }
            created {
                time
            }
        }
        query {
            rawQuery
            type
        }
        ownership {
            owners {
                owner {
                    urn
                }
                type
                source {
                    type
                    url
                }
            }
            lastModified {
                time
            }
        }
    }
}
```

variables: 
```
{
    "urn": "urn:li:chart:(Looker,1)"
}
```

result:
```
{"data":{"chart":{"urn":"urn:li:chart:(Looker,1)","type":"CHART","tool":"Looker","chartId":"1","info":{"title":"Sample Looker Chart","description":"This chart contains sample data from Kafka","inputs":[{"urn":"urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)","name":"SampleKafkaDataset"}],"url":"https://www.looker.com","type":null,"access":"PUBLIC","lastRefreshed":null,"lastModified":{"time":1581407189000},"created":{"time":1581407189000}},"query":{"rawQuery":"SELECT * FROM SampleTable","type":"SQL"},"ownership":{"owners":[{"owner":{"urn":"urn:li:corpuser:datahub"},"type":"STAKEHOLDER","source":null},{"owner":{"urn":"urn:li:corpuser:jdoe"},"type":"DATAOWNER","source":null}],"lastModified":{"time":1581407589000}}}}}
```



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
