### PR TITLE
fix(React): Adding test coverage for search page & fixing filter select bug

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -1,15 +1,20 @@
 import { GetDatasetDocument, UpdateDatasetDocument } from './graphql/dataset.generated';
 import { GetBrowsePathsDocument, GetBrowseResultsDocument } from './graphql/browse.generated';
-import { GetAutoCompleteResultsDocument, GetSearchResultsDocument } from './graphql/search.generated';
+import {
+    GetAutoCompleteResultsDocument,
+    GetSearchResultsDocument,
+    GetSearchResultsQuery,
+} from './graphql/search.generated';
 import { LoginDocument } from './graphql/auth.generated';
 import { GetUserDocument } from './graphql/user.generated';
-import { EntityType } from './types.generated';
+import { Dataset, EntityType } from './types.generated';
 
 const user1 = {
-    username: 'sdas',
     urn: 'urn:li:corpuser:2',
     type: EntityType.CorpUser,
     info: {
+        username: 'sdas',
+        email: 'sdas@domain.com',
         active: true,
         displayName: 'sdas',
         title: 'Software Engineer',
@@ -27,6 +32,7 @@ const user2 = {
     urn: 'urn:li:corpuser:3',
     type: EntityType.CorpUser,
     info: {
+        email: 'john@domain.com',
         active: true,
         displayName: 'john',
         title: 'Eng',
@@ -184,7 +190,7 @@ const dataset3 = {
             time: 0,
         },
     },
-};
+} as Dataset;
 
 /*
     Define mock data to be returned by Apollo MockProvider. 
@@ -440,7 +446,7 @@ export const mocks = [
                         },
                     ],
                 },
-            },
+            } as GetSearchResultsQuery,
         },
     },
     {
@@ -455,7 +461,7 @@ export const mocks = [
                     filters: [
                         {
                             field: 'platform',
-                            value: 'Kafka',
+                            value: 'kafka',
                         },
                     ],
                 },
@@ -463,32 +469,96 @@ export const mocks = [
         },
         result: {
             data: {
+                __typename: 'Query',
                 search: {
+                    __typename: 'SearchResults',
                     start: 0,
                     count: 1,
                     total: 1,
                     entities: [
                         {
-                            __typename: 'Dataset',
                             ...dataset3,
                         },
                     ],
                     facets: [
                         {
                             field: 'origin',
-                            aggregations: [{ value: 'PROD', count: 3 }],
+                            aggregations: [
+                                {
+                                    value: 'PROD',
+                                    count: 3,
+                                },
+                            ],
                         },
                         {
                             field: 'platform',
                             aggregations: [
-                                { value: 'HDFS', count: 1 },
-                                { value: 'MySQL', count: 1 },
-                                { value: 'Kafka', count: 1 },
+                                { value: 'hdfs', count: 1 },
+                                { value: 'mysql', count: 1 },
+                                { value: 'kafka', count: 1 },
                             ],
                         },
                     ],
                 },
+            } as GetSearchResultsQuery,
+        },
+    },
+    {
+        request: {
+            query: GetSearchResultsDocument,
+            variables: {
+                input: {
+                    type: 'DATASET',
+                    query: 'test',
+                    start: 0,
+                    count: 10,
+                    filters: [
+                        {
+                            field: 'platform',
+                            value: 'kafka',
+                        },
+                        {
+                            field: 'platform',
+                            value: 'hdfs',
+                        },
+                    ],
+                },
             },
+        },
+        result: {
+            data: {
+                __typename: 'Query',
+                search: {
+                    __typename: 'SearchResults',
+                    start: 0,
+                    count: 1,
+                    total: 1,
+                    entities: [
+                        {
+                            ...dataset3,
+                        },
+                    ],
+                    facets: [
+                        {
+                            field: 'origin',
+                            aggregations: [
+                                {
+                                    value: 'PROD',
+                                    count: 3,
+                                },
+                            ],
+                        },
+                        {
+                            field: 'platform',
+                            aggregations: [
+                                { value: 'hdfs', count: 1 },
+                                { value: 'mysql', count: 1 },
+                                { value: 'kafka', count: 1 },
+                            ],
+                        },
+                    ],
+                },
+            } as GetSearchResultsQuery,
         },
     },
     {

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -10,10 +10,10 @@ import { GetUserDocument } from './graphql/user.generated';
 import { Dataset, EntityType } from './types.generated';
 
 const user1 = {
+    username: 'sdas',
     urn: 'urn:li:corpuser:2',
     type: EntityType.CorpUser,
     info: {
-        username: 'sdas',
         email: 'sdas@domain.com',
         active: true,
         displayName: 'sdas',

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -76,5 +76,5 @@ export default function SchemaView({ schema }: Props) {
         return [...defaultColumns, ...categoryColumns];
     }, [schema]);
 
-    return <Table pagination={false} dataSource={schema?.fields} columns={columns} />;
+    return <Table pagination={false} dataSource={schema?.fields} columns={columns} rowKey="fieldPath" />;
 }

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -56,7 +56,9 @@ export const SearchBar = ({
         >
             <Select value={activeType} style={{ marginRight: '12px', width: 250 }} onChange={onTypeChange}>
                 {types.map((t) => (
-                    <Option value={t}>{t}</Option>
+                    <Option key={t} value={t}>
+                        {t}
+                    </Option>
                 ))}
             </Select>
             <AutoComplete

--- a/datahub-web-react/src/app/search/SearchFilters.tsx
+++ b/datahub-web-react/src/app/search/SearchFilters.tsx
@@ -28,13 +28,14 @@ export const SearchFilters = ({ facets, selectedFilters, onFilterSelect }: Props
             bodyStyle={{ padding: '24px 0px' }}
         >
             {facets.map((facet) => (
-                <div style={{ padding: '0px 25px 15px 25px' }}>
+                <div key={facet.field} style={{ padding: '0px 25px 15px 25px' }}>
                     <div style={{ fontWeight: 'bold', marginBottom: '10px' }}>
                         {facet.field.charAt(0).toUpperCase() + facet.field.slice(1)}
                     </div>
                     {facet.aggregations.map((aggregation) => (
-                        <>
+                        <span key={`${facet.field}-${aggregation.value}`}>
                             <Checkbox
+                                data-testid={`facet-${facet.field}-${aggregation.value}`}
                                 style={{ margin: '5px 0px' }}
                                 checked={
                                     selectedFilters.find(
@@ -48,7 +49,7 @@ export const SearchFilters = ({ facets, selectedFilters, onFilterSelect }: Props
                                 {aggregation.value} ({aggregation.count})
                             </Checkbox>
                             <br />
-                        </>
+                        </span>
                     ))}
                 </div>
             ))}

--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -29,7 +29,7 @@ export const SearchPage = () => {
     const entityRegistry = useEntityRegistry();
     const searchTypes = entityRegistry.getSearchEntityTypes();
 
-    const params = QueryString.parse(location.search);
+    const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
     const selectedType = entityRegistry.getTypeOrDefaultFromPathName(
         useParams<SearchPageParams>().type || '',
         undefined,

--- a/datahub-web-react/src/app/search/__tests__/SearchPage.test.tsx
+++ b/datahub-web-react/src/app/search/__tests__/SearchPage.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+
+import { SearchPage } from '../SearchPage';
+import TestPageContainer from '../../../utils/test-utils/TestPageContainer';
+import { mocks } from '../../../Mocks';
+
+describe('SearchPage', () => {
+    it('renders', () => {
+        render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/search/dataset?filter_platform=hive,kafka&page=1&query=sample']}>
+                    <SearchPage />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+    });
+
+    it('renders loading', () => {
+        const { getByText } = render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/search/dataset?filter_platform=hive,kafka&page=1&query=sample']}>
+                    <SearchPage />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+        expect(getByText('Loading')).toBeInTheDocument();
+    });
+
+    it('renders the selected filters as checked', async () => {
+        const { getByTestId, queryByTestId } = render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/search/dataset?filter_platform=kafka&page=1&query=test']}>
+                    <SearchPage />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+
+        await waitFor(() => expect(queryByTestId('facet-platform-kafka')).toBeInTheDocument());
+
+        const kafkaPlatformBox = getByTestId('facet-platform-kafka');
+        expect(kafkaPlatformBox).toHaveProperty('checked', true);
+
+        const hdfsPlatformBox = getByTestId('facet-platform-hdfs');
+        expect(hdfsPlatformBox).toHaveProperty('checked', false);
+
+        const prodOriginBox = getByTestId('facet-origin-PROD');
+        expect(prodOriginBox).toHaveProperty('checked', false);
+    });
+
+    it('renders multiple checked filters at once', async () => {
+        const { getByTestId, queryByTestId } = render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/search/dataset?filter_platform=kafka,hdfs&page=1&query=test']}>
+                    <SearchPage />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+
+        await waitFor(() => expect(queryByTestId('facet-platform-kafka')).toBeInTheDocument());
+
+        const kafkaPlatformBox = getByTestId('facet-platform-kafka');
+        expect(kafkaPlatformBox).toHaveProperty('checked', true);
+
+        const hdfsPlatformBox = getByTestId('facet-platform-hdfs');
+        expect(hdfsPlatformBox).toHaveProperty('checked', true);
+
+        const prodOriginBox = getByTestId('facet-origin-PROD');
+        expect(prodOriginBox).toHaveProperty('checked', false);
+    });
+
+    it('clicking a filter selects a new filter', async () => {
+        const { getByTestId, queryByTestId, queryByText } = render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/search/dataset?filter_platform=kafka&page=1&query=test']}>
+                    <SearchPage />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+
+        await waitFor(() => expect(queryByTestId('facet-platform-kafka')).toBeInTheDocument());
+
+        const kafkaPlatformBox = getByTestId('facet-platform-kafka');
+        expect(kafkaPlatformBox).toHaveProperty('checked', true);
+
+        const hdfsPlatformBox = getByTestId('facet-platform-hdfs');
+        expect(hdfsPlatformBox).toHaveProperty('checked', false);
+
+        expect(queryByText('Loading')).not.toBeInTheDocument();
+        fireEvent.click(hdfsPlatformBox);
+        expect(queryByText('Loading')).toBeInTheDocument();
+
+        await waitFor(() => expect(queryByTestId('facet-platform-kafka')).toBeInTheDocument());
+
+        const kafkaPlatformBox2 = getByTestId('facet-platform-kafka');
+        expect(kafkaPlatformBox2).toHaveProperty('checked', true);
+
+        const hdfsPlatformBox2 = getByTestId('facet-platform-hdfs');
+        expect(hdfsPlatformBox2).toHaveProperty('checked', true);
+    });
+});

--- a/datahub-web-react/src/utils/test-utils/TestPageContainer.tsx
+++ b/datahub-web-react/src/utils/test-utils/TestPageContainer.tsx
@@ -8,6 +8,7 @@ import { EntityRegistryContext } from '../../entityRegistryContext';
 
 type Props = {
     children: React.ReactNode;
+    initialEntries?: string[];
 };
 
 export function getTestEntityRegistry() {
@@ -17,11 +18,11 @@ export function getTestEntityRegistry() {
     return entityRegistry;
 }
 
-export default ({ children }: Props) => {
+export default ({ children, initialEntries }: Props) => {
     const entityRegistry = useMemo(() => getTestEntityRegistry(), []);
 
     return (
-        <MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>
             <EntityRegistryContext.Provider value={entityRegistry}>{children}</EntityRegistryContext.Provider>
         </MemoryRouter>
     );


### PR DESCRIPTION
This PR

Introduces tests for search facet filtering
Fixes mock search data so it can be used properly with tests, and enforcing that it will stay correct in the future
Fixes bug where selecting multiple filters provides a broken UI experience.
Fixes key warnings across other tests

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
