### PR TITLE
feat(healthcheck): Add healthchecks to datahub docker images

### DIFF
--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -3,6 +3,7 @@ ARG APP_ENV=prod
 
 FROM openjdk:8-jre-alpine as base
 RUN addgroup -S datahub && adduser -S datahub -G datahub
+RUN apk --no-cache add curl
 
 FROM openjdk:8 as prod-build
 ARG ENABLE_EMBER="false"
@@ -28,8 +29,11 @@ FROM ${APP_ENV}-install as final
 USER datahub
 
 ARG SERVER_PORT=9002
+ENV SERVER_PORT=$SERVER_PORT
 RUN echo $SERVER_PORT
 EXPOSE $SERVER_PORT
+
+HEALTHCHECK --start-period=2m --retries=4 CMD curl --fail http://localhost:$SERVER_PORT/admin || exit 1
 
 ENV JAVA_OPTS=" \
    -Xms512m \

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -28,4 +28,6 @@ USER datahub
 
 EXPOSE 8080
 
+HEALTHCHECK --start-period=2m --retries=4 CMD curl --fail http://localhost:8080/health || exit 1
+
 CMD /datahub/datahub-gms/scripts/start.sh

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -34,4 +34,6 @@ USER datahub
 
 EXPOSE 9090
 
+HEALTHCHECK --start-period=2m --retries=4 CMD curl --fail http://localhost:9091/actuator/health || exit 1
+
 CMD /datahub/datahub-mae-consumer/scripts/start.sh

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -34,4 +34,6 @@ USER datahub
 
 EXPOSE 9090
 
+HEALTHCHECK --start-period=2m --retries=4 CMD curl --fail http://localhost:9090/actuator/health || exit 1
+
 CMD /datahub/datahub-mce-consumer/scripts/start.sh

--- a/gms/war/src/main/webapp/WEB-INF/web.xml
+++ b/gms/war/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,12 @@
   </listener>
 
   <!-- servlet definitions -->
+  <servlet>
+    <display-name>Healch Check Servlet</display-name>
+    <servlet-name>healthCheck</servlet-name>
+    <servlet-class>com.linkedin.gms.servlet.HealthCheck</servlet-class>
+    <async-supported>true</async-supported>
+  </servlet>
   <!--
     HttpRequestHandlerServlet loads the "restliServlet" spring bean as a servlet.  For details, see:
     http://static.springsource.org/spring-framework/docs/3.2.0.RC1/api/org/springframework/web/context/support/HttpRequestHandlerServlet.html
@@ -36,7 +42,10 @@
   </servlet>
 
   <!-- servlet mappings -->
-
+  <servlet-mapping>
+    <servlet-name>healthCheck</servlet-name>
+    <url-pattern>/health</url-pattern>
+  </servlet-mapping>
   <servlet-mapping>
     <servlet-name>restliRequestHandler</servlet-name>
     <url-pattern>/*</url-pattern>


### PR DESCRIPTION
frontend, mae/mce-consumers already have an exposed healthcheck end point, but GMS does not. This PR adds a simple healthcheck end point for GMS and adds HEALTHCHECK commands for the datahub docker images. 

Tested locally and all containers are marked healthy. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
