### PR TITLE
feat(tags): Enable search for datasets by tags

### DIFF
--- a/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
+++ b/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
@@ -47,6 +47,15 @@
               "default_field": "name",
               "default_operator": "AND"
             }
+          },
+          {
+            "query_string": {
+              "query": "$INPUT",
+              "analyzer": "custom_keyword",
+              "boost": 1,
+              "default_field": "tags",
+              "default_operator": "AND"
+            }
           }
         ]
       }

--- a/gms/impl/src/main/resources/index/dataset/mappings.json
+++ b/gms/impl/src/main/resources/index/dataset/mappings.json
@@ -115,6 +115,10 @@
     "upstreams": {
       "type": "keyword",
       "normalizer": "my_normalizer"
+    },
+    "tags": {
+      "type": "keyword",
+      "normalizer": "my_normalizer"
     }
   }
 }

--- a/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
+++ b/metadata-builders/src/main/java/com/linkedin/metadata/builders/search/DatasetIndexBuilder.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.builders.search;
 
 import com.linkedin.common.DatasetUrnArray;
+import com.linkedin.common.GlobalTags;
 import com.linkedin.common.Ownership;
 import com.linkedin.common.Status;
 import com.linkedin.common.urn.DatasetUrn;
@@ -97,6 +98,16 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
   }
 
   @Nonnull
+  private DatasetDocument getDocumentToUpdateFromAspect(@Nonnull DatasetUrn urn,
+      @Nonnull GlobalTags globalTags) {
+    return new DatasetDocument().setUrn(urn)
+        .setTags(new StringArray(globalTags.getTags()
+            .stream()
+            .map(tag -> tag.getTag().getName())
+            .collect(Collectors.toList())));
+  }
+
+  @Nonnull
   private List<DatasetDocument> getDocumentsToUpdateFromSnapshotType(@Nonnull DatasetSnapshot datasetSnapshot) {
     final DatasetUrn urn = datasetSnapshot.getUrn();
     final List<DatasetDocument> documents = datasetSnapshot.getAspects().stream().map(aspect -> {
@@ -112,6 +123,8 @@ public class DatasetIndexBuilder extends BaseIndexBuilder<DatasetDocument> {
         return getDocumentToUpdateFromAspect(urn, aspect.getStatus());
       } else if (aspect.isUpstreamLineage()) {
         return getDocumentToUpdateFromAspect(urn, aspect.getUpstreamLineage());
+      } else if (aspect.isGlobalTags()) {
+        return getDocumentToUpdateFromAspect(urn, aspect.getGlobalTags());
       }
       return null;
     }).filter(Objects::nonNull).collect(Collectors.toList());

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/DatasetDocument.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/DatasetDocument.pdl
@@ -67,4 +67,9 @@ record DatasetDocument includes BaseDocument {
    * List of upstreams for this dataset
    */
   upstreams: optional array[DatasetUrn]
+
+  /**
+   * List of tags for this dataset
+   */
+  tags: optional array[string]
 }


### PR DESCRIPTION
Add search by tags functionality for datasets where if the user queries for a tag, it shows all datasets with the given tag. 
Note, it does not look at the tags of the schema fields.
Also note, query "tags:Legacy" and "Legacy" both work.
<img width="1801" alt="Screen Shot 2021-03-15 at 4 16 37 PM" src="https://user-images.githubusercontent.com/896177/111233956-c3274f80-85aa-11eb-8a38-0e8e958a3895.png">
<img width="1782" alt="Screen Shot 2021-03-15 at 4 16 46 PM" src="https://user-images.githubusercontent.com/896177/111233957-c4587c80-85aa-11eb-802b-939208ca41e0.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
