### PR TITLE
feat(react): redirecting `/assets` to `/`

### DIFF
--- a/datahub-web-react/src/app/Routes.tsx
+++ b/datahub-web-react/src/app/Routes.tsx
@@ -35,7 +35,6 @@ export const Routes = (): JSX.Element => {
             <Switch>
                 <ProtectedRoute isLoggedIn={isLoggedIn} exact path="/" render={() => <HomePage />} />
                 <Route path={PageRoutes.LOG_IN} component={LogIn} />
-
                 {entityRegistry.getEntities().map((entity) => (
                     <ProtectedRoute
                         key={entity.getPathName()}
@@ -54,6 +53,8 @@ export const Routes = (): JSX.Element => {
                     path={PageRoutes.BROWSE_RESULTS}
                     render={() => <BrowseResultsPage />}
                 />
+                {/* Starting the react app locally opens /assets by default. For a smoother dev experience, we'll redirect to the homepage */}
+                <Route path={PageRoutes.ASSETS} component={() => <Redirect to="/" />} exact />
                 <Route component={NoPageFound} />
             </Switch>
         </div>

--- a/datahub-web-react/src/conf/Global.tsx
+++ b/datahub-web-react/src/conf/Global.tsx
@@ -14,4 +14,5 @@ export enum PageRoutes {
     BROWSE = '/browse',
     BROWSE_RESULTS = '/browse/:type',
     DATASETS = '/datasets',
+    ASSETS = '/assets',
 }


### PR DESCRIPTION
Starting the react app locally opens /assets by default. For a smoother dev experience, we'll redirect /assets to the homepage so developers aren't defaulted to a 404 page.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
