### PR TITLE
fix(GraphQL): Bubbling up exceptions logged in GraphQL resolvers

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/BrowsePathsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/BrowsePathsResolver.java
@@ -37,7 +37,7 @@ public class BrowsePathsResolver implements DataFetcher<CompletableFuture<List<B
                 throw new RuntimeException("Failed to retrieve browse paths: "
                         + String.format("entity type %s, urn %s",
                         input.getType(),
-                        input.getUrn()));
+                        input.getUrn()), e);
             }
         });
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/BrowseResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/BrowseResolver.java
@@ -52,7 +52,7 @@ public class BrowseResolver implements DataFetcher<CompletableFuture<BrowseResul
                         input.getPath(),
                         input.getFilters(),
                         start,
-                        count));
+                        count), e);
             }
         });
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/AutoCompleteResolver.java
@@ -61,7 +61,7 @@ public class AutoCompleteResolver implements DataFetcher<CompletableFuture<AutoC
                                 input.getField(),
                                 input.getQuery(),
                                 input.getFilters(),
-                                input.getLimit()));
+                                input.getLimit()), e);
             }
         });
     }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
@@ -64,7 +64,7 @@ public class SearchResolver implements DataFetcher<CompletableFuture<SearchResul
                         input.getQuery(),
                         input.getFilters(),
                         start,
-                        count));
+                        count), e);
             }
         });
     }


### PR DESCRIPTION
Including underlying exception in GQL resolver exceptions. Useful for debugging.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
