### PR TITLE
feat(docker): Add dockerfile for initializing an existing mysql server

### DIFF
--- a/docker/mysql-setup/Dockerfile
+++ b/docker/mysql-setup/Dockerfile
@@ -1,0 +1,8 @@
+FROM jwilder/dockerize:0.6.1
+
+RUN apk add --no-cache mysql-client
+
+COPY docker/mysql-setup/init.sql /init.sql
+
+CMD dockerize -wait tcp://$MYSQL_HOST:$MYSQL_PORT -timeout 240s \
+      mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /init.sql

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -1,0 +1,53 @@
+-- create datahub database
+CREATE DATABASE IF NOT EXISTS datahub;
+USE datahub;
+
+-- create metadata aspect table
+create table if not exists metadata_aspect (
+  urn                           varchar(500) not null,
+  aspect                        varchar(200) not null,
+  version                       bigint(20) not null,
+  metadata                      longtext not null,
+  createdon                     datetime(6) not null,
+  createdby                     varchar(255) not null,
+  createdfor                    varchar(255),
+  constraint pk_metadata_aspect primary key (urn,aspect,version)
+);
+
+-- create default records for datahub user if not exists
+CREATE TABLE temp_metadata_aspect LIKE metadata_aspect;
+INSERT INTO temp_metadata_aspect (urn, aspect, version, metadata, createdon, createdby) VALUES(
+  'urn:li:corpuser:datahub',
+  'com.linkedin.identity.CorpUserInfo',
+  0,
+  '{"displayName":"Data Hub","active":true,"fullName":"Data Hub","email":"datahub@linkedin.com"}',
+  now(),
+  'urn:li:principal:datahub'
+), (
+  'urn:li:corpuser:datahub',
+  'com.linkedin.identity.CorpUserEditableInfo',
+  0,
+  '{"skills":[],"teams":[],"pictureLink":"https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web/packages/data-portal/public/assets/images/default_avatar.png"}',
+  now(),
+  'urn:li:principal:datahub'
+);
+-- only add default records if metadata_aspect is empty
+INSERT INTO metadata_aspect
+SELECT * FROM temp_metadata_aspect
+WHERE NOT EXISTS (SELECT * from metadata_aspect);
+DROP TABLE temp_metadata_aspect;
+
+-- create metadata index table
+CREATE TABLE IF NOT EXISTS metadata_index (
+ `id` BIGINT NOT NULL AUTO_INCREMENT,
+ `urn` VARCHAR(200) NOT NULL,
+ `aspect` VARCHAR(150) NOT NULL,
+ `path` VARCHAR(150) NOT NULL,
+ `longVal` BIGINT,
+ `stringVal` VARCHAR(200),
+ `doubleVal` DOUBLE,
+ CONSTRAINT id_pk PRIMARY KEY (id),
+ INDEX longIndex (`urn`,`aspect`,`path`,`longVal`),
+ INDEX stringIndex (`urn`,`aspect`,`path`,`stringVal`),
+ INDEX doubleIndex (`urn`,`aspect`,`path`,`doubleVal`)
+);


### PR DESCRIPTION
MySQL docker container has a way of inputting a set of SQL commands to be run as the container is starting up. However, this is not the case when hooking up an external MySQL server. 

The mysql-setup docker container runs the init.sql scripts on the inputted MySQL server, which creates the datahub database and adds the tables needed to start up Datahub. 

Note, I am not adding it to docker-compose since it is not needed for local development. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
