### PR TITLE
fix(GraphQL API): Add "fixed" SchemaFieldDataType mapping 

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/SchemaFieldMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/SchemaFieldMapper.java
@@ -54,7 +54,8 @@ public class SchemaFieldMapper implements ModelMapper<com.linkedin.schema.Schema
         } else if (type.isUnionType()) {
             return SchemaFieldDataType.UNION;
         } else {
-            throw new RuntimeException(String.format("Unrecognized SchemaFieldDataType provided %s", type.memberType().getType().name()));
+            throw new RuntimeException(String.format("Unrecognized SchemaFieldDataType provided %s",
+                    type.memberType().toString()));
         }
     }
 }

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/SchemaFieldMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/SchemaFieldMapper.java
@@ -33,6 +33,8 @@ public class SchemaFieldMapper implements ModelMapper<com.linkedin.schema.Schema
         final com.linkedin.schema.SchemaFieldDataType.Type type = dataTypeUnion.getType();
         if (type.isBytesType()) {
             return SchemaFieldDataType.BYTES;
+        } else if (type.isFixedType()) {
+            return SchemaFieldDataType.FIXED;
         } else if (type.isBooleanType()) {
             return SchemaFieldDataType.BOOLEAN;
         } else if (type.isStringType()) {


### PR DESCRIPTION
**Scope**
The GraphQL API 

**Changes**
This change fixes a bug in the GraphQL API where the "fixed" data type is not included in the mapping. Also improves the error message logged so that we can tell exactly which type doesn't match going forward. 

**Acknowledgements**
Thanks to Ming Jiang for finding this!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
