### PR TITLE
fix(es-setup): Remove paths ignore for es/kafka-setup git workflows

### DIFF
--- a/.github/workflows/datahub-kafka-setup.yml
+++ b/.github/workflows/datahub-kafka-setup.yml
@@ -6,16 +6,12 @@ on:
     paths:
       - 'docker/kafka-setup/**'
       - '.github/workflows/docker-kafka-setup.yml'
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches:
       - master
     paths:
       - 'docker/kafka-setup/**'
       - '.github/workflows/docker-kafka-setup.yml'
-    paths_ignore:
-      - '**.md'
   release:
     types: [published, edited]
 

--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -7,8 +7,6 @@ on:
       - 'docker/elasticsearch-setup/**'
       - '.github/workflows/docker-elasticsearch-setup.yml'
       - 'gms/impl/src/main/resources/index/**'
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches:
       - master
@@ -16,8 +14,6 @@ on:
       - 'docker/elasticsearch-setup/**'
       - '.github/workflows/docker-elasticsearch-setup.yml'
       - 'gms/impl/src/main/resources/index/**'
-    paths_ignore:
-      - '**.md'
   release:
     types: [published, edited]
 


### PR DESCRIPTION
Apparently, paths and paths_ignore can't both be set. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
