### PR TITLE
Switch GMA dep from bintray to artifactory.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.junitJupiterVersion = '5.6.1'
-  ext.gmaVersion = '0.2.44'
+  ext.gmaVersion = '0.2.45'
   ext.pegasusVersion = '28.3.7'
 
   apply from: './repositories.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.junitJupiterVersion = '5.6.1'
-  ext.gmaVersion = '0.2.41'
+  ext.gmaVersion = '0.2.44'
   ext.pegasusVersion = '28.3.7'
 
   apply from: './repositories.gradle'

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -13,7 +13,10 @@ repositories {
         url "https://plugins.gradle.org/m2/"
     }
     maven {
-        url "https://linkedin.bintray.com/maven/"
+        url "https://linkedin.jfrog.io/artifactory/open-source/" // GMA
+    }
+    maven {
+        url "https://linkedin.bintray.com/maven/" // pegasus
     }
 }
 


### PR DESCRIPTION
Bintray is set for deprecation and EoL in a few months.

We still need bintray for pegasus until restli team migrates off of it.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
