### PR TITLE
fix(react): fixing theming test in react

### DIFF
--- a/datahub-web-react/craco.config.js
+++ b/datahub-web-react/craco.config.js
@@ -3,12 +3,20 @@ const CracoAntDesignPlugin = require('craco-antd');
 
 const themeConfig = require(`./src/conf/theme/${process.env.REACT_APP_THEME_CONFIG}`);
 
+function addLessPrefixToKeys(styles) {
+    const output = {};
+    Object.keys(styles).forEach((key) => {
+        output[`@${key}`] = styles[key];
+    });
+    return output;
+}
+
 module.exports = {
     plugins: [
         {
             plugin: CracoAntDesignPlugin,
             options: {
-                customizeTheme: themeConfig.styles,
+                customizeTheme: addLessPrefixToKeys(themeConfig.styles),
             },
         },
     ],

--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -47,7 +47,7 @@ const client = new ApolloClient({
 });
 
 const App: React.VFC = () => {
-    const [dynamicThemeConfig, setDynamicThemeConfig] = useState<Theme | null>(null);
+    const [dynamicThemeConfig, setDynamicThemeConfig] = useState<Theme>(defaultThemeConfig);
 
     useEffect(() => {
         import(`./conf/theme/${process.env.REACT_APP_THEME_CONFIG}`).then((theme) => {
@@ -65,22 +65,8 @@ const App: React.VFC = () => {
         return register;
     }, []);
 
-    const theme: Theme = useMemo(() => {
-        const overridesWithoutPrefix: { [key: string]: any } = {};
-        const themeConfig = dynamicThemeConfig || defaultThemeConfig;
-        Object.assign(overridesWithoutPrefix, themeConfig.styles);
-        Object.keys(overridesWithoutPrefix).forEach((key) => {
-            overridesWithoutPrefix[key.substring(1)] = overridesWithoutPrefix[key];
-            delete overridesWithoutPrefix[key];
-        });
-        return {
-            ...themeConfig,
-            styles: overridesWithoutPrefix as Theme['styles'],
-        };
-    }, [dynamicThemeConfig]);
-
     return (
-        <ThemeProvider theme={theme}>
+        <ThemeProvider theme={dynamicThemeConfig}>
             <Router>
                 <EntityRegistryContext.Provider value={entityRegistry}>
                     {/* Temporary: For local testing during development. */}

--- a/datahub-web-react/src/conf/theme/theme_dark.config.json
+++ b/datahub-web-react/src/conf/theme/theme_dark.config.json
@@ -1,21 +1,21 @@
 {
     "styles": {
-        "@border-radius-base": "4px",
-        "@layout-header-background": "#333E4C",
-        "@layout-header-color": "white",
-        "@layout-body-background": "#333E4C",
-        "@component-background": "#333E4C",
-        "@body-background": "#333E4C",
-        "@border-color-base": "white",
-        "@text-color": "fade(white, 85%)",
-        "@text-color-secondary": "fade(white, 45%)",
-        "@heading-color": "fade(white, 85%)",
-        "@background-color-light": "#4b5b71",
-        "@divider-color": "fade(white, 6%)",
-        "@disabled-color": "fade(white, 25%)",
-        "@steps-nav-arrow-color": "fade(white, 25%)",
-        "@homepage-background-upper-fade": "#FFFFFF",
-        "@homepage-background-lower-fade": "#333E4C"
+        "border-radius-base": "4px",
+        "layout-header-background": "#333E4C",
+        "layout-header-color": "white",
+        "layout-body-background": "#333E4C",
+        "component-background": "#333E4C",
+        "body-background": "#333E4C",
+        "border-color-base": "white",
+        "text-color": "fade(white, 85%)",
+        "text-color-secondary": "fade(white, 45%)",
+        "heading-color": "fade(white, 85%)",
+        "background-color-light": "#4b5b71",
+        "divider-color": "fade(white, 6%)",
+        "disabled-color": "fade(white, 25%)",
+        "steps-nav-arrow-color": "fade(white, 25%)",
+        "homepage-background-upper-fade": "#FFFFFF",
+        "homepage-background-lower-fade": "#333E4C"
     },
     "assets": {
         "logoUrl": "/assets/logo.png"

--- a/datahub-web-react/src/conf/theme/theme_light.config.json
+++ b/datahub-web-react/src/conf/theme/theme_light.config.json
@@ -1,21 +1,21 @@
 {
     "styles": {
-        "@border-radius-base": "8px",
-        "@layout-header-background": "#333E4C",
-        "@layout-header-color": "white",
-        "@layout-body-background": "white",
-        "@component-background": "white",
-        "@body-background": "white",
-        "@border-color-base": "#333E4C",
-        "@text-color": "fade(black, 85%)",
-        "@text-color-secondary": "fade(black, 45%)",
-        "@heading-color": "fade(black, 85%)",
-        "@background-color-light": "hsv(0, 0, 98%)",
-        "@divider-color": "fade(black, 6%)",
-        "@disabled-color": "fade(black, 25%)",
-        "@steps-nav-arrow-color": "fade(black, 25%)",
-        "@homepage-background-upper-fade": "#132935",
-        "@homepage-background-lower-fade": "#FFFFFF"
+        "border-radius-base": "8px",
+        "layout-header-background": "#333E4C",
+        "layout-header-color": "white",
+        "layout-body-background": "white",
+        "component-background": "white",
+        "body-background": "white",
+        "border-color-base": "#333E4C",
+        "text-color": "fade(black, 85%)",
+        "text-color-secondary": "fade(black, 45%)",
+        "heading-color": "fade(black, 85%)",
+        "background-color-light": "hsv(0, 0, 98%)",
+        "divider-color": "fade(black, 6%)",
+        "disabled-color": "fade(black, 25%)",
+        "steps-nav-arrow-color": "fade(black, 25%)",
+        "homepage-background-upper-fade": "#132935",
+        "homepage-background-lower-fade": "#FFFFFF"
     },
     "assets": {
         "logoUrl": "/assets/logo.png"


### PR DESCRIPTION
The complexity of removing the less `@` prefixes in react introduced build issue- I'm moving that logic out into the craco.config.js file so the types are simpler on the react side.

This should have been caught in CI, but the build failure did not cause CI to fail:
https://github.com/linkedin/datahub/runs/2062749573#step:6:1145

Corrective action: ensure that build failures in react will cause CI to fail (#2217)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
