### PR TITLE
fix(es-setup): Add git workflows to upload docker for elasticsearch and kafka setup

### DIFF
--- a/.github/workflows/datahub-kafka-setup.yml
+++ b/.github/workflows/datahub-kafka-setup.yml
@@ -7,7 +7,6 @@ on:
       - 'docker/kafka-setup/**'
       - '.github/workflows/docker-kafka-setup.yml'
     paths-ignore:
-      - 'docs/**'
       - '**.md'
   pull_request:
     branches:
@@ -17,7 +16,6 @@ on:
       - '.github/workflows/docker-kafka-setup.yml'
     paths_ignore:
       - '**.md'
-      - '**.env'
   release:
     types: [published, edited]
 

--- a/.github/workflows/datahub-kafka-setup.yml
+++ b/.github/workflows/datahub-kafka-setup.yml
@@ -1,0 +1,83 @@
+name: datahub-kafka-setup docker
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docker/kafka-setup/**'
+      - '.github/workflows/docker-kafka-setup.yml'
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/kafka-setup/**'
+      - '.github/workflows/docker-kafka-setup.yml'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
+  release:
+    types: [published, edited]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
+        run: |
+          echo "GITHUB_REF: $GITHUB_REF"
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          echo "tag=$TAG"
+          echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-kafka-setup
+            docker.pkg.github.com/linkedin/datahub/datahub-kafka-setup
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/kafka-setup/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -1,0 +1,85 @@
+name: datahub-elasticsearch-setup docker
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docker/elasticsearch-setup/**'
+      - '.github/workflows/docker-elasticsearch-setup.yml'
+      - 'gms/impl/src/main/resources/index/**'
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/elasticsearch-setup/**'
+      - '.github/workflows/docker-elasticsearch-setup.yml'
+      - 'gms/impl/src/main/resources/index/**'
+    paths_ignore:
+      - '**.md'
+      - '**.env'
+  release:
+    types: [published, edited]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      publish: ${{ steps.publish.outputs.publish }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute Tag
+        id: tag
+        run: |
+          echo "GITHUB_REF: $GITHUB_REF"
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          TAG=$(echo ${GITHUB_REF} | sed -e "s,refs/heads/master,latest\,${SHORT_SHA},g" -e 's,refs/tags/,,g' -e 's,refs/pull/\([0-9]*\).*,pr\1,g')
+          echo "tag=$TAG"
+          echo "::set-output name=tag::$TAG"
+      - name: Check whether publishing enabled
+        id: publish
+        env:
+          ENABLE_PUBLISH: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
+          echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
+  push_to_registries:
+    name: Build and Push Docker Image to dockerhub and github registries
+    runs-on: ubuntu-latest
+    if: ${{ needs.setup.outputs.publish == 'true' }}
+    needs: setup
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            linkedin/datahub-elasticsearch-setup
+            docker.pkg.github.com/linkedin/datahub/datahub-elasticsearch-setup
+          # add git short SHA as Docker tag
+          tag-custom: ${{ needs.setup.outputs.tag }}
+          tag-custom-only: true
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push image
+        uses: docker/build-push-action@v2
+        with:
+          file: ./docker/elasticsearch-setup/Dockerfile
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -8,7 +8,6 @@ on:
       - '.github/workflows/docker-elasticsearch-setup.yml'
       - 'gms/impl/src/main/resources/index/**'
     paths-ignore:
-      - 'docs/**'
       - '**.md'
   pull_request:
     branches:
@@ -19,7 +18,6 @@ on:
       - 'gms/impl/src/main/resources/index/**'
     paths_ignore:
       - '**.md'
-      - '**.env'
   release:
     types: [published, edited]
 


### PR DESCRIPTION
Add git workflows to upload docker for elasticsearch and kafka setup.

Once latest version of Images for these two is uploaded, I will put out the PR to use the images on dockerhub instead of cached images. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
