### PR TITLE
fix(es-setup): Added images to es/kafka-setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,6 +56,7 @@ services:
   kafka-setup:
     build:
       context: kafka-setup
+    image: linkedin/datahub-kafka-setup:${DATAHUB_VERSION:-latest}
     env_file: kafka-setup/env/docker.env
     hostname: kafka-setup
     container_name: kafka-setup
@@ -120,6 +121,7 @@ services:
     build:
       context: ../
       dockerfile: docker/elasticsearch-setup/Dockerfile
+    image: linkedin/datahub-elasticsearch-setup:${DATAHUB_VERSION:-latest}
     env_file: elasticsearch-setup/env/docker.env
     hostname: elasticsearch-setup
     container_name: elasticsearch-setup


### PR DESCRIPTION
Added the new docker images created for elasticsearch-setup and kafka-setup. 

Tested on local env after nuking. It gets latest versions of mappings and settings and both tasks finish successfully. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
