### PR TITLE
fix(react): enabling charts and dashboards to be supported by theme

### DIFF
--- a/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
@@ -7,9 +7,6 @@ import defaultAvatar from '../../../../images/default_avatar.png';
 
 const styles = {
     content: { width: '100%' },
-    typeLabel: { color: 'rgba(0, 0, 0, 0.45)' },
-    platformLabel: { color: 'rgba(0, 0, 0, 0.45)' },
-    lastUpdatedLabel: { color: 'rgba(0, 0, 0, 0.45)' },
 };
 
 export type Props = {
@@ -27,8 +24,8 @@ export default function ChartHeader({ platform, description, ownership, url, las
         <Space direction="vertical" size={15} style={styles.content}>
             <Row justify="space-between">
                 <Space split={<Divider type="vertical" />}>
-                    <Typography.Text style={styles.typeLabel}>Chart</Typography.Text>
-                    <Typography.Text strong style={styles.platformLabel}>
+                    <Typography.Text type="secondary">Chart</Typography.Text>
+                    <Typography.Text strong type="secondary">
                         {platform}
                     </Typography.Text>
                 </Space>
@@ -45,7 +42,7 @@ export default function ChartHeader({ platform, description, ownership, url, las
                 ))}
             </Avatar.Group>
             {lastModified && (
-                <Typography.Text style={styles.lastUpdatedLabel}>
+                <Typography.Text type="secondary">
                     Last modified at {new Date(lastModified.time).toLocaleDateString('en-US')}
                 </Typography.Text>
             )}

--- a/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
@@ -10,7 +10,6 @@ import ChartSources from './ChartSources';
 import { Message } from '../../../shared/Message';
 
 const PageContainer = styled.div`
-    background-color: white;
     padding: 32px 100px;
 `;
 

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardHeader.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardHeader.tsx
@@ -7,9 +7,6 @@ import defaultAvatar from '../../../../images/default_avatar.png';
 
 const styles = {
     content: { width: '100%' },
-    typeLabel: { color: 'rgba(0, 0, 0, 0.45)' },
-    platformLabel: { color: 'rgba(0, 0, 0, 0.45)' },
-    lastUpdatedLabel: { color: 'rgba(0, 0, 0, 0.45)' },
 };
 
 export type Props = {
@@ -26,8 +23,8 @@ export default function DashboardHeader({ platform, description, ownership, url,
         <Space direction="vertical" size={16} style={styles.content}>
             <Row justify="space-between">
                 <Space split={<Divider type="vertical" />}>
-                    <Typography.Text style={styles.typeLabel}>Dashboard</Typography.Text>
-                    <Typography.Text strong style={styles.platformLabel}>
+                    <Typography.Text type="secondary">Dashboard</Typography.Text>
+                    <Typography.Text strong type="secondary">
                         {platform}
                     </Typography.Text>
                 </Space>
@@ -44,7 +41,7 @@ export default function DashboardHeader({ platform, description, ownership, url,
                 ))}
             </Avatar.Group>
             {lastModified && (
-                <Typography.Text style={styles.lastUpdatedLabel}>
+                <Typography.Text type="secondary">
                     Last modified at {new Date(lastModified.time).toLocaleDateString('en-US')}
                 </Typography.Text>
             )}

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
@@ -10,7 +10,6 @@ import DashboardCharts from './DashboardCharts';
 import { Message } from '../../../shared/Message';
 
 const PageContainer = styled.div`
-    background-color: white;
     padding: 32px 100px;
 `;
 


### PR DESCRIPTION
Charts & dashboards had some custom non-themable css. Removing that here so they can also be configured by the global theme.

<img width="1498" alt="Screen Shot 2021-03-17 at 10 11 46 AM" src="https://user-images.githubusercontent.com/2455694/111509173-b0775c80-8709-11eb-82e4-17f3e9aef264.png">
<img width="1542" alt="Screen Shot 2021-03-17 at 10 10 54 AM" src="https://user-images.githubusercontent.com/2455694/111509178-b2d9b680-8709-11eb-9506-78ddfa75def4.png">




## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
