### PR TITLE
feat(ci): Add SHA based tagging before pushing to docker registries

### DIFF
--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -25,11 +25,14 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
-      - id: tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=react-$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
@@ -39,19 +42,42 @@ jobs:
         run: |
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub-react:
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
     runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup
     steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          dockerfile: ./docker/datahub-frontend/Dockerfile
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-frontend-react
+            docker.pkg.github.com/linkedin/datahub-fork/datahub-frontend-react
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-frontend
-          tags: ${{ needs.setup.outputs.tag }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-frontend/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}
-          build_args: SERVER_PORT=9002,ENABLE_REACT=true
+          build-args: |
+            SERVER_PORT=9002
+            ENABLE_REACT=true

--- a/.github/workflows/docker-frontend.yml
+++ b/.github/workflows/docker-frontend.yml
@@ -25,46 +25,56 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
-      - id: tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
         id: publish
         env:
-            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
-            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          dockerfile: ./docker/datahub-frontend/Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-frontend
-          tags: ${{ needs.setup.outputs.tag }}
-          push: ${{ needs.setup.outputs.publish == 'true' }}
-  build-and-publish-github:
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup
     steps:
-      - uses: actions/checkout@v2
-      - uses: VaultVulp/gp-docker-action@1.1.6
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/datahub-frontend/Dockerfile
-          image-name: datahub-frontend
-          image-tag: ${{ needs.setup.outputs.tag }}
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-frontend
+            docker.pkg.github.com/linkedin/datahub-fork/datahub-frontend
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-frontend/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -25,46 +25,56 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
-      - id: tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
         id: publish
         env:
-            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
-            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          dockerfile: ./docker/datahub-gms/Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-gms
-          tags: ${{ needs.setup.outputs.tag }}
-          push: ${{ needs.setup.outputs.publish == 'true' }}
-  build-and-publish-github:
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup
     steps:
-      - uses: actions/checkout@v2
-      - uses: VaultVulp/gp-docker-action@1.1.6
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/datahub-gms/Dockerfile
-          image-name: datahub-gms
-          image-tag: ${{ needs.setup.outputs.tag }}
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-gms
+            docker.pkg.github.com/linkedin/datahub-fork/datahub-gms
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-gms/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-ingestion.yml
+++ b/.github/workflows/docker-ingestion.yml
@@ -25,46 +25,56 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
-      - id: tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
         id: publish
         env:
-            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
-            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          dockerfile: ./docker/datahub-ingestion/Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-ingestion
-          tags: ${{ needs.setup.outputs.tag }}
-          push: ${{ needs.setup.outputs.publish == 'true' }}
-  build-and-publish-github:
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup
     steps:
-      - uses: actions/checkout@v2
-      - uses: VaultVulp/gp-docker-action@1.1.6
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/datahub-ingestion/Dockerfile
-          image-name: datahub-ingestion
-          image-tag: ${{ needs.setup.outputs.tag }}
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-ingestion
+            docker.pkg.github.com/linkedin/datahub-fork/datahub-ingestion
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-ingestion/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -25,46 +25,56 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
-      - id: tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
         id: publish
         env:
-            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
-            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          dockerfile: ./docker/datahub-mae-consumer/Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-mae-consumer
-          tags: ${{ needs.setup.outputs.tag }}
-          push: ${{ needs.setup.outputs.publish == 'true' }}
-  build-and-publish-github:
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup
     steps:
-      - uses: actions/checkout@v2
-      - uses: VaultVulp/gp-docker-action@1.1.6
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/datahub-mae-consumer/Dockerfile
-          image-name: datahub-mae-consumer
-          image-tag: ${{ needs.setup.outputs.tag }}
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-mae-consumer
+            docker.pkg.github.com/linkedin/datahub-fork/datahub-mae-consumer
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-mae-consumer/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -25,46 +25,56 @@ jobs:
       tag: ${{ steps.tag.outputs.tag }}
       publish: ${{ steps.publish.outputs.publish }}
     steps:
-      - uses: actions/checkout@v2
-      - id: tag
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
         run: |
           echo "GITHUB_REF: $GITHUB_REF"
-          TAG=$(echo ${GITHUB_REF} | sed -e 's,refs/heads/master,latest,g' -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
           echo "tag=$TAG"
           echo "::set-output name=tag::$TAG"
       - name: Check whether publishing enabled
         id: publish
         env:
-            ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-            echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
-            echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
-  build-and-publish-dockerhub:
-    runs-on: ubuntu-latest
-    needs: setup
-    steps:
-      - uses: actions/checkout@v2
-      - uses: docker/build-push-action@v1
-        env:
-          DOCKER_BUILDKIT: 1
-        with:
-          dockerfile: ./docker/datahub-mce-consumer/Dockerfile
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: linkedin/datahub-mce-consumer
-          tags: ${{ needs.setup.outputs.tag }}
-          push: ${{ needs.setup.outputs.publish == 'true' }}
-  build-and-publish-github:
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup
     steps:
-      - uses: actions/checkout@v2
-      - uses: VaultVulp/gp-docker-action@1.1.6
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: ./docker/datahub-mce-consumer/Dockerfile
-          image-name: datahub-mce-consumer
-          image-tag: ${{ needs.setup.outputs.tag }}
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-mce-consumer
+            docker.pkg.github.com/linkedin/datahub-fork/datahub-mce-consumer
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/datahub-mce-consumer/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/docker/docker-compose.react.yml
+++ b/docker/docker-compose.react.yml
@@ -9,7 +9,7 @@ services:
       args:
         SERVER_PORT: 9002
         ENABLE_REACT: "true"
-    image: linkedin/datahub-frontend:react-${DATAHUB_VERSION:-latest}
+    image: linkedin/datahub-frontend-react:${DATAHUB_VERSION:-latest}
     env_file: datahub-frontend/env/docker.env
     hostname: datahub-frontend-react
     container_name: datahub-frontend-react


### PR DESCRIPTION
Changes included in PR
1. Add short SHA based tagging for pushes to master. Solves issue https://github.com/linkedin/datahub/issues/2162
2. Upgrade to v2 of docker/build-and-push-action which simplifies our workflow
3. Make sure the push actions do not run when docker password is not set

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
