### PR TITLE
feat(react): moving schema tab to be default

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/DatasetProfile.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/DatasetProfile.tsx
@@ -45,6 +45,11 @@ export const DatasetProfile = ({ urn }: { urn: string }): JSX.Element => {
     }: Dataset) => {
         return [
             {
+                name: TabType.Schema,
+                path: TabType.Schema.toLowerCase(),
+                content: <SchemaView schema={schema} />,
+            },
+            {
                 name: TabType.Ownership,
                 path: TabType.Ownership.toLowerCase(),
                 content: (
@@ -56,11 +61,6 @@ export const DatasetProfile = ({ urn }: { urn: string }): JSX.Element => {
                         }
                     />
                 ),
-            },
-            {
-                name: TabType.Schema,
-                path: TabType.Schema.toLowerCase(),
-                content: <SchemaView schema={schema} />,
             },
             {
                 name: TabType.Lineage,


### PR DESCRIPTION
Viewing the schema is more likely the primary use case for visiting a dataset profile than viewing ownership- for this reason we should switch the order of the tabs

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
