### PR TITLE
fix(ingest): Add druid-specific identification logic

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/druid.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/druid.py
@@ -18,7 +18,7 @@ class DruidConfig(BasicSQLAlchemyConfig):
     The pydruid library already formats the table name correctly, so we do not
     need to use the schema name when constructing the URN. Without this override,
     every URN would incorrectly start with "druid.
-    
+
     For more information, see https://druid.apache.org/docs/latest/querying/sql.html#schemata-table
 
     """

--- a/metadata-ingestion/src/datahub/ingestion/source/druid.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/druid.py
@@ -14,6 +14,9 @@ class DruidConfig(BasicSQLAlchemyConfig):
     def get_sql_alchemy_url(self):
         return f"{BasicSQLAlchemyConfig.get_sql_alchemy_url(self)}/druid/v2/sql/"
 
+    def get_identifier(self, schema: str, table: str) -> str:
+        return f"{table}"
+
 
 class DruidSource(SQLAlchemySource):
     def __init__(self, config, ctx):

--- a/metadata-ingestion/src/datahub/ingestion/source/druid.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/druid.py
@@ -14,6 +14,14 @@ class DruidConfig(BasicSQLAlchemyConfig):
     def get_sql_alchemy_url(self):
         return f"{BasicSQLAlchemyConfig.get_sql_alchemy_url(self)}/druid/v2/sql/"
 
+    """
+    The pydruid library already formats the table name correctly, so we do not
+    need to use the schema name when constructing the URN. Without this override,
+    every URN would incorrectly start with "druid.
+    
+    For more information, see https://druid.apache.org/docs/latest/querying/sql.html#schemata-table
+
+    """
     def get_identifier(self, schema: str, table: str) -> str:
         return f"{table}"
 

--- a/metadata-ingestion/src/datahub/ingestion/source/druid.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/druid.py
@@ -22,6 +22,7 @@ class DruidConfig(BasicSQLAlchemyConfig):
     For more information, see https://druid.apache.org/docs/latest/querying/sql.html#schemata-table
 
     """
+
     def get_identifier(self, schema: str, table: str) -> str:
         return f"{table}"
 


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

Modifies druid dataset URNs to exclude the table name since that is duplicated by the platform urn.
I.e, for a druid datasource called data.jobexecutionview (in the druid console UI):
 - old Urn: `"urn:li:dataset:(urn:li:dataPlatform:druid,druid.data.jobexecutionview,PROD)"`
 - new Urn: `"urn:li:dataset:(urn:li:dataPlatform:druid,data.jobexecutionview,PROD)"`