### PR TITLE
fix(react): fixing test issues that arose from ill-timed merges

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 
 import { Button, Table, Typography } from 'antd';
 import { AlignType } from 'rc-table/lib/interface';
+import styled from 'styled-components';
 
 import TypeIcon from './TypeIcon';
 import { Schema, SchemaFieldDataType, GlobalTags } from '../../../../../types.generated';

--- a/datahub-web-react/src/app/entity/tag/__tests__/TagProfile.test.tsx
+++ b/datahub-web-react/src/app/entity/tag/__tests__/TagProfile.test.tsx
@@ -35,10 +35,10 @@ describe('TagProfile', () => {
         await waitFor(() => expect(queryByText('abc-sample-tag')).toBeInTheDocument());
 
         expect(getByTestId('avatar-tag-urn:li:corpuser:3')).toBeInTheDocument();
-        expect(getByTestId('avatar-tag-urn:li:corpuser:2')).toBeInTheDocument();
+        expect(getByTestId('avatar-tag-urn:li:corpuser:1')).toBeInTheDocument();
 
-        expect(getByTestId('avatar-tag-urn:li:corpuser:2').closest('a').href).toEqual(
-            'http://localhost/user/urn:li:corpuser:2',
+        expect(getByTestId('avatar-tag-urn:li:corpuser:1').closest('a').href).toEqual(
+            'http://localhost/user/urn:li:corpuser:1',
         );
         expect(getByTestId('avatar-tag-urn:li:corpuser:3').closest('a').href).toEqual(
             'http://localhost/user/urn:li:corpuser:3',


### PR DESCRIPTION
The source of the first issue was here:
https://github.com/linkedin/datahub/commit/adfe60e97a824dbd318f6fd5de18ec1a08ba6343#diff-5c20ca9f49771819e70acc9b2f908109988f1010d07b0dca6413827716495b50L5

I removed the styles import in the tags pr because I removed the last `styled` component in that file in the commit. However, in https://github.com/linkedin/datahub/pull/2179, the styled import was needed for new styling being added. #2179 was merged first, so when #2164 landed it removed the import.

The source of the second issue was here:
https://github.com/linkedin/datahub/pull/2184/files#diff-350db4e8bd35a6898bda713bffb601ed934b67166cf9add1d4abf32c3829e616R14

#2184 altered test data that was referenced in #2179. When #2179 and #2184 landed, the test data was altered but the assertions were not updated, causing the test to fail.

Corrective action: React tests do not take long to run- we should consider running the react tests again a second time in a pre-commit hook for pull requests that touch datahub-frontend-react


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
