### PR TITLE
fix(react): fix randomizing suggestions on autocorrect

### DIFF
--- a/datahub-web-react/src/app/entity/user/UserProfile.tsx
+++ b/datahub-web-react/src/app/entity/user/UserProfile.tsx
@@ -1,5 +1,5 @@
 import { Divider, Alert } from 'antd';
-import React from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
 import UserHeader from './UserHeader';
@@ -33,19 +33,22 @@ export default function UserProfile() {
             return ownershipResult[type].loading;
         }) || loading;
 
+    const ownershipForDetails = useMemo(() => {
+        Object.keys(ownershipResult).forEach((type) => {
+            const entities = ownershipResult[type].data?.search?.entities;
+
+            if (!entities || entities.length === 0) {
+                delete ownershipResult[type];
+            } else {
+                ownershipResult[type] = ownershipResult[type].data?.search?.entities;
+            }
+        });
+        return ownershipResult;
+    }, [ownershipResult]);
+
     if (error || (!loading && !error && !data)) {
         return <Alert type="error" message={error?.message || 'Entity failed to load'} />;
     }
-
-    Object.keys(ownershipResult).forEach((type) => {
-        const entities = ownershipResult[type].data?.search?.entities;
-
-        if (!entities || entities.length === 0) {
-            delete ownershipResult[type];
-        } else {
-            ownershipResult[type] = ownershipResult[type].data?.search?.entities;
-        }
-    });
 
     return (
         <PageContainer>
@@ -59,7 +62,7 @@ export default function UserProfile() {
                 teams={data?.corpUser?.editableInfo?.teams}
             />
             <Divider />
-            <UserDetails urn={urn} subview={subview} item={item} ownerships={ownershipResult} />
+            <UserDetails urn={urn} subview={subview} item={item} ownerships={ownershipForDetails} />
         </PageContainer>
     );
 }

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -137,7 +137,8 @@ export const HomePageHeader = () => {
             });
         }
         return result;
-    }, [suggestionsLoading, allSearchResultsByType]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [suggestionsLoading]);
 
     return (
         <Background>

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -137,8 +137,7 @@ export const HomePageHeader = () => {
             });
         }
         return result;
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [suggestionsLoading]);
+    }, [suggestionsLoading, allSearchResultsByType]);
 
     return (
         <Background>

--- a/datahub-web-react/src/utils/customGraphQL/useGetAllEntitySearchResults.ts
+++ b/datahub-web-react/src/utils/customGraphQL/useGetAllEntitySearchResults.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { EntityType, SearchInput } from '../../types.generated';
 import { useGetSearchResultsQuery } from '../../graphql/search.generated';
 import { useEntityRegistry } from '../../app/useEntityRegistry';
@@ -24,5 +25,9 @@ export function useGetAllEntitySearchResults(input: AllEntityInput<SearchInput, 
         });
     }
 
-    return result;
+    return useMemo(
+        () => result,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        Object.keys(result).map((key) => result[key]),
+    );
 }


### PR DESCRIPTION
useGetAllEntitySearchResults is not referentially equal even when the apollo cache hasn't changed. we cant depend on it- removing it from the dependency array for recalculating suggestions.



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
