### PR TITLE
fix: remain as root until final datahub-frontend build stage

### DIFF
--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -3,7 +3,6 @@ ARG APP_ENV=prod
 
 FROM openjdk:8-jre-alpine as base
 RUN addgroup -S datahub && adduser -S datahub -G datahub
-USER datahub
 
 FROM openjdk:8 as prod-build
 ARG ENABLE_EMBER="false"


### PR DESCRIPTION
Should fix the issue shown here: https://github.com/linkedin/datahub/runs/2172716066?check_suite_focus=true#step:6:4499. Not a best practice violation since there's another `USER datahub` directive later in the Dockerfile. Tested locally.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
