### PR TITLE
fix(tags): fixing margins on tags for long descriptions

### DIFF
--- a/datahub-web-react/src/app/shared/EntityProfile.tsx
+++ b/datahub-web-react/src/app/shared/EntityProfile.tsx
@@ -28,6 +28,7 @@ const TagsTitle = styled(Typography.Title)`
 const TagCard = styled(Card)`
     margin-top: 24px;
     font-size: 18px;
+    min-width: 450px;
     width: 450px;
     height: 100%;
 `;


### PR DESCRIPTION
Long descriptions pushed the tag module to the side because it didn't have a min-width.

fixed version:
![image](https://user-images.githubusercontent.com/2455694/111710816-a3409780-8807-11eb-9833-f8c2ed8e963c.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
