### PR TITLE
feat(ingest): Support alternative authentication in sql ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -52,10 +52,10 @@ class SQLAlchemyConfig(ConfigModel):
 
 
 class BasicSQLAlchemyConfig(SQLAlchemyConfig):
-    username: str = ""
-    password: str = ""
+    username: Optional[str] = None
+    password: Optional[str] = None
     host_port: str
-    database: str = ""
+    database: Optional[str] = None
     scheme: str
 
     def get_sql_alchemy_url(self):

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -52,14 +52,22 @@ class SQLAlchemyConfig(ConfigModel):
 
 
 class BasicSQLAlchemyConfig(SQLAlchemyConfig):
-    username: str
-    password: str
+    username: str = ""
+    password: str = ""
     host_port: str
     database: str = ""
     scheme: str
 
     def get_sql_alchemy_url(self):
-        url = f"{self.scheme}://{self.username}:{self.password}@{self.host_port}/{self.database}"
+        url = f"{self.scheme}://"
+        if self.username:
+            url += f"{self.username}"
+            if self.password:
+                url += f":{self.password}"
+            url += "@"
+        url += f"{self.host_port}"
+        if self.database:
+            url += f"/{self.database}"
         return url
 
 


### PR DESCRIPTION
Makes username/password/database config properties optional to allow sqlachemy to connect with alternative authentication methods such as kerberos.

This was tested by specifying only the mandatory host_port config and then passing extra required properties through the `options` map which is specific to each `<SQL database, Auth Method>` combination.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
