### PR TITLE
fix(react): fixing search result formatting issues

### DIFF
--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -70,7 +70,6 @@ export default function DefaultPreviewCard({
                 )}
             </Space>
             <Space direction="vertical" align="end" size={36} style={styles.rightColumn}>
-                {tags && tags.tags?.length && <TagGroup editableTags={tags} maxShow={3} />}
                 <Space direction="vertical" size={12}>
                     <Typography.Text strong>Owned By</Typography.Text>
                     <Avatar.Group maxCount={4}>
@@ -83,6 +82,7 @@ export default function DefaultPreviewCard({
                         ))}
                     </Avatar.Group>
                 </Space>
+                <TagGroup editableTags={tags} maxShow={3} />
             </Space>
         </Row>
     );


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/2455694/111789109-0b31c500-887e-11eb-95c0-ead864d412b9.png)

Now, the result looks natural without tags, and with them:

![image](https://user-images.githubusercontent.com/2455694/111789229-23a1df80-887e-11eb-82ba-692f404f831e.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
