### PR TITLE
fix(ingest): hotfix for breaking change from confluent_kafka

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/kafka_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/kafka_emitter.py
@@ -36,7 +36,9 @@ class DatahubKafkaEmitter:
             return tuple_encoding
 
         avro_serializer = AvroSerializer(
-            SCHEMA_JSON_STR, schema_registry_client, to_dict=convert_mce_to_dict
+            schema_str=SCHEMA_JSON_STR,
+            schema_registry_client=schema_registry_client,
+            to_dict=convert_mce_to_dict,
         )
 
         producer_config = {


### PR DESCRIPTION
Hotfix for a breaking change introduced by https://github.com/confluentinc/confluent-kafka-python/pull/1000. We will remain compatible with both new and old versions of `confluent_kafka`.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
