### PR TITLE
feat(react): adding raw schema view option for table schemas

### DIFF
--- a/datahub-web-react/.eslintrc.js
+++ b/datahub-web-react/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
         'no-plusplus': 'off',
         'no-prototype-builtins': 'off',
         'react/require-default-props': 'off',
+        'no-underscore-dangle': 'off',
         '@typescript-eslint/no-unused-vars': [
             'error',
             {

--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/Schema.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/Schema.test.tsx
@@ -28,13 +28,13 @@ describe('Schema', () => {
         expect(queryAllByTestId('icon-STRING')).toHaveLength(2);
         expect(queryAllByTestId('schema-raw-view')).toHaveLength(0);
 
-        const rawButton = getByText('View Raw');
+        const rawButton = getByText('Raw');
         fireEvent.click(rawButton);
 
         expect(queryAllByTestId('icon-STRING')).toHaveLength(0);
         expect(queryAllByTestId('schema-raw-view')).toHaveLength(1);
 
-        const schemaButton = getByText('View Schema');
+        const schemaButton = getByText('Tabular');
         fireEvent.click(schemaButton);
 
         expect(queryAllByTestId('icon-STRING')).toHaveLength(2);

--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/Schema.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/Schema.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import Schema from '../schema/Schema';
 import TestPageContainer from '../../../../../utils/test-utils/TestPageContainer';
 import { sampleSchema } from '../stories/sampleSchema';
@@ -16,5 +16,28 @@ describe('Schema', () => {
         expect(getByText('shipping_address')).toBeInTheDocument();
         expect(getByText('the address the order ships to')).toBeInTheDocument();
         expect(queryAllByTestId('icon-STRING')).toHaveLength(2);
+    });
+
+    it('renders raw', () => {
+        const { getByText, queryAllByTestId } = render(
+            <TestPageContainer>
+                <Schema schema={sampleSchema} />
+            </TestPageContainer>,
+        );
+
+        expect(queryAllByTestId('icon-STRING')).toHaveLength(2);
+        expect(queryAllByTestId('schema-raw-view')).toHaveLength(0);
+
+        const rawButton = getByText('View Raw');
+        fireEvent.click(rawButton);
+
+        expect(queryAllByTestId('icon-STRING')).toHaveLength(0);
+        expect(queryAllByTestId('schema-raw-view')).toHaveLength(1);
+
+        const schemaButton = getByText('View Schema');
+        fireEvent.click(schemaButton);
+
+        expect(queryAllByTestId('icon-STRING')).toHaveLength(2);
+        expect(queryAllByTestId('schema-raw-view')).toHaveLength(0);
     });
 });

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -18,7 +18,7 @@ const BadgeGroup = styled.div`
 const ViewRawButtonContainer = styled.div`
     display: flex;
     justify-content: flex-end;
-    padding-bottom: 8px;
+    padding-bottom: 16px;
 `;
 
 export type Props = {
@@ -88,9 +88,7 @@ export default function SchemaView({ schema }: Props) {
         <>
             {schema?.platformSchema?.__typename === 'TableSchema' && (
                 <ViewRawButtonContainer>
-                    <Button type="link" onClick={() => setShowRaw(!showRaw)}>
-                        {showRaw ? 'View Schema' : 'View Raw'}
-                    </Button>
+                    <Button onClick={() => setShowRaw(!showRaw)}>{showRaw ? 'Tabular' : 'Raw'}</Button>
                 </ViewRawButtonContainer>
             )}
             {showRaw ? (

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
-import { Table, Typography } from 'antd';
+import { Button, Table, Typography } from 'antd';
 import { AlignType } from 'rc-table/lib/interface';
 import styled from 'styled-components';
 
@@ -13,6 +13,12 @@ import { Schema, SchemaField, SchemaFieldDataType } from '../../../../../types.g
 const BadgeGroup = styled.div`
     margin-top: 4px;
     margin-left: -4px;
+`;
+
+const ViewRawButtonContainer = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    padding-bottom: 8px;
 `;
 
 export type Props = {
@@ -76,5 +82,29 @@ export default function SchemaView({ schema }: Props) {
         return [...defaultColumns, ...categoryColumns];
     }, [schema]);
 
-    return <Table pagination={false} dataSource={schema?.fields} columns={columns} rowKey="fieldPath" />;
+    const [showRaw, setShowRaw] = useState(false);
+
+    return (
+        <>
+            {schema?.platformSchema?.__typename === 'TableSchema' && (
+                <ViewRawButtonContainer>
+                    <Button type="link" onClick={() => setShowRaw(!showRaw)}>
+                        {showRaw ? 'View Schema' : 'View Raw'}
+                    </Button>
+                </ViewRawButtonContainer>
+            )}
+            {showRaw ? (
+                <Typography.Text data-testid="schema-raw-view">
+                    <pre>
+                        <code>
+                            {schema?.platformSchema?.__typename === 'TableSchema' &&
+                                JSON.stringify(JSON.parse(schema.platformSchema.schema), null, 2)}
+                        </code>
+                    </pre>
+                </Typography.Text>
+            ) : (
+                <Table pagination={false} dataSource={schema?.fields} columns={columns} rowKey="fieldPath" />
+            )}
+        </>
+    );
 }

--- a/datahub-web-react/src/app/entity/dataset/profile/stories/sampleSchema.ts
+++ b/datahub-web-react/src/app/entity/dataset/profile/stories/sampleSchema.ts
@@ -94,6 +94,11 @@ export const sampleSchema: Schema = {
             recursive: false,
         },
     ],
+    platformSchema: {
+        __typename: 'TableSchema',
+        schema:
+            '{ "type": "record", "name": "SampleHdfsSchema", "namespace": "com.linkedin.dataset", "doc": "Sample HDFS dataset", "fields": [ { "name": "field_foo", "type": [ "string" ] }, { "name": "field_bar", "type": [ "boolean" ] } ] }',
+    },
 };
 
 export const sampleSchemaWithTags: Schema = {


### PR DESCRIPTION
Table schema now has `View Raw` button:
![](https://user-images.githubusercontent.com/2455694/110182867-809f8f00-7dc2-11eb-80a4-44b7fee62456.png)

And that takes you to a raw view:
![](https://user-images.githubusercontent.com/2455694/110182891-8bf2ba80-7dc2-11eb-9dfd-30736bf1ac75.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
