### PR TITLE
feat(React): Impl browse UI for Dashboards and Charts

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -101,7 +101,11 @@ public class ChartType implements SearchableEntityType<Chart>, BrowsableEntityTy
     }
 
     @Override
-    public BrowseResults browse(@Nonnull List<String> path, @Nullable List<FacetFilterInput> filters, int start, int count, @Nonnull QueryContext context) throws Exception {
+    public BrowseResults browse(@Nonnull List<String> path,
+                                @Nullable List<FacetFilterInput> filters,
+                                int start,
+                                int count,
+                                @Nonnull QueryContext context) throws Exception {
         final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, CHART_SEARCH_CONFIG.getFacetFields());
         final String pathStr = path.size() > 0 ? BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path) : "";
         final BrowseResult result = _chartsClient.browse(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -2,19 +2,26 @@ package com.linkedin.datahub.graphql.types.chart;
 
 import com.linkedin.chart.client.Charts;
 import com.linkedin.common.urn.ChartUrn;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.BrowsePath;
+import com.linkedin.datahub.graphql.generated.BrowseResults;
 import com.linkedin.datahub.graphql.generated.Chart;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.BrowsableEntityType;
 import com.linkedin.datahub.graphql.types.SearchableEntityType;
 import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.datahub.graphql.types.mappers.BrowsePathsMapper;
+import com.linkedin.datahub.graphql.types.mappers.BrowseResultMetadataMapper;
 import com.linkedin.datahub.graphql.types.mappers.ChartMapper;
 import com.linkedin.datahub.graphql.types.mappers.SearchResultsMapper;
 import com.linkedin.metadata.configs.ChartSearchConfig;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.BrowseResult;
 import com.linkedin.restli.common.CollectionResponse;
 
 import javax.annotation.Nonnull;
@@ -26,7 +33,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class ChartType implements SearchableEntityType<Chart> {
+import static com.linkedin.datahub.graphql.Constants.BROWSE_PATH_DELIMITER;
+
+public class ChartType implements SearchableEntityType<Chart>, BrowsableEntityType<Chart> {
 
     private final Charts _chartsClient;
     private static final ChartSearchConfig CHART_SEARCH_CONFIG = new ChartSearchConfig();
@@ -62,7 +71,7 @@ public class ChartType implements SearchableEntityType<Chart> {
                 gmsResults.add(chartMap.getOrDefault(urn, null));
             }
             return gmsResults.stream()
-                    .map(gmsDataset -> gmsDataset == null ? null : ChartMapper.map(gmsDataset))
+                    .map(gmsChart -> gmsChart == null ? null : ChartMapper.map(gmsChart))
                     .collect(Collectors.toList());
         } catch (Exception e) {
             throw new RuntimeException("Failed to batch load Charts", e);
@@ -89,6 +98,34 @@ public class ChartType implements SearchableEntityType<Chart> {
         final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, CHART_SEARCH_CONFIG.getFacetFields());
         final AutoCompleteResult result = _chartsClient.autocomplete(query, field, facetFilters, limit);
         return AutoCompleteResultsMapper.map(result);
+    }
+
+    @Override
+    public BrowseResults browse(@Nonnull List<String> path, @Nullable List<FacetFilterInput> filters, int start, int count, @Nonnull QueryContext context) throws Exception {
+        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, CHART_SEARCH_CONFIG.getFacetFields());
+        final String pathStr = path.size() > 0 ? BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path) : "";
+        final BrowseResult result = _chartsClient.browse(
+                pathStr,
+                facetFilters,
+                start,
+                count);
+        final List<String> urns = result.getEntities().stream().map(entity -> entity.getUrn().toString()).collect(Collectors.toList());
+        final List<Chart> charts = batchLoad(urns, context);
+        final BrowseResults browseResults = new BrowseResults();
+        browseResults.setStart(result.getFrom());
+        browseResults.setCount(result.getPageSize());
+        browseResults.setTotal(result.getNumEntities());
+        browseResults.setMetadata(BrowseResultMetadataMapper.map(result.getMetadata()));
+        browseResults.setEntities(charts.stream()
+                .map(chart -> (com.linkedin.datahub.graphql.generated.Entity) chart)
+                .collect(Collectors.toList()));
+        return browseResults;
+    }
+
+    @Override
+    public List<BrowsePath> browsePaths(@Nonnull String urn, @Nonnull QueryContext context) throws Exception {
+        final StringArray result = _chartsClient.getBrowsePaths(getChartUrn(urn));
+        return BrowsePathsMapper.map(result);
     }
 
     private ChartUrn getChartUrn(String urnStr) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -2,19 +2,26 @@ package com.linkedin.datahub.graphql.types.dashboard;
 
 import com.linkedin.common.urn.DashboardUrn;
 import com.linkedin.dashboard.client.Dashboards;
+import com.linkedin.data.template.StringArray;
 import com.linkedin.datahub.graphql.QueryContext;
 import com.linkedin.datahub.graphql.generated.AutoCompleteResults;
+import com.linkedin.datahub.graphql.generated.BrowsePath;
+import com.linkedin.datahub.graphql.generated.BrowseResults;
 import com.linkedin.datahub.graphql.generated.Dashboard;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.datahub.graphql.generated.FacetFilterInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
 import com.linkedin.datahub.graphql.resolvers.ResolverUtils;
+import com.linkedin.datahub.graphql.types.BrowsableEntityType;
 import com.linkedin.datahub.graphql.types.SearchableEntityType;
 import com.linkedin.datahub.graphql.types.mappers.AutoCompleteResultsMapper;
+import com.linkedin.datahub.graphql.types.mappers.BrowsePathsMapper;
+import com.linkedin.datahub.graphql.types.mappers.BrowseResultMetadataMapper;
 import com.linkedin.datahub.graphql.types.mappers.DashboardMapper;
 import com.linkedin.datahub.graphql.types.mappers.SearchResultsMapper;
 import com.linkedin.metadata.configs.DashboardSearchConfig;
 import com.linkedin.metadata.query.AutoCompleteResult;
+import com.linkedin.metadata.query.BrowseResult;
 import com.linkedin.restli.common.CollectionResponse;
 
 import javax.annotation.Nonnull;
@@ -26,7 +33,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class DashboardType implements SearchableEntityType<Dashboard> {
+import static com.linkedin.datahub.graphql.Constants.BROWSE_PATH_DELIMITER;
+
+public class DashboardType implements SearchableEntityType<Dashboard>, BrowsableEntityType<Dashboard> {
 
     private final Dashboards _dashboardsClient;
     private static final DashboardSearchConfig DASHBOARDS_SEARCH_CONFIG = new DashboardSearchConfig();
@@ -62,7 +71,7 @@ public class DashboardType implements SearchableEntityType<Dashboard> {
                 gmsResults.add(dashboardMap.getOrDefault(urn, null));
             }
             return gmsResults.stream()
-                    .map(gmsDataset -> gmsDataset == null ? null : DashboardMapper.map(gmsDataset))
+                    .map(gmsDashboard -> gmsDashboard == null ? null : DashboardMapper.map(gmsDashboard))
                     .collect(Collectors.toList());
         } catch (Exception e) {
             throw new RuntimeException("Failed to batch load Dashboards", e);
@@ -89,6 +98,34 @@ public class DashboardType implements SearchableEntityType<Dashboard> {
         final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, DASHBOARDS_SEARCH_CONFIG.getFacetFields());
         final AutoCompleteResult result = _dashboardsClient.autocomplete(query, field, facetFilters, limit);
         return AutoCompleteResultsMapper.map(result);
+    }
+
+    @Override
+    public BrowseResults browse(@Nonnull List<String> path, @Nullable List<FacetFilterInput> filters, int start, int count, @Nonnull QueryContext context) throws Exception {
+        final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, DASHBOARDS_SEARCH_CONFIG.getFacetFields());
+        final String pathStr = path.size() > 0 ? BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path) : "";
+        final BrowseResult result = _dashboardsClient.browse(
+                pathStr,
+                facetFilters,
+                start,
+                count);
+        final List<String> urns = result.getEntities().stream().map(entity -> entity.getUrn().toString()).collect(Collectors.toList());
+        final List<Dashboard> dashboards = batchLoad(urns, context);
+        final BrowseResults browseResults = new BrowseResults();
+        browseResults.setStart(result.getFrom());
+        browseResults.setCount(result.getPageSize());
+        browseResults.setTotal(result.getNumEntities());
+        browseResults.setMetadata(BrowseResultMetadataMapper.map(result.getMetadata()));
+        browseResults.setEntities(dashboards.stream()
+                .map(dashboard -> (com.linkedin.datahub.graphql.generated.Entity) dashboard)
+                .collect(Collectors.toList()));
+        return browseResults;
+    }
+
+    @Override
+    public List<BrowsePath> browsePaths(@Nonnull String urn, @Nonnull QueryContext context) throws Exception {
+        final StringArray result = _dashboardsClient.getBrowsePaths(getDashboardUrn(urn));
+        return BrowsePathsMapper.map(result);
     }
 
     private com.linkedin.common.urn.DashboardUrn getDashboardUrn(String urnStr) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -101,7 +101,10 @@ public class DashboardType implements SearchableEntityType<Dashboard>, Browsable
     }
 
     @Override
-    public BrowseResults browse(@Nonnull List<String> path, @Nullable List<FacetFilterInput> filters, int start, int count, @Nonnull QueryContext context) throws Exception {
+    public BrowseResults browse(@Nonnull List<String> path,
+                                @Nullable List<FacetFilterInput> filters,
+                                int start, int count,
+                                @Nonnull QueryContext context) throws Exception {
         final Map<String, String> facetFilters = ResolverUtils.buildFacetFilters(filters, DASHBOARDS_SEARCH_CONFIG.getFacetFields());
         final String pathStr = path.size() > 0 ? BROWSE_PATH_DELIMITER + String.join(BROWSE_PATH_DELIMITER, path) : "";
         final BrowseResult result = _dashboardsClient.browse(

--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -32,7 +32,7 @@ export class ChartEntity implements Entity<Chart> {
 
     isSearchEnabled = () => true;
 
-    isBrowseEnabled = () => false;
+    isBrowseEnabled = () => true;
 
     getAutoCompleteFieldName = () => 'title';
 

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -32,7 +32,7 @@ export class DashboardEntity implements Entity<Dashboard> {
 
     isSearchEnabled = () => true;
 
-    isBrowseEnabled = () => false;
+    isBrowseEnabled = () => true;
 
     getAutoCompleteFieldName = () => 'title';
 

--- a/datahub-web-react/src/graphql/browse.graphql
+++ b/datahub-web-react/src/graphql/browse.graphql
@@ -42,6 +42,85 @@ query getBrowseResults($input: BrowseInput!) {
                     }
                 }
             }
+            ... on Dashboard {
+                urn
+                type
+                tool
+                dashboardId
+                info {
+                    name
+                    description
+                    url
+                    access
+                    lastModified {
+                        time
+                    }
+                }
+                ownership {
+                    owners {
+                        owner {
+                            urn
+                            type
+                            username
+                            info {
+                                active
+                                displayName
+                                title
+                                firstName
+                                lastName
+                                fullName
+                            }
+                            editableInfo {
+                                pictureLink
+                            }
+                        }
+                        type
+                    }
+                    lastModified {
+                        time
+                    }
+                }
+            }
+            ... on Chart {
+                urn
+                type
+                tool
+                chartId
+                info {
+                    name
+                    description
+                    url
+                    type
+                    access
+                    lastModified {
+                        time
+                    }
+                }
+                ownership {
+                    owners {
+                        owner {
+                            urn
+                            type
+                            username
+                            info {
+                                active
+                                displayName
+                                title
+                                firstName
+                                lastName
+                                fullName
+                            }
+                            editableInfo {
+                                pictureLink
+                            }
+                        }
+                        type
+                    }
+                    lastModified {
+                        time
+                    }
+                }
+            }
         }
         start
         count

--- a/gms/client/src/main/java/com/linkedin/chart/client/Charts.java
+++ b/gms/client/src/main/java/com/linkedin/chart/client/Charts.java
@@ -51,14 +51,14 @@ public class Charts extends BaseBrowsableClient<Chart, ChartUrn> {
     }
 
     /**
-     * Gets browse path(s) given dataset urn
+     * Gets browse path(s) given a chart urn
      *
      * @param urn urn for the entity
      * @return list of paths given urn
      * @throws RemoteInvocationException
      */
     @Nonnull
-    public StringArray getBrowsePaths(@Nonnull DatasetUrn urn) throws RemoteInvocationException {
+    public StringArray getBrowsePaths(@Nonnull ChartUrn urn) throws RemoteInvocationException {
         ChartsDoGetBrowsePathsRequestBuilder requestBuilder = CHARTS_REQUEST_BUILDERS
             .actionGetBrowsePaths()
             .urnParam(urn);

--- a/gms/client/src/main/java/com/linkedin/chart/client/Charts.java
+++ b/gms/client/src/main/java/com/linkedin/chart/client/Charts.java
@@ -6,7 +6,6 @@ import com.linkedin.chart.ChartsDoGetBrowsePathsRequestBuilder;
 import com.linkedin.chart.ChartsFindBySearchRequestBuilder;
 import com.linkedin.chart.ChartsRequestBuilders;
 import com.linkedin.common.urn.ChartUrn;
-import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.dashboard.Chart;
 import com.linkedin.dashboard.ChartKey;
 import com.linkedin.data.template.StringArray;

--- a/gms/client/src/main/java/com/linkedin/dashboard/client/Dashboards.java
+++ b/gms/client/src/main/java/com/linkedin/dashboard/client/Dashboards.java
@@ -1,7 +1,6 @@
 package com.linkedin.dashboard.client;
 
 import com.linkedin.common.urn.DashboardUrn;
-import com.linkedin.common.urn.DatasetUrn;
 import com.linkedin.dashboard.Dashboard;
 import com.linkedin.dashboard.DashboardKey;
 import com.linkedin.dashboard.DashboardsDoAutocompleteRequestBuilder;
@@ -58,7 +57,7 @@ public class Dashboards extends BaseBrowsableClient<Dashboard, DashboardUrn> {
      * @throws RemoteInvocationException
      */
     @Nonnull
-    public StringArray getBrowsePaths(@Nonnull DatasetUrn urn) throws RemoteInvocationException {
+    public StringArray getBrowsePaths(@Nonnull DashboardUrn urn) throws RemoteInvocationException {
         DashboardsDoGetBrowsePathsRequestBuilder requestBuilder = DASHBOARDS_REQUEST_BUILDERS
             .actionGetBrowsePaths()
             .urnParam(urn);


### PR DESCRIPTION
**Scope**
These changes are limited to datahub-frontend GraphQL API and the React app.

**Changes**
This PR implements the UI for Browse Charts and Dashboards. It builds on[ Dexters PR](https://github.com/linkedin/datahub/pull/2143) that implemented this functionality on the GMS side. 
- Make ChartType, DashboardType a BrowsableType. 
- Extend client side browse query to include Charts, Dashboards. 
- Fix minor URN type bug in GMS client. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
