### PR TITLE
fix(GraphQL): Fixing required Dataset audit stamps bug 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/DatasetMapper.java
@@ -35,13 +35,7 @@ public class DatasetMapper implements ModelMapper<com.linkedin.dataset.Dataset, 
         partialPlatform.setUrn(dataset.getPlatform().toString());
         result.setPlatform(partialPlatform);
 
-        // TODO: Modify GMS to return created, lastModified at the top level as contract requires.
         if (dataset.hasSchemaMetadata()) {
-            result.setCreated(AuditStampMapper.map(dataset.getSchemaMetadata().getCreated()));
-            result.setLastModified(AuditStampMapper.map(dataset.getSchemaMetadata().getLastModified()));
-            if (dataset.getSchemaMetadata().hasDeleted()) {
-                result.setDeleted(AuditStampMapper.map(dataset.getSchemaMetadata().getDeleted()));
-            }
             result.setSchema(SchemaMetadataMapper.map(dataset.getSchemaMetadata()));
         }
         if (dataset.hasPlatformNativeType()) {

--- a/datahub-graphql-core/src/main/resources/gms.graphql
+++ b/datahub-graphql-core/src/main/resources/gms.graphql
@@ -190,21 +190,6 @@ type Dataset implements Entity {
     Downstream Lineage metadata of the dataset
     """
     downstreamLineage: DownstreamLineage
-
-    """
-    An AuditStamp corresponding to the creation of this Dataset
-    """
-    created: AuditStamp!
-
-    """
-    An AuditStamp corresponding to the modification of this Dataset
-    """
-    lastModified: AuditStamp!
-
-    """
-    An optional AuditStamp corresponding to the deletion of this Dataset
-    """
-    deleted: AuditStamp
 }
 
 type DataPlatform implements Entity {

--- a/datahub-web-react/src/app/entity/dataset/profile/stories/sampleDataset.ts
+++ b/datahub-web-react/src/app/entity/dataset/profile/stories/sampleDataset.ts
@@ -12,8 +12,6 @@ export const sampleDataset: Dataset = {
     origin: FabricType.Prod,
     description: 'Some description',
     type: EntityType.Dataset,
-    created: { time: 1 },
-    lastModified: { time: 1 },
     tags: [],
     ownership: {
         owners: [
@@ -35,8 +33,6 @@ export const sampleDeprecatedDataset: Dataset = {
     origin: FabricType.Prod,
     description: 'Some deprecated description',
     type: EntityType.Dataset,
-    created: { time: 1 },
-    lastModified: { time: 1 },
     tags: [],
     ownership: {
         owners: [

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -17,9 +17,6 @@ query getChart($urn: String!) {
                 }
                 platformNativeType
                 tags
-                lastModified {
-                    time
-                }
                 ownership {
                     owners {
                         owner {

--- a/datahub-web-react/src/graphql/dataset.graphql
+++ b/datahub-web-react/src/graphql/dataset.graphql
@@ -14,12 +14,6 @@ fragment nonRecursiveDatasetFields on Dataset {
         key
         value
     }
-    created {
-        time
-    }
-    lastModified {
-        time
-    }
     ownership {
         owners {
             owner {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -27,12 +27,6 @@ query getSearchResults($input: SearchInput!) {
                     key
                     value
                 }
-                created {
-                    time
-                }
-                lastModified {
-                    time
-                }
                 ownership {
                     owners {
                         owner {


### PR DESCRIPTION
This fixes a bug in the GraphQL API where Dataset model had required "created" and "lastModified" timestamps. This was initially modeled as such because it was based off of the [Dataset.pdl](https://github.com/linkedin/datahub/blob/master/gms/api/src/main/pegasus/com/linkedin/dataset/Dataset.pdl) model, which includes ChangeAuditStamp _which are never populated_. 

In order to populate, we were incorrectly using the SchemaMetadata timestamps, which will break reads if SchemaMetadata has not been provided for a Dataset. Fixing by removing these timestamps from the Dataset GQL model to match [Dataset.pdl](https://github.com/linkedin/datahub/blob/master/gms/api/src/main/pegasus/com/linkedin/dataset/Dataset.pdl) served by GMS. 

Note that these fields were not actively consumed by any client (eg. React or beyond), so this change will not break anyone. 

**Acknowledgements**

Thanks to Brendan from GeoTab for identifying this!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
