### PR TITLE
fix(react): fixing format we propagate filters to graphql in

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -516,11 +516,7 @@ export const mocks = [
                     filters: [
                         {
                             field: 'platform',
-                            value: 'kafka',
-                        },
-                        {
-                            field: 'platform',
-                            value: 'hdfs',
+                            value: 'kafka,hdfs',
                         },
                     ],
                 },

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -43,7 +43,6 @@ export class DatasetEntity implements Entity<Dataset> {
     renderProfile = (urn: string) => <Profile urn={urn} />;
 
     renderPreview = (_: PreviewType, data: Dataset) => {
-        console.log(data);
         return (
             <Preview
                 urn={data.urn}

--- a/datahub-web-react/src/app/search/EntitySearchResults.tsx
+++ b/datahub-web-react/src/app/search/EntitySearchResults.tsx
@@ -8,6 +8,7 @@ import { IconStyleType } from '../entity/Entity';
 import { Message } from '../shared/Message';
 import { useEntityRegistry } from '../useEntityRegistry';
 import { SearchFilters } from './SearchFilters';
+import { filtersToGraphqlParams } from './utils/filtersToGraphqlParams';
 
 const styles = {
     loading: { marginTop: '10%' },
@@ -44,7 +45,7 @@ export const EntitySearchResults = ({ type, query, page, filters, onChangeFilter
                 query,
                 start: (page - 1) * SearchCfg.RESULTS_PER_PAGE,
                 count: SearchCfg.RESULTS_PER_PAGE,
-                filters,
+                filters: filtersToGraphqlParams(filters),
             },
         },
     });

--- a/datahub-web-react/src/app/search/utils/filtersToGraphqlParams.ts
+++ b/datahub-web-react/src/app/search/utils/filtersToGraphqlParams.ts
@@ -1,0 +1,10 @@
+import { FacetFilterInput } from '../../../types.generated';
+
+export function filtersToGraphqlParams(filters: Array<FacetFilterInput>): Array<FacetFilterInput> {
+    return Object.entries(
+        filters.reduce((acc, filter) => {
+            acc[filter.field] = [...(acc[filter.field] || []), filter.value];
+            return acc;
+        }, {} as Record<string, string[]>),
+    ).map(([field, values]) => ({ field, value: values.join(',') } as FacetFilterInput));
+}


### PR DESCRIPTION
Facet params need to be in a comma separated string in order for multiple to be applied at once. They are propagated directly to elastic search, and this is the format elastic search expects. Updated the test mocks to correctly reflect what elastic expects.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
