### PR TITLE
feat(React): Add URL link to dashboard / chart page

### DIFF
--- a/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Space, Tooltip, Typography } from 'antd';
+import { Avatar, Button, Row, Space, Tooltip, Typography } from 'antd';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { AuditStamp, EntityType, Ownership } from '../../../../types.generated';
@@ -10,16 +10,20 @@ export type Props = {
     description?: string;
     ownership?: Ownership | null;
     lastModified?: AuditStamp;
+    url?: string | null;
 };
 
-export default function ChartHeader({ platform, description, ownership, lastModified }: Props) {
+export default function ChartHeader({ platform, description, ownership, url, lastModified }: Props) {
     const entityRegistry = useEntityRegistry();
 
     return (
         <>
-            <Typography.Title level={5} style={{ color: 'gray' }}>
-                {platform}
-            </Typography.Title>
+            <Row justify="space-between">
+                <Typography.Title level={5} style={{ color: 'gray' }}>
+                    {platform}
+                </Typography.Title>
+                {url && <Button href={url}>View in {platform}</Button>}
+            </Row>
             <Typography.Paragraph>{description}</Typography.Paragraph>
             <Space direction="vertical">
                 <Avatar.Group maxCount={6} size="large">

--- a/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
@@ -37,6 +37,7 @@ export default function ChartProfile({ urn }: { urn: string }) {
             platform={chart.tool}
             ownership={chart.ownership}
             lastModified={chart.info?.lastModified}
+            url={chart.info?.url}
         />
     );
 

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardHeader.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardHeader.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Space, Tooltip, Typography } from 'antd';
+import { Avatar, Button, Row, Space, Tooltip, Typography } from 'antd';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { AuditStamp, EntityType, Ownership } from '../../../../types.generated';
@@ -10,16 +10,19 @@ export type Props = {
     description?: string;
     ownership?: Ownership | null;
     lastModified?: AuditStamp;
+    url?: string | null;
 };
 
-export default function DashboardHeader({ platform, description, ownership, lastModified }: Props) {
+export default function DashboardHeader({ platform, description, ownership, url, lastModified }: Props) {
     const entityRegistry = useEntityRegistry();
-
     return (
         <>
-            <Typography.Title level={5} style={{ color: 'gray' }}>
-                {platform}
-            </Typography.Title>
+            <Row justify="space-between">
+                <Typography.Title level={5} style={{ color: 'gray' }}>
+                    {platform}
+                </Typography.Title>
+                {url && <Button href={url}>View in {platform}</Button>}
+            </Row>
             <Typography.Paragraph>{description}</Typography.Paragraph>
             <Space direction="vertical">
                 <Avatar.Group maxCount={6} size="large">

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
@@ -40,6 +40,7 @@ export default function DashboardProfile({ urn }: { urn: string }) {
             platform={dashboard.tool}
             ownership={dashboard.ownership}
             lastModified={dashboard.info?.lastModified}
+            url={dashboard.info?.url}
         />
     );
 


### PR DESCRIPTION
**Scope**
This change only impacts the React app. 

**Changes**
Simply add a button to Chart / Dashboard profile that redirects user to the chart / dashboard link. See screenshots below. 

<img width="1440" alt="Screen Shot 2021-02-22 at 9 29 51 PM" src="https://user-images.githubusercontent.com/17549204/108806049-84771a00-7555-11eb-8a7d-2e960b110afd.png">
<img width="1440" alt="Screen Shot 2021-02-22 at 9 30 50 PM" src="https://user-images.githubusercontent.com/17549204/108806053-86d97400-7555-11eb-903b-09ada1219d66.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
