### PR TITLE
docs: point to hosted docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,3 @@
-# DataHub: A Generalized Metadata Search & Discovery Tool
-[![Version](https://img.shields.io/github/v/release/linkedin/datahub?include_prereleases)](https://github.com/linkedin/datahub/releases)
-[![build & test](https://github.com/linkedin/datahub/workflows/build%20&%20test/badge.svg?branch=master&event=push)](https://github.com/linkedin/datahub/actions?query=workflow%3A%22build+%26+test%22+branch%3Amaster+event%3Apush)
-[![Docker Pulls](https://img.shields.io/docker/pulls/linkedin/datahub-gms.svg)](https://hub.docker.com/r/linkedin/datahub-gms)
-[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/datahubspace/shared_invite/zt-dkzbxfck-dzNl96vBzB06pJpbRwP6RA)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md)
-[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/linkedin/datahub)](https://github.com/linkedin/datahub/pulls?q=is%3Apr)
-[![License](https://img.shields.io/github/license/linkedin/datahub)](https://github.com/linkedin/datahub/blob/master/LICENSE)
-
----
-
-[Quickstart](docs/quickstart.md) |
-[Documentation](https://datahubproject.io/docs/) |
-[Features](docs/features.md) |
-[Roadmap](docs/roadmap.md) |
-[Adoption](#adoption) |
-[FAQ](docs/faq.md) |
-[Town Hall](docs/townhalls.md)
-
----
 
 <!--HOSTED_DOCS_ONLY
 import ThemedImage from '@theme/ThemedImage';
@@ -42,8 +22,33 @@ export const Logo = (props) => {
 
 <!--
 HOSTED_DOCS_ONLY-->
-![DataHub](docs/imgs/datahub-logo.png)
+<p align="center">
+<img alt="DataHub" src="docs/imgs/datahub-logo.png" height="200px" />
+</p>
 <!-- -->
+
+# DataHub: A Generalized Metadata Search & Discovery Tool
+
+[![Version](https://img.shields.io/github/v/release/linkedin/datahub?include_prereleases)](https://github.com/linkedin/datahub/releases)
+[![build & test](https://github.com/linkedin/datahub/workflows/build%20&%20test/badge.svg?branch=master&event=push)](https://github.com/linkedin/datahub/actions?query=workflow%3A%22build+%26+test%22+branch%3Amaster+event%3Apush)
+[![Docker Pulls](https://img.shields.io/docker/pulls/linkedin/datahub-gms.svg)](https://hub.docker.com/r/linkedin/datahub-gms)
+[![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](https://join.slack.com/t/datahubspace/shared_invite/zt-dkzbxfck-dzNl96vBzB06pJpbRwP6RA)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/linkedin/datahub)](https://github.com/linkedin/datahub/pulls?q=is%3Apr)
+[![License](https://img.shields.io/github/license/linkedin/datahub)](https://github.com/linkedin/datahub/blob/master/LICENSE)
+
+---
+
+[Quickstart](https://datahubproject.io/docs/quickstart) |
+[Documentation](https://datahubproject.io/docs/) |
+[Features](https://datahubproject.io/docs/features) |
+[Roadmap](https://datahubproject.io/docs/roadmap) |
+[Adoption](#adoption) |
+[FAQ](https://datahubproject.io/docs/faq) |
+[Demo](https://datahubproject.io/docs/demo) |
+[Town Hall](https://datahubproject.io/docs/townhalls)
+
+---
 
 > 📣 Next DataHub town hall meeting on Mar 19th, 7am-8am PDT ([convert to your local time](https://greenwichmeantime.com/time/to/pacific-local/))
 > - Topic Proposals: [submit here](https://docs.google.com/forms/d/1v2ynbAXjJlqY97xE_X1DAntNrXDznOFiNfryUkMPtkI/)
@@ -68,9 +73,9 @@ Please follow the [DataHub Quickstart Guide](docs/quickstart.md) to get a copy o
 
 ## Demo and Screenshots
 
-There's a [hosted demo environment](docs/demo.md) where you can play around with DataHub before installing.
+There's a [hosted demo environment](https://datahubproject.io/docs/demo) where you can play around with DataHub before installing.
 
-[![DataHub Demo GIF](docs/imgs/demo_large.gif)](docs/demo.md)
+[![DataHub Demo GIF](docs/imgs/demo_large.gif)](https://datahubproject.io/docs/demo)
 
 ## Source Code and Repositories
 * [linkedin/datahub](https://github.com/linkedin/datahub): This repository contains the complete source code for both DataHub's frontend & backend services. We currently follow a hybrid open source model for development in this repository. See [this blog post](https://engineering.linkedin.com/blog/2020/open-sourcing-datahub--linkedins-metadata-search-and-discovery-p) for details on how we do it. 

--- a/docs-website/README.md
+++ b/docs-website/README.md
@@ -11,7 +11,9 @@ yarn install
 ## Local Development
 
 ```console
-yarn start
+yarn run lint
+yarn run generate
+yarn run start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -107,28 +107,27 @@ function markdown_add_edit_url(
   contents.data.custom_edit_url = editUrl;
 }
 
-const reverse_slug_cache: Record<string, string> = {};
-
 function markdown_add_slug(
   contents: matter.GrayMatterFile<string>,
   filepath: string
 ): void {
-  if (!contents.data.slug) {
-    const slug = get_slug(filepath);
-    contents.data.slug = slug;
+  if (contents.data.slug) {
+    return;
   }
 
-  reverse_slug_cache[contents.data.slug] = filepath;
+  const slug = get_slug(filepath);
+  contents.data.slug = slug;
 }
 
 function new_url(original: string, filepath: string): string {
+  if (original.toLowerCase().startsWith(HOSTED_SITE_URL)) {
+    // For absolute links to the hosted docs site, we transform them into local ones.
+    // Note that HOSTED_SITE_URL does not have a trailing slash, so after the replacement,
+    // the url will start with a slash.
+    return original.replace(HOSTED_SITE_URL, "");
+  }
+
   if (original.startsWith("http://") || original.startsWith("https://")) {
-    if (original.toLowerCase().startsWith(HOSTED_SITE_URL)) {
-      // For absolute links to the hosted docs site, we transform them into local ones.
-      // Note that HOSTED_SITE_URL does not have a trailing slash, so after the replacement,
-      // the url will start with a slash.
-      return original.replace(HOSTED_SITE_URL, "");
-    }
     if (
       (original
         .toLowerCase()

--- a/docs-website/generateDocsDir.ts
+++ b/docs-website/generateDocsDir.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 // Note: this must be executed within the docs-website directory.
 
 // Constants.
+const HOSTED_SITE_URL = "https://datahubproject.io";
 const GITHUB_EDIT_URL = "https://github.com/linkedin/datahub/blob/master";
 const GITHUB_BROWSE_URL = "https://github.com/linkedin/datahub/blob/master";
 
@@ -68,6 +69,7 @@ function get_slug(filepath: string): string {
 
 const hardcoded_titles = {
   "README.md": "Introduction",
+  "docs/demo.md": "Demo",
 };
 
 function markdown_guess_title(
@@ -105,20 +107,28 @@ function markdown_add_edit_url(
   contents.data.custom_edit_url = editUrl;
 }
 
+const reverse_slug_cache: Record<string, string> = {};
+
 function markdown_add_slug(
   contents: matter.GrayMatterFile<string>,
   filepath: string
 ): void {
-  if (contents.data.slug) {
-    return;
+  if (!contents.data.slug) {
+    const slug = get_slug(filepath);
+    contents.data.slug = slug;
   }
 
-  const slug = get_slug(filepath);
-  contents.data.slug = slug;
+  reverse_slug_cache[contents.data.slug] = filepath;
 }
 
 function new_url(original: string, filepath: string): string {
   if (original.startsWith("http://") || original.startsWith("https://")) {
+    if (original.toLowerCase().startsWith(HOSTED_SITE_URL)) {
+      // For absolute links to the hosted docs site, we transform them into local ones.
+      // Note that HOSTED_SITE_URL does not have a trailing slash, so after the replacement,
+      // the url will start with a slash.
+      return original.replace(HOSTED_SITE_URL, "");
+    }
     if (
       (original
         .toLowerCase()

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,8 +1,3 @@
----
-title: "Demo"
-hide_title: true
----
-
 # DataHub Demo Environment
 
 We have a hosted demo environment available, kindly provided by [Acryl](https://acryl.io/).


### PR DESCRIPTION
Streamlines the readme and points links towards the hosted docs site.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
