### PR TITLE
feat(tags): improving elastic search templates for tags

### DIFF
--- a/datahub-web-react/src/app/shared/tags/AddTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagModal.tsx
@@ -121,7 +121,7 @@ export default function AddTagModal({ updateTags, globalTags, visible, onClose }
                 onSelect={(selected) =>
                     selected === CREATE_TAG_VALUE ? setShowCreateModal(true) : setSelectedTagValue(String(selected))
                 }
-                notFoundContent={loading ? 'loading' : 'type at least 3 character to search'}
+                notFoundContent={loading ? 'loading' : 'type to search'}
             >
                 {autocompleteOptions}
             </TagSelect>

--- a/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
+++ b/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
@@ -56,6 +56,15 @@
               "default_field": "tags",
               "default_operator": "AND"
             }
+          },
+          {
+            "query_string": {
+              "query": "$INPUT",
+              "analyzer": "whitespace_lowercase",
+              "boost": 0.0625,
+              "default_field": "tags.ngram",
+              "default_operator": "AND"
+            }
           }
         ]
       }

--- a/gms/impl/src/main/resources/index/dataset/mappings.json
+++ b/gms/impl/src/main/resources/index/dataset/mappings.json
@@ -118,7 +118,13 @@
     },
     "tags": {
       "type": "keyword",
-      "normalizer": "my_normalizer"
+      "normalizer": "my_normalizer",
+      "fields": {
+        "ngram": {
+          "type": "text",
+          "analyzer": "custom_ngram"
+        }
+      }
     }
   }
 }

--- a/gms/impl/src/main/resources/index/tags/settings.json
+++ b/gms/impl/src/main/resources/index/tags/settings.json
@@ -4,7 +4,7 @@
       "filter": {
         "autocomplete_filter": {
           "type": "edge_ngram",
-          "min_gram": "3",
+          "min_gram": "1",
           "max_gram": "20"
         },
         "custom_delimiter": {


### PR DESCRIPTION
Accomplishes two things:

1) allows searching by tags using prefix-matching if they didn't search for the full tag name

2) starts autocomplete earlier when search for tags in the add tag flow

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
