### PR TITLE
feat(search-by-field): Add the ability to search for field names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext.junitJupiterVersion = '5.6.1'
-  ext.gmaVersion = '0.2.45'
+  ext.gmaVersion = '0.2.49'
   ext.pegasusVersion = '28.3.7'
 
   apply from: './repositories.gradle'

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/SearchResultsMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/mappers/SearchResultsMapper.java
@@ -1,51 +1,73 @@
 package com.linkedin.datahub.graphql.types.mappers;
 
+import com.google.common.collect.Streams;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.generated.AggregationMetadata;
 import com.linkedin.datahub.graphql.generated.Entity;
 import com.linkedin.datahub.graphql.generated.FacetMetadata;
+import com.linkedin.datahub.graphql.generated.MatchedField;
+import com.linkedin.datahub.graphql.generated.SearchResult;
 import com.linkedin.datahub.graphql.generated.SearchResults;
+import com.linkedin.metadata.query.MatchMetadata;
 import com.linkedin.metadata.query.SearchResultMetadata;
 import com.linkedin.restli.common.CollectionResponse;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+
 public class SearchResultsMapper<T extends RecordTemplate, E extends Entity> {
 
-    public static <T extends RecordTemplate, E extends Entity> SearchResults map(
-            @Nonnull final CollectionResponse<T> results,
-            @Nonnull final Function<T, E> elementMapper) {
-        return new SearchResultsMapper<T, E>().apply(results, elementMapper);
+  public static <T extends RecordTemplate, E extends Entity> SearchResults map(
+      @Nonnull final CollectionResponse<T> results, @Nonnull final Function<T, E> elementMapper) {
+    return new SearchResultsMapper<T, E>().apply(results, elementMapper);
+  }
+
+  public SearchResults apply(@Nonnull final CollectionResponse<T> input, @Nonnull final Function<T, E> elementMapper) {
+    final SearchResults result = new SearchResults();
+
+    if (!input.hasPaging()) {
+      throw new RuntimeException("Invalid search response received. Unable to find paging details.");
     }
+    result.setStart(input.getPaging().getStart());
+    result.setCount(input.getPaging().getCount());
+    result.setTotal(input.getPaging().getTotal());
 
-    public SearchResults apply(@Nonnull final CollectionResponse<T> input,
-                               @Nonnull final Function<T, E> elementMapper) {
-        final SearchResults result = new SearchResults();
-
-        if (!input.hasPaging()) {
-            throw new RuntimeException("Invalid search response received. Unable to find paging details.");
-        }
-        result.setStart(input.getPaging().getStart());
-        result.setCount(input.getPaging().getCount());
-        result.setTotal(input.getPaging().getTotal());
-        result.setEntities(input.getElements().stream().map(elementMapper::apply).collect(Collectors.toList()));
-
-        final SearchResultMetadata searchResultMetadata = new SearchResultMetadata(input.getMetadataRaw());
-        result.setFacets(searchResultMetadata.getSearchResultMetadatas().stream().map(this::mapFacet).collect(Collectors.toList()));
-
-        return result;
+    final SearchResultMetadata searchResultMetadata = new SearchResultMetadata(input.getMetadataRaw());
+    Stream<E> entities = input.getElements().stream().map(elementMapper::apply);
+    if (searchResultMetadata.getMatches() != null) {
+      result.setSearchResults(
+          Streams.zip(entities, searchResultMetadata.getMatches().stream().map(this::getMatchedFieldEntry),
+              SearchResult::new).collect(Collectors.toList()));
+    } else {
+      result.setSearchResults(
+          entities.map(entity -> new SearchResult(entity, Collections.emptyList())).collect(Collectors.toList()));
     }
+    result.setFacets(
+        searchResultMetadata.getSearchResultMetadatas().stream().map(this::mapFacet).collect(Collectors.toList()));
 
-    private FacetMetadata mapFacet(com.linkedin.metadata.query.AggregationMetadata aggregationMetadata) {
-        final FacetMetadata facetMetadata = new FacetMetadata();
-        facetMetadata.setField(aggregationMetadata.getName());
-        facetMetadata.setAggregations(aggregationMetadata.getAggregations()
-                .entrySet()
-                .stream()
-                .map(entry -> new AggregationMetadata(entry.getKey(), entry.getValue()))
-                .collect(Collectors.toList()));
-        return facetMetadata;
-    }
+    return result;
+  }
+
+  private FacetMetadata mapFacet(com.linkedin.metadata.query.AggregationMetadata aggregationMetadata) {
+    final FacetMetadata facetMetadata = new FacetMetadata();
+    facetMetadata.setField(aggregationMetadata.getName());
+    facetMetadata.setAggregations(aggregationMetadata.getAggregations()
+        .entrySet()
+        .stream()
+        .map(entry -> new AggregationMetadata(entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList()));
+    return facetMetadata;
+  }
+
+  private List<MatchedField> getMatchedFieldEntry(MatchMetadata highlightMetadata) {
+    return highlightMetadata.getMatchedFields()
+        .stream()
+        .map(field -> new MatchedField(field.getName(), field.getValue()))
+        .collect(Collectors.toList());
+  }
 }

--- a/datahub-graphql-core/src/main/resources/gms.graphql
+++ b/datahub-graphql-core/src/main/resources/gms.graphql
@@ -891,6 +891,30 @@ input FacetFilterInput {
 	value: String!
 }
 
+type MatchedField {
+    """
+    Name of the field that matched
+    """
+    name: String!
+
+    """
+    Value of the field that matched
+    """
+    value: String!
+}
+
+type SearchResult {
+    """
+    Searched entity
+    """
+    entity: Entity!
+
+    """
+    Matched field names and their values
+    """
+    matchedFields: [MatchedField!]!
+}
+
 type SearchResults {
     """
     The starting point of paginated results
@@ -910,7 +934,7 @@ type SearchResults {
     """
     The search results
     """
-    entities: [Entity!]!
+    searchResults: [SearchResult!]!
 
     """
     Field aggregations used for faceted search

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -477,18 +477,30 @@ export const mocks = [
                     start: 0,
                     count: 3,
                     total: 3,
-                    entities: [
+                    searchResults: [
                         {
-                            __typename: 'Dataset',
-                            ...dataset1,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset1,
+                            },
+                            matchedFields: [
+                                {
+                                    name: 'fieldName',
+                                    value: 'fieldValue',
+                                },
+                            ],
                         },
                         {
-                            __typename: 'Dataset',
-                            ...dataset2,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset2,
+                            },
                         },
                         {
-                            __typename: 'Dataset',
-                            ...dataset3,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset3,
+                            },
                         },
                     ],
                     facets: [
@@ -535,10 +547,13 @@ export const mocks = [
                     start: 0,
                     count: 1,
                     total: 1,
-                    entities: [
+                    searchResults: [
                         {
-                            __typename: 'Dataset',
-                            ...dataset3,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset3,
+                            },
+                            matchedFields: [],
                         },
                     ],
                     facets: [
@@ -590,10 +605,13 @@ export const mocks = [
                     start: 0,
                     count: 1,
                     total: 1,
-                    entities: [
+                    searchResults: [
                         {
-                            __typename: 'Dataset',
-                            ...dataset3,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset3,
+                            },
+                            matchedFields: [],
                         },
                     ],
                     facets: [
@@ -637,9 +655,12 @@ export const mocks = [
                     start: 0,
                     count: 2,
                     total: 2,
-                    entities: [
+                    searchResult: [
                         {
-                            ...user1,
+                            entity: {
+                                ...user1,
+                            },
+                            matchedFields: [],
                         },
                     ],
                 },
@@ -705,7 +726,7 @@ export const mocks = [
                     start: 0,
                     count: 0,
                     total: 2,
-                    entities: [],
+                    searchResults: [],
                     facets: [],
                 },
             },
@@ -732,10 +753,13 @@ export const mocks = [
                     start: 0,
                     count: 1,
                     total: 1,
-                    entities: [
+                    searchResults: [
                         {
-                            __typename: 'Dataset',
-                            ...dataset3,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset3,
+                            },
+                            matchedFields: [],
                         },
                     ],
                     facets: [
@@ -782,14 +806,20 @@ export const mocks = [
                     start: 0,
                     count: 1,
                     total: 1,
-                    entities: [
+                    searchResults: [
                         {
-                            __typename: 'Dataset',
-                            ...dataset3,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset3,
+                            },
+                            matchedFields: [],
                         },
                         {
-                            __typename: 'Dataset',
-                            ...dataset4,
+                            entity: {
+                                __typename: 'Dataset',
+                                ...dataset4,
+                            },
+                            matchedFields: [],
                         },
                     ],
                     facets: [

--- a/datahub-web-react/src/app/entity/Entity.tsx
+++ b/datahub-web-react/src/app/entity/Entity.tsx
@@ -1,4 +1,4 @@
-import { EntityType } from '../../types.generated';
+import { EntityType, SearchResult } from '../../types.generated';
 
 export enum PreviewType {
     /**
@@ -76,4 +76,9 @@ export interface Entity<T> {
      * Renders a preview of the entity across different use cases like search, browse, etc.
      */
     renderPreview: (type: PreviewType, data: T) => JSX.Element;
+
+    /**
+     * Renders a search result
+     */
+    renderSearch: (result: SearchResult) => JSX.Element;
 }

--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -1,4 +1,4 @@
-import { EntityType } from '../../types.generated';
+import { EntityType, SearchResult } from '../../types.generated';
 import { Entity, IconStyleType, PreviewType } from './Entity';
 
 function validatedGet<K, V>(key: K, map: Map<K, V>): V {
@@ -88,9 +88,9 @@ export default class EntityRegistry {
         return entity.renderPreview(type, data);
     }
 
-    renderSearchResult<T>(type: EntityType, data: T): JSX.Element {
+    renderSearchResult(type: EntityType, searchResult: SearchResult): JSX.Element {
         const entity = validatedGet(type, this.entityTypeToEntity);
-        return entity.renderPreview(PreviewType.SEARCH, data);
+        return entity.renderSearch(searchResult);
     }
 
     renderBrowse<T>(type: EntityType, data: T): JSX.Element {

--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -1,6 +1,6 @@
 import { LineChartOutlined } from '@ant-design/icons';
 import * as React from 'react';
-import { Chart, EntityType } from '../../../types.generated';
+import { Chart, EntityType, SearchResult } from '../../../types.generated';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { ChartPreview } from './preview/ChartPreview';
 import ChartProfile from './profile/ChartProfile';
@@ -54,5 +54,9 @@ export class ChartEntity implements Entity<Chart> {
                 tags={data?.globalTags || undefined}
             />
         );
+    };
+
+    renderSearch = (result: SearchResult) => {
+        return this.renderPreview(PreviewType.SEARCH, result.entity as Chart);
     };
 }

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -1,6 +1,6 @@
 import { DashboardFilled, DashboardOutlined } from '@ant-design/icons';
 import * as React from 'react';
-import { Dashboard, EntityType } from '../../../types.generated';
+import { Dashboard, EntityType, SearchResult } from '../../../types.generated';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { DashboardPreview } from './preview/DashboardPreview';
 import DashboardProfile from './profile/DashboardProfile';
@@ -54,5 +54,9 @@ export class DashboardEntity implements Entity<Dashboard> {
                 owners={data.ownership?.owners}
             />
         );
+    };
+
+    renderSearch = (result: SearchResult) => {
+        return this.renderPreview(PreviewType.SEARCH, result.entity as Dashboard);
     };
 }

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -1,9 +1,20 @@
 import * as React from 'react';
 import { DatabaseFilled, DatabaseOutlined } from '@ant-design/icons';
-import { Dataset, EntityType } from '../../../types.generated';
+import { Tag, Typography } from 'antd';
+import styled from 'styled-components';
+import { Dataset, EntityType, SearchResult } from '../../../types.generated';
 import { DatasetProfile } from './profile/DatasetProfile';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { Preview } from './preview/Preview';
+import { FIELDS_TO_HIGHLIGHT } from './search/highlights';
+
+const MatchTag = styled(Tag)`
+    &&& {
+        margin-bottom: 0px;
+        margin-top: 10px;
+        display: block;
+    }
+`;
 
 /**
  * Definition of the DataHub Dataset entity.
@@ -53,6 +64,34 @@ export class DatasetEntity implements Entity<Dataset> {
                 platformLogo={data.platform.info?.logoUrl}
                 owners={data.ownership?.owners}
                 globalTags={data.globalTags}
+            />
+        );
+    };
+
+    renderSearch = (result: SearchResult) => {
+        const data = result.entity as Dataset;
+        return (
+            <Preview
+                urn={data.urn}
+                name={data.name}
+                origin={data.origin}
+                description={data.description}
+                platformName={data.platform.name}
+                platformLogo={data.platform.info?.logoUrl}
+                owners={data.ownership?.owners}
+                globalTags={data.globalTags}
+                snippet={
+                    // Add match highlights only if all the matched fields are in the FIELDS_TO_HIGHLIGHT
+                    result.matchedFields.length > 0 &&
+                    result.matchedFields.every((field) => FIELDS_TO_HIGHLIGHT.has(field.name)) && (
+                        <MatchTag>
+                            <Typography.Text>
+                                Matches {FIELDS_TO_HIGHLIGHT.get(result.matchedFields[0].name)}{' '}
+                                <b>{result.matchedFields[0].value}</b>
+                            </Typography.Text>
+                        </MatchTag>
+                    )
+                }
             />
         );
     };

--- a/datahub-web-react/src/app/entity/dataset/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entity/dataset/preview/Preview.tsx
@@ -12,6 +12,7 @@ export const Preview = ({
     platformLogo,
     owners,
     globalTags,
+    snippet,
 }: {
     urn: string;
     name: string;
@@ -21,6 +22,7 @@ export const Preview = ({
     platformLogo?: string | null;
     owners?: Array<Owner> | null;
     globalTags?: GlobalTags | null;
+    snippet?: React.ReactNode | null;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     return (
@@ -42,6 +44,7 @@ export const Preview = ({
                     };
                 }) || []
             }
+            snippet={snippet}
         />
     );
 };

--- a/datahub-web-react/src/app/entity/dataset/search/highlights.ts
+++ b/datahub-web-react/src/app/entity/dataset/search/highlights.ts
@@ -1,0 +1,2 @@
+export const FIELDS_TO_HIGHLIGHT = new Map();
+FIELDS_TO_HIGHLIGHT.set('fieldPaths', 'column');

--- a/datahub-web-react/src/app/entity/tag/Tag.tsx
+++ b/datahub-web-react/src/app/entity/tag/Tag.tsx
@@ -1,6 +1,6 @@
 import { TagOutlined, TagFilled } from '@ant-design/icons';
 import * as React from 'react';
-import { Tag, EntityType } from '../../../types.generated';
+import { Tag, EntityType, SearchResult } from '../../../types.generated';
 import DefaultPreviewCard from '../../preview/DefaultPreviewCard';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import TagProfile from './TagProfile';
@@ -49,4 +49,8 @@ export class TagEntity implements Entity<Tag> {
             url={`/${this.getPathName()}/${data.urn}`}
         />
     );
+
+    renderSearch = (result: SearchResult) => {
+        return this.renderPreview(PreviewType.SEARCH, result.entity as Tag);
+    };
 }

--- a/datahub-web-react/src/app/entity/user/User.tsx
+++ b/datahub-web-react/src/app/entity/user/User.tsx
@@ -1,6 +1,6 @@
 import { UserOutlined } from '@ant-design/icons';
 import * as React from 'react';
-import { CorpUser, EntityType } from '../../../types.generated';
+import { CorpUser, EntityType, SearchResult } from '../../../types.generated';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { Preview } from './preview/Preview';
 import UserProfile from './UserProfile';
@@ -50,4 +50,8 @@ export class UserEntity implements Entity<CorpUser> {
             photoUrl={data.editableInfo?.pictureLink || undefined}
         />
     );
+
+    renderSearch = (result: SearchResult) => {
+        return this.renderPreview(PreviewType.SEARCH, result.entity as CorpUser);
+    };
 }

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -56,7 +56,7 @@ function getSuggestionFieldsFromResult(result: GetSearchResultsQuery): string[] 
     return (
         (result?.search?.searchResults
             ?.map((searchResult) => searchResult.entity)
-            .map((entity) => {
+            ?.map((entity) => {
                 switch (entity.__typename) {
                     case 'Dataset':
                         return entity.name.split('.').slice(-1)[0];

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -54,8 +54,9 @@ const HeaderContainer = styled.div`
 
 function getSuggestionFieldsFromResult(result: GetSearchResultsQuery): string[] {
     return (
-        (result?.search?.entities
-            ?.map((entity) => {
+        (result?.search?.searchResults
+            ?.map((searchResult) => searchResult.entity)
+            .map((entity) => {
                 switch (entity.__typename) {
                     case 'Dataset':
                         return entity.name.split('.').slice(-1)[0];

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -1,6 +1,7 @@
 import { Avatar, Divider, Image, Row, Space, Tag, Tooltip, Typography } from 'antd';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 import { EntityType, GlobalTags } from '../../types.generated';
 import defaultAvatar from '../../images/default_avatar.png';
 import { useEntityRegistry } from '../useEntityRegistry';
@@ -16,10 +17,18 @@ interface Props {
     qualifier?: string | null;
     tags?: GlobalTags;
     owners?: Array<{ urn: string; name?: string; photoUrl?: string }>;
+    snippet?: React.ReactNode;
 }
 
+const DescriptionParagraph = styled(Typography.Paragraph)`
+    &&& {
+        margin-bottom: 0px;
+        padding-left: 8px;
+    }
+`;
+
 const styles = {
-    row: { width: '100%' },
+    row: { width: '100%', marginBottom: '0px' },
     leftColumn: { maxWidth: '75%' },
     rightColumn: { maxWidth: '25%' },
     logoImage: { width: '48px' },
@@ -27,8 +36,6 @@ const styles = {
     typeName: { color: '#585858' },
     platformName: { color: '#585858' },
     ownedBy: { color: '#585858' },
-    description: { paddingLeft: 8, margin: 0 },
-    noDescription: { color: '#d8d8d8' },
 };
 
 export default function DefaultPreviewCard({
@@ -41,6 +48,7 @@ export default function DefaultPreviewCard({
     qualifier,
     tags,
     owners,
+    snippet,
 }: Props) {
     const entityRegistry = useEntityRegistry();
     return (
@@ -61,13 +69,14 @@ export default function DefaultPreviewCard({
                         </Space>
                     </Space>
                 </Link>
-                {description.length === 0 ? (
-                    <Typography.Paragraph style={{ ...styles.description, ...styles.noDescription }}>
-                        No description
-                    </Typography.Paragraph>
-                ) : (
-                    <Typography.Paragraph style={styles.description}>{description}</Typography.Paragraph>
-                )}
+                <div>
+                    {description.length === 0 ? (
+                        <DescriptionParagraph type="secondary">No description</DescriptionParagraph>
+                    ) : (
+                        <DescriptionParagraph>{description}</DescriptionParagraph>
+                    )}
+                    {snippet}
+                </div>
             </Space>
             <Space direction="vertical" align="end" size={36} style={styles.rightColumn}>
                 <Space direction="vertical" size={12}>

--- a/datahub-web-react/src/app/search/AllEntitiesSearchResults.tsx
+++ b/datahub-web-react/src/app/search/AllEntitiesSearchResults.tsx
@@ -24,7 +24,8 @@ export const AllEntitiesSearchResults = ({ query }: Props) => {
 
     const noResults = Object.keys(allSearchResultsByType).every((type) => {
         return (
-            !allSearchResultsByType[type].loading && allSearchResultsByType[type].data?.search?.entities.length === 0
+            !allSearchResultsByType[type].loading &&
+            allSearchResultsByType[type].data?.search?.searchResults.length === 0
         );
     });
 
@@ -41,9 +42,9 @@ export const AllEntitiesSearchResults = ({ query }: Props) => {
             {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
             {noResults && noResultsView}
             {Object.keys(allSearchResultsByType).map((type: any) => {
-                const entities = allSearchResultsByType[type].data?.search?.entities;
-                if (entities && entities.length > 0) {
-                    return <EntityGroupSearchResults type={type} query={query} entities={entities} />;
+                const searchResults = allSearchResultsByType[type].data?.search?.searchResults;
+                if (searchResults && searchResults.length > 0) {
+                    return <EntityGroupSearchResults type={type} query={query} searchResults={searchResults} />;
                 }
                 return null;
             })}

--- a/datahub-web-react/src/app/search/EntityGroupSearchResults.tsx
+++ b/datahub-web-react/src/app/search/EntityGroupSearchResults.tsx
@@ -1,9 +1,10 @@
 import { ArrowRightOutlined } from '@ant-design/icons';
 import { Button, Card, Divider, List, Space, Typography } from 'antd';
+import { ListProps } from 'antd/lib/list';
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
-import { EntityType } from '../../types.generated';
+import { EntityType, SearchResult } from '../../types.generated';
 import { IconStyleType } from '../entity/Entity';
 import { useEntityRegistry } from '../useEntityRegistry';
 import { navigateToSearchUrl } from './utils/navigateToSearchUrl';
@@ -29,16 +30,16 @@ const ResultList = styled(List)`
 interface Props {
     type: EntityType;
     query: string;
-    entities: Array<any>;
+    searchResults: Array<SearchResult>;
 }
 
-export const EntityGroupSearchResults = ({ type, query, entities }: Props) => {
+export const EntityGroupSearchResults = ({ type, query, searchResults }: Props) => {
     const history = useHistory();
     const entityRegistry = useEntityRegistry();
 
     return (
         <Space direction="vertical" style={styles.resultsContainer}>
-            <ResultList
+            <ResultList<React.FC<ListProps<SearchResult>>>
                 header={
                     <span style={styles.header}>
                         <Typography.Title level={2}>{entityRegistry.getCollectionName(type)}</Typography.Title>
@@ -48,7 +49,7 @@ export const EntityGroupSearchResults = ({ type, query, entities }: Props) => {
                     </span>
                 }
                 footer={
-                    entities.length > 0 && (
+                    searchResults.length > 0 && (
                         <Button
                             type="text"
                             style={styles.seeAllButton}
@@ -69,12 +70,12 @@ export const EntityGroupSearchResults = ({ type, query, entities }: Props) => {
                         </Button>
                     )
                 }
-                dataSource={entities}
+                dataSource={searchResults as SearchResult[]}
                 split={false}
-                renderItem={(item, index) => (
+                renderItem={(searchResult, index) => (
                     <>
-                        <List.Item>{entityRegistry.renderSearchResult(type, item)}</List.Item>
-                        {index < entities.length - 1 && <Divider />}
+                        <List.Item>{entityRegistry.renderSearchResult(type, searchResult)}</List.Item>
+                        {index < searchResults.length - 1 && <Divider />}
                     </>
                 )}
                 bordered

--- a/datahub-web-react/src/app/search/EntitySearchResults.tsx
+++ b/datahub-web-react/src/app/search/EntitySearchResults.tsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { FilterOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 import { Alert, Button, Card, Divider, List, Modal, Pagination, Row, Typography } from 'antd';
+import { ListProps } from 'antd/lib/list';
 import { SearchCfg } from '../../conf';
 import { useGetSearchResultsQuery } from '../../graphql/search.generated';
-import { EntityType, FacetFilterInput } from '../../types.generated';
+import { EntityType, FacetFilterInput, SearchResult } from '../../types.generated';
 import { IconStyleType } from '../entity/Entity';
 import { Message } from '../shared/Message';
 import { useEntityRegistry } from '../useEntityRegistry';
@@ -59,7 +60,7 @@ export const EntitySearchResults = ({ type, query, page, filters, onChangeFilter
         },
     });
 
-    const results = data?.search?.entities || [];
+    const results = data?.search?.searchResults || [];
     const pageStart = data?.search?.start || 0;
     const pageSize = data?.search?.count || 0;
     const totalResults = data?.search?.total || 0;
@@ -124,7 +125,7 @@ export const EntitySearchResults = ({ type, query, page, filters, onChangeFilter
                 </b>{' '}
                 of <b>{totalResults}</b> results
             </Typography.Paragraph>
-            <ResultList
+            <ResultList<React.FC<ListProps<SearchResult>>>
                 header={
                     <Card bodyStyle={styles.resultHeaderCardBody} style={styles.resultHeaderCard as any}>
                         {entityRegistry.getIcon(type, 36, IconStyleType.ACCENT)}
@@ -132,9 +133,9 @@ export const EntitySearchResults = ({ type, query, page, filters, onChangeFilter
                 }
                 dataSource={results}
                 split={false}
-                renderItem={(item, index) => (
+                renderItem={(searchResult, index) => (
                     <>
-                        <List.Item>{entityRegistry.renderSearchResult(type, item)}</List.Item>
+                        <List.Item>{entityRegistry.renderSearchResult(type, searchResult)}</List.Item>
                         {index < results.length - 1 && <Divider />}
                     </>
                 )}

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -10,152 +10,158 @@ query getSearchResults($input: SearchInput!) {
         start
         count
         total
-        entities {
-            urn
-            type
-            ... on Dataset {
-                name
-                origin
-                description
-                uri
-                platform {
+        searchResults {
+            entity {
+                urn
+                type
+                ... on Dataset {
                     name
+                    origin
+                    description
+                    uri
+                    platform {
+                        name
+                        info {
+                            logoUrl
+                        }
+                    }
+                    platformNativeType
+                    tags
+                    properties {
+                        key
+                        value
+                    }
+                    ownership {
+                        owners {
+                            owner {
+                                urn
+                                type
+                                username
+                                info {
+                                    active
+                                    displayName
+                                    title
+                                    firstName
+                                    lastName
+                                    fullName
+                                }
+                                editableInfo {
+                                    pictureLink
+                                }
+                            }
+                            type
+                        }
+                        lastModified {
+                            time
+                        }
+                    }
+                    globalTags {
+                        tags {
+                            tag {
+                                urn
+                                name
+                                description
+                            }
+                        }
+                    }
+                }
+                ... on CorpUser {
+                    username
                     info {
-                        logoUrl
+                        active
+                        displayName
+                        title
+                        firstName
+                        lastName
+                        fullName
+                    }
+                    editableInfo {
+                        pictureLink
                     }
                 }
-                platformNativeType
-                tags
-                properties {
-                    key
-                    value
-                }
-                ownership {
-                    owners {
-                        owner {
-                            urn
-                            type
-                            username
-                            info {
-                                active
-                                displayName
-                                title
-                                firstName
-                                lastName
-                                fullName
-                            }
-                            editableInfo {
-                                pictureLink
-                            }
-                        }
-                        type
-                    }
-                    lastModified {
-                        time
-                    }
-                }
-                globalTags {
-                    tags {
-                        tag {
-                            urn
-                            name
-                            description
-                        }
-                    }
-                }
-            }
-            ... on CorpUser {
-                username
-                info {
-                    active
-                    displayName
-                    title
-                    firstName
-                    lastName
-                    fullName
-                }
-                editableInfo {
-                    pictureLink
-                }
-            }
-            ... on Dashboard {
-                urn
-                type
-                tool
-                dashboardId
-                info {
-                    name
-                    description
-                    url
-                    access
-                    lastModified {
-                        time
-                    }
-                }
-                ownership {
-                    owners {
-                        owner {
-                            urn
-                            type
-                            username
-                            info {
-                                active
-                                displayName
-                                title
-                                firstName
-                                lastName
-                                fullName
-                            }
-                            editableInfo {
-                                pictureLink
-                            }
-                        }
-                        type
-                    }
-                    lastModified {
-                        time
-                    }
-                }
-            }
-            ... on Chart {
-                urn
-                type
-                tool
-                chartId
-                info {
-                    name
-                    description
-                    url
+                ... on Dashboard {
+                    urn
                     type
-                    access
-                    lastModified {
-                        time
-                    }
-                }
-                ownership {
-                    owners {
-                        owner {
-                            urn
-                            type
-                            username
-                            info {
-                                active
-                                displayName
-                                title
-                                firstName
-                                lastName
-                                fullName
-                            }
-                            editableInfo {
-                                pictureLink
-                            }
+                    tool
+                    dashboardId
+                    info {
+                        name
+                        description
+                        url
+                        access
+                        lastModified {
+                            time
                         }
-                        type
                     }
-                    lastModified {
-                        time
+                    ownership {
+                        owners {
+                            owner {
+                                urn
+                                type
+                                username
+                                info {
+                                    active
+                                    displayName
+                                    title
+                                    firstName
+                                    lastName
+                                    fullName
+                                }
+                                editableInfo {
+                                    pictureLink
+                                }
+                            }
+                            type
+                        }
+                        lastModified {
+                            time
+                        }
                     }
                 }
+                ... on Chart {
+                    urn
+                    type
+                    tool
+                    chartId
+                    info {
+                        name
+                        description
+                        url
+                        type
+                        access
+                        lastModified {
+                            time
+                        }
+                    }
+                    ownership {
+                        owners {
+                            owner {
+                                urn
+                                type
+                                username
+                                info {
+                                    active
+                                    displayName
+                                    title
+                                    firstName
+                                    lastName
+                                    fullName
+                                }
+                                editableInfo {
+                                    pictureLink
+                                }
+                            }
+                            type
+                        }
+                        lastModified {
+                            time
+                        }
+                    }
+                }
+            }
+            matchedFields {
+                name
+                value
             }
         }
         facets {

--- a/gms/api/src/main/snapshot/com.linkedin.chart.charts.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.chart.charts.snapshot.json
@@ -585,6 +585,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -602,6 +626,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.dashboard.dashboards.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dashboard.dashboards.snapshot.json
@@ -532,6 +532,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -549,6 +573,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.dataflow.dataFlows.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataflow.dataFlows.snapshot.json
@@ -404,6 +404,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -421,6 +445,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.datajob.dataJobs.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.datajob.dataJobs.snapshot.json
@@ -496,6 +496,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -513,6 +537,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.dataprocess.dataProcesses.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataprocess.dataProcesses.snapshot.json
@@ -343,6 +343,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -360,6 +384,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
@@ -850,7 +850,7 @@
                 }, {
                   "type" : "record",
                   "name" : "UrnForeignKey",
-                  "doc" : "If SchemaMetadata fields make any external references and references are of type com.linkeidn.common.Urn or any children, this models can be used to mark it.",
+                  "doc" : "If SchemaMetadata fields make any external references and references are of type com.linkedin.common.Urn or any children, this models can be used to mark it.",
                   "fields" : [ {
                     "name" : "currentFieldPath",
                     "type" : "com.linkedin.dataset.SchemaFieldPath",
@@ -1288,6 +1288,30 @@
     } ]
   }, "com.linkedin.metadata.query.IndexPathParams", "com.linkedin.metadata.query.IndexValue", {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -1305,6 +1329,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.identity.corpGroups.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.identity.corpGroups.snapshot.json
@@ -266,6 +266,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -283,6 +307,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.identity.corpUsers.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.identity.corpUsers.snapshot.json
@@ -323,6 +323,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -340,6 +364,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.ml.mlModels.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.ml.mlModels.snapshot.json
@@ -853,6 +853,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -870,6 +894,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/api/src/main/snapshot/com.linkedin.tag.tags.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.tag.tags.snapshot.json
@@ -258,6 +258,30 @@
     } ]
   }, {
     "type" : "record",
+    "name" : "MatchMetadata",
+    "namespace" : "com.linkedin.metadata.query",
+    "fields" : [ {
+      "name" : "matchedFields",
+      "type" : {
+        "type" : "array",
+        "items" : {
+          "type" : "record",
+          "name" : "MatchedField",
+          "fields" : [ {
+            "name" : "name",
+            "type" : "string",
+            "doc" : "Matched field name"
+          }, {
+            "name" : "value",
+            "type" : "string",
+            "doc" : "Matched field value"
+          } ]
+        }
+      },
+      "doc" : "Matched field name and values"
+    } ]
+  }, "com.linkedin.metadata.query.MatchedField", {
+    "type" : "record",
     "name" : "SearchResultMetadata",
     "namespace" : "com.linkedin.metadata.query",
     "doc" : "The model for the search result",
@@ -275,6 +299,14 @@
         "items" : "com.linkedin.common.Urn"
       },
       "doc" : "A list of urns corresponding to search documents (in order) as returned by the search index"
+    }, {
+      "name" : "matches",
+      "type" : {
+        "type" : "array",
+        "items" : "MatchMetadata"
+      },
+      "doc" : "A list of match metadata for each search result, containing the list of fields in the search document that matched the query",
+      "optional" : true
     } ]
   }, {
     "type" : "record",

--- a/gms/impl/src/main/java/com/linkedin/metadata/configs/DatasetSearchConfig.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/configs/DatasetSearchConfig.java
@@ -1,13 +1,16 @@
 package com.linkedin.metadata.configs;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.metadata.dao.search.BaseSearchConfig;
 import com.linkedin.metadata.dao.utils.SearchUtils;
 import com.linkedin.metadata.search.DatasetDocument;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 public class DatasetSearchConfig extends BaseSearchConfig<DatasetDocument> {
@@ -38,5 +41,11 @@ public class DatasetSearchConfig extends BaseSearchConfig<DatasetDocument> {
   @Nonnull
   public String getAutocompleteQueryTemplate() {
     return SearchUtils.readResourceFile(getClass(), "datasetESAutocompleteQueryTemplate.json");
+  }
+
+  @Override
+  @Nullable
+  public List<String> getFieldsToHighlightMatch() {
+    return ImmutableList.of("name", "fieldPaths");
   }
 }

--- a/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
+++ b/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
@@ -65,6 +65,23 @@
               "default_field": "tags.ngram",
               "default_operator": "AND"
             }
+          },
+          {
+            "query_string": {
+              "query": "$INPUT",
+              "analyzer": "whitespace_lowercase",
+              "boost": 0.2,
+              "default_field": "fieldPaths.delimited",
+              "default_operator": "AND"
+            }
+          },
+          {
+            "query_string": {
+              "query": "$INPUT",
+              "analyzer": "custom_keyword",
+              "default_field": "fieldPaths",
+              "default_operator": "AND"
+            }
           }
         ]
       }


### PR DESCRIPTION
Add the ability to search for field names. Since field names are not shown in the search preview add the matched field name as snippet to prevent confusion on why this entity showed up in the search results. 

<img width="1395" alt="Screen Shot 2021-03-19 at 11 32 49 AM" src="https://user-images.githubusercontent.com/896177/112183047-1a38b000-8bbb-11eb-8c51-1c36cd71c653.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
