### PR TITLE
fix(react): setting CI to false for builds

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -38,7 +38,7 @@
     },
     "scripts": {
         "start": "yarn run generate && BROWSER=none craco start",
-        "build": "yarn run generate && craco build && rm -rf dist/ && cp -r build/ dist/ && rm -r build/",
+        "build": "yarn run generate && CI=false craco build && rm -rf dist/ && cp -r build/ dist/ && rm -r build/",
         "test": "craco test",
         "eject": "react-scripts eject",
         "storybook": "start-storybook -p 6006 -s public",


### PR DESCRIPTION
With CI=true, we fail on warnings

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
