### PR TITLE
ci(react): fail CI on build errors

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -38,7 +38,7 @@
     },
     "scripts": {
         "start": "yarn run generate && BROWSER=none craco start",
-        "build": "yarn run generate && craco build; rm -r dist/; cp -r build/ dist/ && rm -r build/",
+        "build": "yarn run generate && craco build && rm -rf dist/ && cp -r build/ dist/ && rm -r build/",
         "test": "craco test",
         "eject": "react-scripts eject",
         "storybook": "start-storybook -p 6006 -s public",


### PR DESCRIPTION
When our build script was delimitated by semicolons, errors to build would not prevent the gradle script from completing. This meant certain build issues that (a) did not fail any tests and (b) did not cause any lint issues could slip by. Such an example was:

https://github.com/linkedin/datahub/pull/2215

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
