### PR TITLE
feat(Kubernetes): Add JMX exporter containers to all DataHub components

### DIFF
--- a/contrib/kubernetes/datahub/charts/datahub-frontend/README.md
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/README.md
@@ -10,6 +10,7 @@ Current chart version is `0.2.0`
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | datahub.play.mem.buffer.size | string | `"10MB"` |  |
+| exporters.jmx.enabled | boolean | false |  |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/templates/config-jmx-exporter.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/templates/config-jmx-exporter.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.exporters.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "datahub-frontend.fullname" . }}-config-jmx-exporter
+  labels:
+    {{- include "datahub-frontend.labels" . | nindent 4 }}
+data:
+  config.yml: |-
+    hostPort: localhost:{{ .Values.env.JMXPORT }}
+    lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
+    lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    rules:
+{{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
+    ssl: false
+    startDelaySeconds: {{ .Values.exporters.jmx.config.startDelaySeconds }}
+{{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/templates/deployment.yaml
@@ -29,6 +29,11 @@ spec:
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
+      {{- if .Values.exporters.jmx.enabled }}
+      - name: config-jmx-exporter
+        configMap:
+          name: {{ include "datahub-frontend.fullname" . }}-config-jmx-exporter
+      {{- end }}
       initContainers:
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}
@@ -74,6 +79,38 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
+        {{- if .Values.exporters.jmx.enabled }}
+        - name: jmx-exporter
+          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
+          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
+          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
+          ports:
+          {{- range $key, $port := .Values.exporters.jmx.ports }}
+          - name: {{ $key }}
+          {{ toYaml $port | indent 14 }}
+          {{- end }}
+          livenessProbe:
+            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
+          readinessProbe:
+            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
+          env:
+            - name: SERVICE_PORT
+              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
+            {{- with .Values.exporters.jmx.env }}
+            {{- range $key, $value := . }}
+          - name: {{ $key | upper | replace "." "_" }}
+            value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          resources:
+            {{ toYaml .Values.exporters.jmx.resources | indent 12 }}
+          volumeMounts:
+            - name: config-jmx-exporter
+              mountPath: /opt/jmx_exporter/config.yml
+              subPath: config.yml
+        {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/templates/deployment.yaml
@@ -80,36 +80,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
-        {{- if .Values.exporters.jmx.enabled }}
-        - name: jmx-exporter
-          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
-          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
-          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
-          ports:
-          {{- range $key, $port := .Values.exporters.jmx.ports }}
-          - name: {{ $key }}
-          {{ toYaml $port | indent 14 }}
-          {{- end }}
-          livenessProbe:
-            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
-          readinessProbe:
-            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
-          env:
-            - name: SERVICE_PORT
-              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
-            {{- with .Values.exporters.jmx.env }}
-            {{- range $key, $value := . }}
-          - name: {{ $key | upper | replace "." "_" }}
-            value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-          resources:
-            {{ toYaml .Values.exporters.jmx.resources | indent 12 }}
-          volumeMounts:
-            - name: config-jmx-exporter
-              mountPath: /opt/jmx_exporter/config.yml
-              subPath: config.yml
-        {{- end }}
+        {{- include "datahub-jmxexporter.container" . }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
@@ -96,45 +96,45 @@ env:
 exporters:
   jmx:
     enabled: false
-    image:
-      repository: bitnami/jmx-exporter
-      tag: 0.15.0
-      pullPolicy: IfNotPresent
-    config:
-      lowercaseOutputName: true
-      lowercaseOutputLabelNames: true
-      rules:
-        - pattern: ".*"
-      startDelaySeconds: 30
-    env: {}
-    resources: {}
-    path: /metrics
-    ports:
-      jmxxp:
-        containerPort: 5556
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    serviceMonitor:
-      interval: 30s
-      scrapeTimeout: 30s
-      scheme: http
+#    image:
+#      repository: bitnami/jmx-exporter
+#      tag: 0.15.0
+#      pullPolicy: IfNotPresent
+#    config:
+#      lowercaseOutputName: true
+#      lowercaseOutputLabelNames: true
+#      rules:
+#        - pattern: ".*"
+#      startDelaySeconds: 30
+#    env: {}
+#    resources: {}
+#    path: /metrics
+#    ports:
+#      jmxxp:
+#        containerPort: 5556
+#        protocol: TCP
+#    livenessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    readinessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    serviceMonitor:
+#      interval: 30s
+#      scrapeTimeout: 30s
+#      scheme: http
 
 datahub:
   play:

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
@@ -89,6 +89,53 @@ tolerations: []
 
 affinity: {}
 
+env:
+  SERVERPORT: 9001
+  JMXPORT: 1099
+
+exporters:
+  jmx:
+    enabled: false
+    image:
+      repository: bitnami/jmx-exporter
+      tag: 0.15.0
+      pullPolicy: IfNotPresent
+    config:
+      lowercaseOutputName: true
+      lowercaseOutputLabelNames: true
+      rules:
+        - pattern: ".*"
+      startDelaySeconds: 30
+    env: {}
+    resources: {}
+    path: /metrics
+    ports:
+      jmxxp:
+        containerPort: 5556
+        protocol: TCP
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    serviceMonitor:
+      interval: 30s
+      scrapeTimeout: 30s
+      scheme: http
+
 datahub:
   play:
     mem:

--- a/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-frontend/values.yaml
@@ -90,7 +90,6 @@ tolerations: []
 affinity: {}
 
 env:
-  SERVERPORT: 9001
   JMXPORT: 1099
 
 exporters:

--- a/contrib/kubernetes/datahub/charts/datahub-gms/README.md
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/README.md
@@ -9,6 +9,7 @@ Current chart version is `0.2.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| exporters.jmx.enabled | boolean | false |  |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/config-jmx-exporter.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/config-jmx-exporter.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.exporters.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "datahub-gms.fullname" . }}-config-jmx-exporter
+  labels:
+    {{- include "datahub-gms.labels" . | nindent 4 }}
+data:
+  config.yml: |-
+    hostPort: localhost:{{ .Values.env.JMXPORT }}
+    lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
+    lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    rules:
+{{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
+    ssl: false
+    startDelaySeconds: {{ .Values.exporters.jmx.config.startDelaySeconds }}
+{{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
             defaultMode: 256
             secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
         {{- end }}
+        {{- if .Values.exporters.jmx.enabled }}
+        - name: config-jmx-exporter
+          configMap:
+            name: {{ include "datahub-gms.fullname" . }}-config-jmx-exporter
+        {{ - end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -114,6 +119,38 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
+{{- if .Values.exporters.jmx.enabled }}
+        - name: jmx-exporter
+          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
+          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
+          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
+          ports:
+          {{- range $key, $port := .Values.exporters.jmx.ports }}
+            - name: {{ $key }}
+{{ toYaml $port | indent 14 }}
+          {{- end }}
+          livenessProbe:
+            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
+          readinessProbe:
+            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
+          env:
+            - name: SERVICE_PORT
+              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
+          {{- with .Values.exporters.jmx.env }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.exporters.jmx.resources | indent 12 }}
+          volumeMounts:
+            - name: config-jmx-exporter
+              mountPath: /opt/jmx_exporter/config.yml
+              subPath: config.yml
+{{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -120,36 +120,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
-{{- if .Values.exporters.jmx.enabled }}
-        - name: jmx-exporter
-          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
-          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
-          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
-          ports:
-          {{- range $key, $port := .Values.exporters.jmx.ports }}
-            - name: {{ $key }}
-{{ toYaml $port | indent 14 }}
-          {{- end }}
-          livenessProbe:
-            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
-          readinessProbe:
-            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
-          env:
-            - name: SERVICE_PORT
-              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
-          {{- with .Values.exporters.jmx.env }}
-            {{- range $key, $value := . }}
-            - name: {{ $key | upper | replace "." "_" }}
-              value: {{ $value | quote }}
-            {{- end }}
-          {{- end }}
-          resources:
-{{ toYaml .Values.exporters.jmx.resources | indent 12 }}
-          volumeMounts:
-            - name: config-jmx-exporter
-              mountPath: /opt/jmx_exporter/config.yml
-              subPath: config.yml
-{{- end }}
+        {{- include "datahub-jmxexporter.container" . }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: config-jmx-exporter
           configMap:
             name: {{ include "datahub-gms.fullname" . }}-config-jmx-exporter
-        {{ - end }}
+        {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
@@ -95,44 +95,44 @@ env:
 exporters:
   jmx:
     enabled: false
-    image:
-      repository: bitnami/jmx-exporter
-      tag: 0.15.0
-      pullPolicy: IfNotPresent
-    config:
-      lowercaseOutputName: true
-      rules:
-        - pattern: ".*"
-      startDelaySeconds: 30
-    env: {}
-    resources: {}
-    path: /metrics
-    ports:
-      jmxxp:
-        containerPort: 5556
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    serviceMonitor:
-      interval: 30s
-      scrapeTimeout: 30s
-      scheme: http
+#    image:
+#      repository: bitnami/jmx-exporter
+#      tag: 0.15.0
+#      pullPolicy: IfNotPresent
+#    config:
+#      lowercaseOutputName: true
+#      rules:
+#        - pattern: ".*"
+#      startDelaySeconds: 30
+#    env: {}
+#    resources: {}
+#    path: /metrics
+#    ports:
+#      jmxxp:
+#        containerPort: 5556
+#        protocol: TCP
+#    livenessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    readinessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    serviceMonitor:
+#      interval: 30s
+#      scrapeTimeout: 30s
+#      scheme: http
 
 #This section is useful if we are installing this chart separately for testing
 # helm install datahub-gms datahub-gms/

--- a/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
@@ -89,7 +89,6 @@ tolerations: []
 affinity: {}
 
 env:
-  SERVERPORT: 9001
   JMXPORT: 1099
 
 exporters:

--- a/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-gms/values.yaml
@@ -88,6 +88,52 @@ tolerations: []
 
 affinity: {}
 
+env:
+  SERVERPORT: 9001
+  JMXPORT: 1099
+
+exporters:
+  jmx:
+    enabled: false
+    image:
+      repository: bitnami/jmx-exporter
+      tag: 0.15.0
+      pullPolicy: IfNotPresent
+    config:
+      lowercaseOutputName: true
+      rules:
+        - pattern: ".*"
+      startDelaySeconds: 30
+    env: {}
+    resources: {}
+    path: /metrics
+    ports:
+      jmxxp:
+        containerPort: 5556
+        protocol: TCP
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    serviceMonitor:
+      interval: 30s
+      scrapeTimeout: 30s
+      scheme: http
+
 #This section is useful if we are installing this chart separately for testing
 # helm install datahub-gms datahub-gms/
 global:

--- a/contrib/kubernetes/datahub/charts/datahub-jmxexporter/Chart.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-jmxexporter/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: datahub-jmxexporter
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: library
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.2.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 0.3.1

--- a/contrib/kubernetes/datahub/charts/datahub-jmxexporter/templates/_container.tpl
+++ b/contrib/kubernetes/datahub/charts/datahub-jmxexporter/templates/_container.tpl
@@ -1,0 +1,32 @@
+{{- define "datahub-jmxexporter.container" -}}
+{{- if .Values.exporters.jmx.enabled }}
+        - name: jmx-exporter
+          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
+          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
+          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
+          ports:
+  {{- range $key, $port := .Values.exporters.jmx.ports }}
+            - name: {{ $key }}
+{{ toYaml $port | indent 14 }}
+  {{- end }}
+          livenessProbe:
+{{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
+          readinessProbe:
+{{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
+          env:
+            - name: SERVICE_PORT
+              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
+          {{- with .Values.exporters.jmx.env }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.exporters.jmx.resources | indent 12 }}
+          volumeMounts:
+            - name: config-jmx-exporter
+              mountPath: /opt/jmx_exporter/config.yml
+              subPath: config.yml
+{{- end }}
+{{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/README.md
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/README.md
@@ -9,6 +9,7 @@ Current chart version is `0.2.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| exporters.jmx.enabled | boolean | false |  |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/config-jmx-exporter.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.exporters.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "datahub-mae-consumer.fullname" . }}-config-jmx-exporter
+  labels:
+    {{- include "datahub-mae-consumer.labels" . | nindent 4 }}
+data:
+  config.yml: |-
+    hostPort: localhost:{{ .Values.env.JMXPORT }}
+    lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
+    lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    rules:
+{{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
+    ssl: false
+    startDelaySeconds: {{ .Values.exporters.jmx.config.startDelaySeconds }}
+{{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -103,36 +103,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
-{{- if .Values.exporters.jmx.enabled }}
-        - name: jmx-exporter
-          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
-          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
-          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
-          ports:
-          {{- range $key, $port := .Values.exporters.jmx.ports }}
-          - name: {{ $key }}
-          {{ toYaml $port | indent 14 }}
-          {{- end }}
-          livenessProbe:
-            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
-          readinessProbe:
-            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
-          env:
-            - name: SERVICE_PORT
-              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
-            {{- with .Values.exporters.jmx.env }}
-            {{- range $key, $value := . }}
-            - name: {{ $key | upper | replace "." "_" }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-          resources:
-            {{ toYaml .Values.exporters.jmx.resources | indent 12 }}
-          volumeMounts:
-            - name: config-jmx-exporter
-              mountPath: /opt/jmx_exporter/config.yml
-              subPath: config.yml
-{{- end }}
+        {{- include "datahub-jmxexporter.container" . }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
             defaultMode: 256
             secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
         {{- end }}
+        {{- if .Values.exporters.jmx.enabled }}
+        - name: config-jmx-exporter
+          configMap:
+            name: {{ include "datahub-mae-consumer.fullname" . }}-config-jmx-exporter
+        {{ - end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -97,6 +102,38 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
+{{- if .Values.exporters.jmx.enabled }}
+        - name: jmx-exporter
+          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
+          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
+          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
+          ports:
+          {{- range $key, $port := .Values.exporters.jmx.ports }}
+          - name: {{ $key }}
+          {{ toYaml $port | indent 14 }}
+          {{- end }}
+          livenessProbe:
+            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
+          readinessProbe:
+            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
+          env:
+            - name: SERVICE_PORT
+              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
+            {{- with .Values.exporters.jmx.env }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          resources:
+            {{ toYaml .Values.exporters.jmx.resources | indent 12 }}
+          volumeMounts:
+            - name: config-jmx-exporter
+              mountPath: /opt/jmx_exporter/config.yml
+              subPath: config.yml
+{{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: config-jmx-exporter
           configMap:
             name: {{ include "datahub-mae-consumer.fullname" . }}-config-jmx-exporter
-        {{ - end }}
+        {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
@@ -90,7 +90,6 @@ tolerations: []
 affinity: {}
 
 env:
-  SERVERPORT: 9001
   JMXPORT: 1099
 
 exporters:

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
@@ -89,6 +89,52 @@ tolerations: []
 
 affinity: {}
 
+env:
+  SERVERPORT: 9001
+  JMXPORT: 1099
+
+exporters:
+  jmx:
+    enabled: false
+    image:
+      repository: bitnami/jmx-exporter
+      tag: 0.15.0
+      pullPolicy: IfNotPresent
+    config:
+      lowercaseOutputName: true
+      rules:
+        - pattern: ".*"
+      startDelaySeconds: 30
+    env: {}
+    resources: {}
+    path: /metrics
+    ports:
+      jmxxp:
+        containerPort: 5556
+        protocol: TCP
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    serviceMonitor:
+      interval: 30s
+      scrapeTimeout: 30s
+      scheme: http
+
 global:
   elasticsearch:
     host: "elasticsearch"

--- a/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mae-consumer/values.yaml
@@ -96,44 +96,44 @@ env:
 exporters:
   jmx:
     enabled: false
-    image:
-      repository: bitnami/jmx-exporter
-      tag: 0.15.0
-      pullPolicy: IfNotPresent
-    config:
-      lowercaseOutputName: true
-      rules:
-        - pattern: ".*"
-      startDelaySeconds: 30
-    env: {}
-    resources: {}
-    path: /metrics
-    ports:
-      jmxxp:
-        containerPort: 5556
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    serviceMonitor:
-      interval: 30s
-      scrapeTimeout: 30s
-      scheme: http
+#    image:
+#      repository: bitnami/jmx-exporter
+#      tag: 0.15.0
+#      pullPolicy: IfNotPresent
+#    config:
+#      lowercaseOutputName: true
+#      rules:
+#        - pattern: ".*"
+#      startDelaySeconds: 30
+#    env: {}
+#    resources: {}
+#    path: /metrics
+#    ports:
+#      jmxxp:
+#        containerPort: 5556
+#        protocol: TCP
+#    livenessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    readinessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    serviceMonitor:
+#      interval: 30s
+#      scrapeTimeout: 30s
+#      scheme: http
 
 global:
   elasticsearch:

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/README.md
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/README.md
@@ -9,6 +9,7 @@ Current chart version is `0.2.0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| exporters.jmx.enabled | boolean | false |  |
 | extraEnvs | Extra [environment variables][] which will be appended to the `env:` definition for the container | `[]` |
 | extraVolumes | Templatable string of additional `volumes` to be passed to the `tpl` function | "" |
 | extraVolumeMounts | Templatable string of additional `volumeMounts` to be passed to the `tpl` function | "" |

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/config-jmx-exporter.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.exporters.jmx.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "datahub-mce-consumer.fullname" . }}-config-jmx-exporter
+  labels:
+    {{- include "datahub-mce-consumer.labels" . | nindent 4 }}
+data:
+  config.yml: |-
+    hostPort: localhost:{{ .Values.env.JMXPORT }}
+    lowercaseOutputName: {{ .Values.exporters.jmx.config.lowercaseOutputName }}
+    lowercaseOutputLabelNames: {{ .Values.exporters.jmx.config.lowercaseOutputLabelNames }}
+    rules:
+{{ .Values.exporters.jmx.config.rules | toYaml | indent 6 }}
+    ssl: false
+    startDelaySeconds: {{ .Values.exporters.jmx.config.startDelaySeconds }}
+{{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: config-jmx-exporter
           configMap:
             name: {{ include "datahub-mce-consumer.fullname" . }}-config-jmx-exporter
-        {{ - end }}
+        {{- end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -36,6 +36,11 @@ spec:
             defaultMode: 256
             secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
         {{- end }}
+        {{- if .Values.exporters.jmx.enabled }}
+        - name: config-jmx-exporter
+          configMap:
+            name: {{ include "datahub-mce-consumer.fullname" . }}-config-jmx-exporter
+        {{ - end }}
       {{- if .Values.extraVolumes }}
         {{ toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
@@ -86,6 +91,38 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+
+{{- if .Values.exporters.jmx.enabled }}
+        - name: jmx-exporter
+          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
+          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
+          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
+          ports:
+          {{- range $key, $port := .Values.exporters.jmx.ports }}
+          - name: {{ $key }}
+          {{ toYaml $port | indent 14 }}
+          {{- end }}
+          livenessProbe:
+            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
+          readinessProbe:
+            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
+          env:
+            - name: SERVICE_PORT
+              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
+            {{- with .Values.exporters.jmx.env }}
+            {{- range $key, $value := . }}
+            - name: {{ $key | upper | replace "." "_" }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          resources:
+            {{ toYaml .Values.exporters.jmx.resources | indent 12 }}
+          volumeMounts:
+            - name: config-jmx-exporter
+              mountPath: /opt/jmx_exporter/config.yml
+              subPath: config.yml
+{{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -92,36 +92,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
-{{- if .Values.exporters.jmx.enabled }}
-        - name: jmx-exporter
-          image: "{{ .Values.exporters.jmx.image.repository }}:{{ .Values.exporters.jmx.image.tag }}"
-          imagePullPolicy: {{ .Values.exporters.jmx.image.pullPolicy }}
-          args: ["{{ .Values.exporters.jmx.ports.jmxxp.containerPort}}", "/opt/jmx_exporter/config.yml"]
-          ports:
-          {{- range $key, $port := .Values.exporters.jmx.ports }}
-          - name: {{ $key }}
-          {{ toYaml $port | indent 14 }}
-          {{- end }}
-          livenessProbe:
-            {{ toYaml .Values.exporters.jmx.livenessProbe | indent 12 }}
-          readinessProbe:
-            {{ toYaml .Values.exporters.jmx.readinessProbe | indent 12 }}
-          env:
-            - name: SERVICE_PORT
-              value: {{ .Values.exporters.jmx.ports.jmxxp.containerPort | quote }}
-            {{- with .Values.exporters.jmx.env }}
-            {{- range $key, $value := . }}
-            - name: {{ $key | upper | replace "." "_" }}
-              value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
-          resources:
-            {{ toYaml .Values.exporters.jmx.resources | indent 12 }}
-          volumeMounts:
-            - name: config-jmx-exporter
-              mountPath: /opt/jmx_exporter/config.yml
-              subPath: config.yml
-{{- end }}
+        {{- include "datahub-jmxexporter.container" . }}
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
@@ -90,7 +90,6 @@ tolerations: []
 affinity: {}
 
 env:
-  SERVERPORT: 9001
   JMXPORT: 1099
 
 exporters:

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
@@ -89,6 +89,52 @@ tolerations: []
 
 affinity: {}
 
+env:
+  SERVERPORT: 9001
+  JMXPORT: 1099
+
+exporters:
+  jmx:
+    enabled: false
+    image:
+      repository: bitnami/jmx-exporter
+      tag: 0.15.0
+      pullPolicy: IfNotPresent
+    config:
+      lowercaseOutputName: true
+      rules:
+        - pattern: ".*"
+      startDelaySeconds: 30
+    env: {}
+    resources: {}
+    path: /metrics
+    ports:
+      jmxxp:
+        containerPort: 5556
+        protocol: TCP
+    livenessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    readinessProbe:
+      httpGet:
+        path: /metrics
+        port: jmxxp
+      initialDelaySeconds: 30
+      periodSeconds: 15
+      timeoutSeconds: 60
+      failureThreshold: 8
+      successThreshold: 1
+    serviceMonitor:
+      interval: 30s
+      scrapeTimeout: 30s
+      scheme: http
+
 global:
   kafka:
     bootstrap:

--- a/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
+++ b/contrib/kubernetes/datahub/charts/datahub-mce-consumer/values.yaml
@@ -96,44 +96,44 @@ env:
 exporters:
   jmx:
     enabled: false
-    image:
-      repository: bitnami/jmx-exporter
-      tag: 0.15.0
-      pullPolicy: IfNotPresent
-    config:
-      lowercaseOutputName: true
-      rules:
-        - pattern: ".*"
-      startDelaySeconds: 30
-    env: {}
-    resources: {}
-    path: /metrics
-    ports:
-      jmxxp:
-        containerPort: 5556
-        protocol: TCP
-    livenessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    readinessProbe:
-      httpGet:
-        path: /metrics
-        port: jmxxp
-      initialDelaySeconds: 30
-      periodSeconds: 15
-      timeoutSeconds: 60
-      failureThreshold: 8
-      successThreshold: 1
-    serviceMonitor:
-      interval: 30s
-      scrapeTimeout: 30s
-      scheme: http
+#    image:
+#      repository: bitnami/jmx-exporter
+#      tag: 0.15.0
+#      pullPolicy: IfNotPresent
+#    config:
+#      lowercaseOutputName: true
+#      rules:
+#        - pattern: ".*"
+#      startDelaySeconds: 30
+#    env: {}
+#    resources: {}
+#    path: /metrics
+#    ports:
+#      jmxxp:
+#        containerPort: 5556
+#        protocol: TCP
+#    livenessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    readinessProbe:
+#      httpGet:
+#        path: /metrics
+#        port: jmxxp
+#      initialDelaySeconds: 30
+#      periodSeconds: 15
+#      timeoutSeconds: 60
+#      failureThreshold: 8
+#      successThreshold: 1
+#    serviceMonitor:
+#      interval: 30s
+#      scrapeTimeout: 30s
+#      scheme: http
 
 global:
   kafka:

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -5,6 +5,8 @@ FROM openjdk:8-jre-alpine as base
 ENV DOCKERIZE_VERSION v0.6.1
 RUN apk --no-cache add curl tar \
     && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.20.v20190813/jetty-runner-9.4.20.v20190813.jar --output jetty-runner.jar \
+    && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-jmx/9.4.20.v20190813/jetty-jmx-9.4.20.v20190813.jar --output jetty-jmx.jar \
+    && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.20.v20190813/jetty-util-9.4.20.v20190813.jar --output jetty-util.jar \
     && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
 FROM openjdk:8 as prod-build
@@ -25,6 +27,9 @@ FROM ${APP_ENV}-install as final
 
 RUN addgroup -S datahub && adduser -S datahub -G datahub
 USER datahub
+
+ENV JMX_OPTS=""
+ENV JAVA_OPTS=""
 
 EXPOSE 8080
 

--- a/docker/datahub-gms/start.sh
+++ b/docker/datahub-gms/start.sh
@@ -23,4 +23,7 @@ dockerize \
   -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT \
   -wait $NEO4J_HOST \
   -timeout 240s \
-  java -jar /jetty-runner.jar /datahub/datahub-gms/bin/war.war
+  java $JAVA_OPTS $JMX_OPTS \
+  --jar jetty-util.jar \
+  --jar jetty-jmx.jar \
+  -jar /jetty-runner.jar /datahub/datahub-gms/bin/war.war

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -32,6 +32,9 @@ FROM ${APP_ENV}-install as final
 RUN addgroup -S datahub && adduser -S datahub -G datahub
 USER datahub
 
+ENV JMX_OPTS=""
+ENV JAVA_OPTS=""
+
 EXPOSE 9090
 
 HEALTHCHECK --start-period=2m --retries=4 CMD curl --fail http://localhost:9091/actuator/health || exit 1

--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -22,4 +22,4 @@ dockerize \
   -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT \
   -wait $NEO4J_HOST \
   -timeout 240s \
-  java -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
+  java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -32,6 +32,9 @@ FROM ${APP_ENV}-install as final
 RUN addgroup -S datahub && adduser -S datahub -G datahub
 USER datahub
 
+ENV JMX_OPTS=""
+ENV JAVA_OPTS=""
+
 EXPOSE 9090
 
 HEALTHCHECK --start-period=2m --retries=4 CMD curl --fail http://localhost:9090/actuator/health || exit 1

--- a/docker/datahub-mce-consumer/start.sh
+++ b/docker/datahub-mce-consumer/start.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-#    -wait tcp://GMS_HOST:$GMS_PORT \
 dockerize \
   -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
   -timeout 240s \
-  java -jar /datahub/datahub-mce-consumer/bin/mce-consumer-job.jar
+  java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mce-consumer/bin/mce-consumer-job.jar


### PR DESCRIPTION
Fixes https://github.com/linkedin/datahub/issues/2214

Added JMX exporter container to Helm charts.
Also added JVM_OPTS and JMX_OPTS to such that it is easy to configure the JMX on the original container.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
