### PR TITLE
refactor(docker-dev): set up elasticsearch using local mapping on docker-compose.dev

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -11,6 +11,18 @@
 # TODO mount + debug docker file for frontend
 version: '3.8'
 services:
+  # Pre-creates the search indices using local mapping/settings.json
+  elasticsearch-setup:
+    image: elasticsearch-setup:debug
+    build:
+      context: elasticsearch-setup
+      dockerfile: Dockerfile
+      args:
+        APP_ENV: dev
+    volumes:
+      - ./elasticsearch-setup/create-indices.sh:/create-indices.sh
+      - ../gms/impl/src/main/resources/index/:/index
+
   datahub-gms:
     image: linkedin/datahub-gms:debug
     build:

--- a/docker/elasticsearch-setup/Dockerfile
+++ b/docker/elasticsearch-setup/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache curl jq
 
 FROM base AS prod-install
 
-COPY docker/elasticsearch-setup/create-indices.sh /index
+COPY docker/elasticsearch-setup/create-indices.sh /
 RUN chmod 755 create-indices.sh
 COPY gms/impl/src/main/resources/index /index
 

--- a/docker/elasticsearch-setup/Dockerfile
+++ b/docker/elasticsearch-setup/Dockerfile
@@ -1,10 +1,21 @@
 # This "container" is a workaround to pre-create search indices
-FROM jwilder/dockerize:0.6.1
+
+# Defining environment
+ARG APP_ENV=prod
+
+FROM jwilder/dockerize:0.6.1 AS base
 
 RUN apk add --no-cache curl jq
 
-COPY docker/elasticsearch-setup/create-indices.sh /
-RUN chmod 755 create-indices.sh
-COPY gms/impl/src/main/resources/index /
+FROM base AS prod-install
 
+COPY docker/elasticsearch-setup/create-indices.sh /index
+RUN chmod 755 create-indices.sh
+COPY gms/impl/src/main/resources/index /index
+
+FROM base AS dev-install
+# Dummy stage for development. Use local files for setup
+# See this excellent thread https://github.com/docker/cli/issues/1134
+
+FROM ${APP_ENV}-install as final
 CMD dockerize -wait http://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT -timeout 120s /create-indices.sh

--- a/docker/elasticsearch-setup/Dockerfile
+++ b/docker/elasticsearch-setup/Dockerfile
@@ -17,5 +17,5 @@ FROM base AS dev-install
 # Dummy stage for development. Use local files for setup
 # See this excellent thread https://github.com/docker/cli/issues/1134
 
-FROM ${APP_ENV}-install as final
+FROM ${APP_ENV}-install AS final
 CMD dockerize -wait http://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT -timeout 120s /create-indices.sh

--- a/docker/elasticsearch-setup/create-indices.sh
+++ b/docker/elasticsearch-setup/create-indices.sh
@@ -4,8 +4,8 @@ set -e
 
 function create_index {
   jq -n \
-    --slurpfile settings $2 \
-    --slurpfile mappings $3 \
+    --slurpfile settings index/$2 \
+    --slurpfile mappings index/$3 \
     '.settings=$settings[0] | .mappings.doc=$mappings[0]' > /tmp/data
 
   curl -XPUT $ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT/$1 --data @/tmp/data


### PR DESCRIPTION
Make it easy to test mapping/setting.json changes by adding an elasticsearch-setup:debug image to docker-compose.dev.yml 

The overridden elasticsearch-setup container mounts the local mapping/setting.json files and uses them to create indices. 
Followed the method used in the dev setup for gms/mae-consumer/mce-consumer containers

**Test**
`./docker/dev.sh` runs correctly and confirmed that the local changes to mappings got picked up
Running the prod path by doing the following (Thanks @jplaisted)
```
cd docker
./nuke.sh # start from scratch to really verify things
docker compose pull # pull latest images
docker image rm docker_elasticsearch-setup # delete pulled image
docker-compose build elasticsearch-setup # rebuild image
docker-compose -p datahub up # launch docker without pulling
```
ran correctly as well. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
