### PR TITLE
feat(react): updating entity layouts to be friendly to smaller viewport sizes

### DIFF
--- a/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
@@ -10,9 +10,7 @@ import ChartSources from './ChartSources';
 import { Message } from '../../../shared/Message';
 import TagGroup from '../../../shared/tags/TagGroup';
 
-const PageContainer = styled.div`
-    padding: 32px 100px;
-`;
+const PageContainer = styled.div``;
 
 export enum TabType {
     Ownership = 'Ownership',

--- a/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
@@ -1,6 +1,5 @@
 import { Alert } from 'antd';
 import React from 'react';
-import styled from 'styled-components';
 import { Chart, GlobalTags } from '../../../../types.generated';
 import { Ownership as OwnershipView } from '../../shared/Ownership';
 import { EntityProfile } from '../../../shared/EntityProfile';
@@ -9,8 +8,6 @@ import { GetChartDocument, useGetChartQuery, useUpdateChartMutation } from '../.
 import ChartSources from './ChartSources';
 import { Message } from '../../../shared/Message';
 import TagGroup from '../../../shared/tags/TagGroup';
-
-const PageContainer = styled.div``;
 
 export enum TabType {
     Ownership = 'Ownership',
@@ -72,25 +69,23 @@ export default function ChartProfile({ urn }: { urn: string }) {
     };
 
     return (
-        <PageContainer>
-            <>
-                {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
-                {data && data.chart && (
-                    <EntityProfile
-                        tags={
-                            <TagGroup
-                                editableTags={data.chart?.globalTags as GlobalTags}
-                                canAdd
-                                canRemove
-                                updateTags={(globalTags) => updateChart({ variables: { input: { urn, globalTags } } })}
-                            />
-                        }
-                        title={data.chart.info?.name || ''}
-                        tabs={getTabs(data.chart as Chart)}
-                        header={getHeader(data.chart as Chart)}
-                    />
-                )}
-            </>
-        </PageContainer>
+        <>
+            {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
+            {data && data.chart && (
+                <EntityProfile
+                    tags={
+                        <TagGroup
+                            editableTags={data.chart?.globalTags as GlobalTags}
+                            canAdd
+                            canRemove
+                            updateTags={(globalTags) => updateChart({ variables: { input: { urn, globalTags } } })}
+                        />
+                    }
+                    title={data.chart.info?.name || ''}
+                    tabs={getTabs(data.chart as Chart)}
+                    header={getHeader(data.chart as Chart)}
+                />
+            )}
+        </>
     );
 }

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
@@ -14,9 +14,7 @@ import DashboardCharts from './DashboardCharts';
 import { Message } from '../../../shared/Message';
 import TagGroup from '../../../shared/tags/TagGroup';
 
-const PageContainer = styled.div`
-    padding: 32px 100px;
-`;
+const PageContainer = styled.div``;
 
 export enum TabType {
     Ownership = 'Ownership',

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardProfile.tsx
@@ -1,6 +1,5 @@
 import { Alert } from 'antd';
 import React from 'react';
-import styled from 'styled-components';
 import {
     GetDashboardDocument,
     useGetDashboardQuery,
@@ -13,8 +12,6 @@ import DashboardHeader from './DashboardHeader';
 import DashboardCharts from './DashboardCharts';
 import { Message } from '../../../shared/Message';
 import TagGroup from '../../../shared/tags/TagGroup';
-
-const PageContainer = styled.div``;
 
 export enum TabType {
     Ownership = 'Ownership',
@@ -79,27 +76,23 @@ export default function DashboardProfile({ urn }: { urn: string }) {
     };
 
     return (
-        <PageContainer>
-            <>
-                {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
-                {data && data.dashboard && (
-                    <EntityProfile
-                        title={data.dashboard.info?.name || ''}
-                        tags={
-                            <TagGroup
-                                editableTags={data.dashboard?.globalTags as GlobalTags}
-                                canAdd
-                                canRemove
-                                updateTags={(globalTags) =>
-                                    updateDashboard({ variables: { input: { urn, globalTags } } })
-                                }
-                            />
-                        }
-                        tabs={getTabs(data.dashboard as Dashboard)}
-                        header={getHeader(data.dashboard as Dashboard)}
-                    />
-                )}
-            </>
-        </PageContainer>
+        <>
+            {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
+            {data && data.dashboard && (
+                <EntityProfile
+                    title={data.dashboard.info?.name || ''}
+                    tags={
+                        <TagGroup
+                            editableTags={data.dashboard?.globalTags as GlobalTags}
+                            canAdd
+                            canRemove
+                            updateTags={(globalTags) => updateDashboard({ variables: { input: { urn, globalTags } } })}
+                        />
+                    }
+                    tabs={getTabs(data.dashboard as Dashboard)}
+                    header={getHeader(data.dashboard as Dashboard)}
+                />
+            )}
+        </>
     );
 }

--- a/datahub-web-react/src/app/shared/EntityProfile.tsx
+++ b/datahub-web-react/src/app/shared/EntityProfile.tsx
@@ -16,11 +16,6 @@ export interface EntityProfileProps {
     }>;
 }
 
-const FlexSpace = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
 const TagsTitle = styled(Typography.Title)`
     font-size: 18px;
 `;
@@ -28,9 +23,8 @@ const TagsTitle = styled(Typography.Title)`
 const TagCard = styled(Card)`
     margin-top: 24px;
     font-size: 18px;
-    min-width: 450px;
-    width: 450px;
-    height: 100%;
+    min-width: 100%;
+    width: 100%;
 `;
 
 const TagIcon = styled(TagOutlined)`
@@ -52,22 +46,26 @@ export const EntityProfile = ({ title, tags, header, tabs }: EntityProfileProps)
     return (
         <Layout.Content style={{ padding: '0px 100px' }}>
             <div>
-                <FlexSpace>
-                    <div>
-                        <Row style={{ padding: '20px 0px 10px 0px' }}>
-                            <Col span={24}>
-                                <h1>{title}</h1>
-                            </Col>
-                        </Row>
-                        {header}
-                    </div>
-                    <TagCard>
-                        <TagsTitle type="secondary" level={4}>
-                            <TagIcon /> Tags
-                        </TagsTitle>
-                        {tags}
-                    </TagCard>
-                </FlexSpace>
+                <Row>
+                    <Col span={16} md={16} sm={24} xs={24}>
+                        <div>
+                            <Row style={{ padding: '20px 0px 10px 0px' }}>
+                                <Col span={24}>
+                                    <h1>{title}</h1>
+                                </Col>
+                            </Row>
+                            {header}
+                        </div>
+                    </Col>
+                    <Col span={8} xs={24} sm={24} md={8}>
+                        <TagCard>
+                            <TagsTitle type="secondary" level={4}>
+                                <TagIcon /> Tags
+                            </TagsTitle>
+                            {tags}
+                        </TagCard>
+                    </Col>
+                </Row>
                 <Divider style={{ marginBottom: '0px' }} />
                 <Row style={{ padding: '0px 0px 10px 0px' }}>
                     <Col span={24}>


### PR DESCRIPTION
The header layout used to look strange on small viewport sizes. This change improves that:

![image](https://user-images.githubusercontent.com/2455694/112071896-f67b5880-8b2d-11eb-9a28-cbac1795fc2f.png)

wide layout remains the same:
![image](https://user-images.githubusercontent.com/2455694/112072179-83261680-8b2e-11eb-9263-6b8f12582683.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
