### PR TITLE
feat(react): show search suggestions

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -161,6 +161,7 @@ const dataset2 = {
 };
 
 const dataset3 = {
+    __typename: 'Dataset',
     urn: 'urn:li:dataset:3',
     type: EntityType.Dataset,
     platform: {
@@ -236,6 +237,11 @@ const dataset3 = {
     editableSchemaMetadata: null,
     deprecation: null,
 } as Dataset;
+
+const dataset4 = {
+    ...dataset3,
+    name: 'Fourth Test Dataset',
+};
 
 const sampleTag = {
     urn: 'urn:li:tag:abc-sample-tag',
@@ -730,6 +736,60 @@ export const mocks = [
                         {
                             __typename: 'Dataset',
                             ...dataset3,
+                        },
+                    ],
+                    facets: [
+                        {
+                            field: 'origin',
+                            aggregations: [
+                                {
+                                    value: 'PROD',
+                                    count: 3,
+                                },
+                            ],
+                        },
+                        {
+                            field: 'platform',
+                            aggregations: [
+                                { value: 'hdfs', count: 1 },
+                                { value: 'mysql', count: 1 },
+                                { value: 'kafka', count: 1 },
+                            ],
+                        },
+                    ],
+                },
+            } as GetSearchResultsQuery,
+        },
+    },
+    {
+        request: {
+            query: GetSearchResultsDocument,
+            variables: {
+                input: {
+                    type: 'DATASET',
+                    query: '*',
+                    start: 0,
+                    count: 20,
+                    filters: [],
+                },
+            },
+        },
+        result: {
+            data: {
+                __typename: 'Query',
+                search: {
+                    __typename: 'SearchResults',
+                    start: 0,
+                    count: 1,
+                    total: 1,
+                    entities: [
+                        {
+                            __typename: 'Dataset',
+                            ...dataset3,
+                        },
+                        {
+                            __typename: 'Dataset',
+                            ...dataset4,
                         },
                     ],
                     facets: [

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useHistory } from 'react-router';
-import { Typography, Image, Space, AutoComplete, Input, Row, Button, Carousel } from 'antd';
+import { Typography, Image, AutoComplete, Input, Row, Button, Carousel } from 'antd';
 import styled, { useTheme } from 'styled-components';
 
 import { ManageAccount } from '../shared/ManageAccount';
@@ -11,7 +11,7 @@ import { GetSearchResultsQuery, useGetAutoCompleteResultsLazyQuery } from '../..
 import { useGetAllEntitySearchResults } from '../../utils/customGraphQL/useGetAllEntitySearchResults';
 import { EntityType } from '../../types.generated';
 
-const Background = styled(Space)`
+const Background = styled.div`
     width: 100%;
     background-image: linear-gradient(
         ${(props) => props.theme.styles['homepage-background-upper-fade']},
@@ -35,10 +35,15 @@ const styles = {
 };
 
 const CarouselElement = styled.div`
-    height: 100px;
+    height: 120px;
     color: #fff;
-    line-height: 100px;
+    line-height: 120px;
     text-align: center;
+`;
+
+const CarouselContainer = styled.div`
+    margin-top: -24px;
+    padding-bottom: 40px;
 `;
 
 const HeaderContainer = styled.div`
@@ -119,7 +124,7 @@ export const HomePageHeader = () => {
     }
 
     return (
-        <Background direction="vertical">
+        <Background>
             <Row justify="space-between" style={styles.navBar}>
                 <WelcomeText>
                     {data && (
@@ -156,18 +161,29 @@ export const HomePageHeader = () => {
                 )}
                 <Typography.Text style={styles.subHeaderLabel}>Try searching for...</Typography.Text>
             </HeaderContainer>
-            <div>
+            <CarouselContainer>
                 <Carousel autoplay>
                     {suggestionsToShow.length > 0 &&
-                        suggestionsToShow.map((suggestion) => (
+                        suggestionsToShow.slice(0, 3).map((suggestion) => (
                             <CarouselElement>
-                                <Button type="text" style={styles.subHeaderText}>
+                                <Button
+                                    type="text"
+                                    style={styles.subHeaderText}
+                                    onClick={() =>
+                                        navigateToSearchUrl({
+                                            type: undefined,
+                                            query: suggestion,
+                                            history,
+                                            entityRegistry,
+                                        })
+                                    }
+                                >
                                     {suggestion}
                                 </Button>
                             </CarouselElement>
                         ))}
                 </Carousel>
-            </div>
+            </CarouselContainer>
         </Background>
     );
 };

--- a/datahub-web-react/src/app/home/__tests__/HomePage.test.tsx
+++ b/datahub-web-react/src/app/home/__tests__/HomePage.test.tsx
@@ -41,4 +41,17 @@ describe('HomePage', () => {
         await waitFor(() => expect(queryByTitle('The Great Test Dataset')).toBeInTheDocument());
         await waitFor(() => expect(queryByTitle('Some other test')).toBeInTheDocument());
     });
+
+    it('renders search suggestions', async () => {
+        const { getByText, queryAllByText } = render(
+            <MockedProvider mocks={mocks} addTypename>
+                <TestPageContainer>
+                    <HomePage />
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+        await waitFor(() => expect(getByText('Try searching for...')).toBeInTheDocument());
+        expect(queryAllByText('Yet Another Dataset').length).toBeGreaterThanOrEqual(1);
+        expect(queryAllByText('Fourth Test Dataset').length).toBeGreaterThanOrEqual(1);
+    });
 });


### PR DESCRIPTION
Search suggestions are fetched from elastic by querying for `*` and then randomizing the order of the result

![image](https://user-images.githubusercontent.com/2455694/111829678-3d591c00-88aa-11eb-806e-19df02d3746a.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
