### PR TITLE
feat(es-7-migration): Update script and migration docs and add a simple Dockerfile

### DIFF
--- a/contrib/elasticsearch/es7-upgrade/Dockerfile
+++ b/contrib/elasticsearch/es7-upgrade/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.8
+COPY . .
+RUN pip install --upgrade pip
+RUN pip install elasticsearch
+ENTRYPOINT ["python", "transfer.py"]

--- a/contrib/elasticsearch/es7-upgrade/transfer.py
+++ b/contrib/elasticsearch/es7-upgrade/transfer.py
@@ -14,12 +14,12 @@ import time
 parser = argparse.ArgumentParser(description="Transfers ES indexes between clusters.")
 parser.add_argument('-s', '--source', required=True, help='Source cluster URL and port.')
 parser.add_argument('-d', '--dest', required=True, help='Destination cluster URL and port.')
-parser.add_argument('--source-ssl', required=False, default=True, help='Enables / disables source SSL.')
-parser.add_argument('--dest-ssl', required=False, default=True, help='Enables / disables destination SSL.')
+parser.add_argument('--disable-source-ssl', required=False, action='store_true', help='If set, disable source SSL.')
+parser.add_argument('--disable-dest-ssl', required=False, action='store_true', help='If set, disable destination SSL.')
 parser.add_argument('--cert-file', required=False, default=None, help='Cert file to use with SSL.')
 parser.add_argument('--key-file', required=False, default=None, help='Key file to use with SSL.')
 parser.add_argument('--ca-file', required=False, default=None, help='Certificate authority file to use for SSL.')
-parser.add_argument('--create-only', required=False, default=False, help='If true, only create the index (with settings/mappings/aliases).')
+parser.add_argument('--create-only', required=False, action='store_true', help='If set, only create the index (with settings/mappings/aliases).')
 parser.add_argument('-i', '--indices', required=False, default="*", help='Regular expression for indexes to copy.')
 parser.add_argument('--name-override', required=False, default=None, help='destination index name override')
 
@@ -207,9 +207,9 @@ def copy_index_data(clients, index, name_override):
 
 
 def main():
-    ssl_context=create_ssl_context()
-    source_ssl_context = ssl_context if args.source_ssl else None
-    dest_ssl_context = ssl_context if args.dest_ssl else None
+    ssl_context = create_ssl_context() if not args.disable_source_ssl or not args.disable_dest_ssl else None
+    source_ssl_context = ssl_context if not args.disable_source_ssl else None
+    dest_ssl_context = ssl_context if not args.disable_dest_ssl else None
     clients = EsClients(create_client(args.source, source_ssl_context), create_client(args.dest, dest_ssl_context))
     indices = get_index_settings(clients.source_client, args.indices)
 

--- a/docs/advanced/es-7-upgrade.md
+++ b/docs/advanced/es-7-upgrade.md
@@ -1,9 +1,11 @@
-# Elasticsearch upgrade from 5.6.8 to 7.9.3: Summary of changes
+# Elasticsearch upgrade from 5.6.8 to 7.9.3
+
+## Summary of changes
+Checkout the list of breaking changes for [Elasticsearch 6](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html) and [Elasticsearch 7](https://www.elastic.co/guide/en/elasticsearch/reference/7.x/breaking-changes-7.0.html). Following is the summary of changes that impact Datahub. 
 
 ### Search index mapping & settings
 - Removal of mapping types (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html))
 - Specify the maximum allowed difference between `min_gram` and `max_gram` for NGramTokenizer and NGramTokenFilter by adding property `max_ngram_diff` in index settings, particularly if the difference is greater than 1 (as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html))
-
 
 ### Search query
 The following parameters are/were `optional` and hence automatically populated in the search query. Some tests that expect a certain search query to be sent to ES will change with the ES upgrade.
@@ -13,3 +15,15 @@ The following parameters are/were `optional` and hence automatically populated i
 ### Java High Level Rest Client
 - In 7.9.3, Java High Level Rest Client instance needs a REST low-level client builder to be built. In 5.6.8, the same instance needs REST low-level client
 - Document APIs such as the Index API, Delete API, etc no longer takes the doc `type` as an input
+
+## Migration strategy
+
+As mentioned in the docs, indices created in Elasticsearch 5.x are not readable by Elasticsearch 7.x. Running the upgraded elasticsearch container on the existing esdata volume will fail. 
+
+For local development, our recommendation is to run the `docker/nuke.sh` script to remove the existing esdata volume before starting up the containers. Note, all data will be lost. 
+
+To migrate without losing data, please refer to the python script and Dockerfile in `contrib/elasticsearch/es7-upgrade`. The script takes source and destination elasticsearch cluster URL and SSL configuration (if applicable) as input. It ports the mappings and settings for all indices in the source cluster to the destination cluster making the necessary changes stated above. Then it transfers all documents in the source cluster to the destination cluster. 
+
+## Plan
+
+We will create an "elasticsearch5" branch with the version of master prior to the elasticsearch 7 upgrade. However, we will not be supporting this branch moving forward and all future development will be done using elasticsearch 7.9.3

--- a/docs/advanced/es-7-upgrade.md
+++ b/docs/advanced/es-7-upgrade.md
@@ -24,6 +24,15 @@ For local development, our recommendation is to run the `docker/nuke.sh` script 
 
 To migrate without losing data, please refer to the python script and Dockerfile in `contrib/elasticsearch/es7-upgrade`. The script takes source and destination elasticsearch cluster URL and SSL configuration (if applicable) as input. It ports the mappings and settings for all indices in the source cluster to the destination cluster making the necessary changes stated above. Then it transfers all documents in the source cluster to the destination cluster. 
 
+You can run the script in a docker container as follows
+```
+docker build -t migrate-es-7 .
+docker run migrate-es-7 -s SOURCE -d DEST [--disable-source-ssl]
+                   [--disable-dest-ssl] [--cert-file CERT_FILE]
+                   [--key-file KEY_FILE] [--ca-file CA_FILE] [--create-only]
+                   [-i INDICES] [--name-override NAME_OVERRIDE]
+```
+
 ## Plan
 
-We will create an "elasticsearch5" branch with the version of master prior to the elasticsearch 7 upgrade. However, we will not be supporting this branch moving forward and all future development will be done using elasticsearch 7.9.3
+We will create an "elasticsearch-5-legacy" branch with the version of master prior to the elasticsearch 7 upgrade. However, we will not be supporting this branch moving forward and all future development will be done using elasticsearch 7.9.3


### PR DESCRIPTION
The script requires ssl configuration even if we disable ssl. Update the script to take optional disable-ssl params for source and destination. 

Add simple Dockerfile to run a docker container that runs the script. 

Update migration doc with recommendations on how to migrate to es7. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
