### PR TITLE
bug(docker react): Fix react docker image build

### DIFF
--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -54,4 +54,4 @@ jobs:
           repository: linkedin/datahub-frontend
           tags: ${{ needs.setup.outputs.tag }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
-          build_args: ENABLE_REACT=true,PORT=9002
+          build_args: SERVER_PORT=9002,ENABLE_REACT=true

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -22,6 +22,8 @@ RUN chown -R datahub:datahub /datahub-frontend && chmod 755 /datahub-frontend
 USER datahub
 
 ARG SERVER_PORT=9001
+RUN echo $SERVER_PORT
+
 EXPOSE $SERVER_PORT
 
 ENV JAVA_OPTS=" \

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk:8 as builder
 
-ARG ENABLE_REACT
-ARG PORT
+ARG ENABLE_REACT false
 
 RUN apt-get update && apt-get install -y wget \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
@@ -21,15 +20,17 @@ RUN addgroup -S datahub && adduser -S datahub -G datahub
 COPY --from=builder /datahub-frontend /datahub-frontend/
 RUN chown -R datahub:datahub /datahub-frontend && chmod 755 /datahub-frontend
 USER datahub
-EXPOSE ${PORT:-9001}
+
+ARG SERVER_PORT 9001
+EXPOSE $SERVER_PORT
 
 ENV JAVA_OPTS=" \
-	-Xms512m \
-	-Xmx1024m \
-	-Dhttp.port=${PORT:-9001} \
-	-Dconfig.file=datahub-frontend/conf/application.conf \
-	-Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf \
-	-Dlogback.configurationFile=datahub-frontend/conf/logback.xml \
-	-Dlogback.debug=true \
-	-Dpidfile.path=/datahub-frontend/play.pid"
+   -Xms512m \
+   -Xmx1024m \
+   -Dhttp.port=$SERVER_PORT \
+   -Dconfig.file=datahub-frontend/conf/application.conf \
+   -Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf \
+   -Dlogback.configurationFile=datahub-frontend/conf/logback.xml \
+   -Dlogback.debug=true \
+   -Dpidfile.path=/datahub-frontend/play.pid"
 CMD ["datahub-frontend/bin/playBinary"]

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8 as builder
 
-ARG ENABLE_REACT false
+ARG ENABLE_REACT="false"
 
 RUN apt-get update && apt-get install -y wget \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
@@ -21,7 +21,7 @@ COPY --from=builder /datahub-frontend /datahub-frontend/
 RUN chown -R datahub:datahub /datahub-frontend && chmod 755 /datahub-frontend
 USER datahub
 
-ARG SERVER_PORT 9001
+ARG SERVER_PORT=9001
 EXPOSE $SERVER_PORT
 
 ENV JAVA_OPTS=" \

--- a/docker/docker-compose.react.yml
+++ b/docker/docker-compose.react.yml
@@ -7,8 +7,8 @@ services:
       context: ../
       dockerfile: docker/datahub-frontend/Dockerfile
       args:
+        SERVER_PORT: 9002
         ENABLE_REACT: "true"
-        PORT: 9002
     image: linkedin/datahub-frontend:react-${DATAHUB_VERSION:-latest}
     env_file: datahub-frontend/env/docker.env
     hostname: datahub-frontend-react


### PR DESCRIPTION
A build arg syntax issue is causing the `datahub-frontend:react` image to ignore the correct port arg (defaulting to 9001 instead of 9002). This PR should resolve the issue.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
