### PR TITLE
Add looker metadata ingestion examples

### DIFF
--- a/contrib/metadata-ingestion/python/looker/dashboard_ingestion/README.md
+++ b/contrib/metadata-ingestion/python/looker/dashboard_ingestion/README.md
@@ -1,0 +1,15 @@
+## looker_dashboard_ingestion.py
+This tool helps ingest Looker dashboard and chart metadata into datahub.
+Currently it creates a separate platform named "looker" and loads all dashboard and chart information into that platform as virtual datasets. This was to workaround datahub's lack of support for dashboard entities, however datahub recently started supporting proper dashboard entities. 
+
+The script assumes you already have run lookml_ingestion.py to scrape view definitions into datahub, this is important because we assign lineage between looker views and looker dashboards/charts where possible.
+
+
+## Steps:
+- Use a version of python >= 3.7
+- Make a virtual environment
+- pip install -r requirements.txt
+- Set env vars: LOOKERSDK_CLIENT_ID, LOOKERSDK_CLIENT_SECRET, LOOKERSDK_BASE_URL
+- Configure extra kafka conf in looker_dashboard_ingestion.py
+
+python looker_dashboard_ingestion.py

--- a/contrib/metadata-ingestion/python/looker/dashboard_ingestion/looker_dashboard_ingestion.py
+++ b/contrib/metadata-ingestion/python/looker/dashboard_ingestion/looker_dashboard_ingestion.py
@@ -1,0 +1,426 @@
+#! /usr/bin/python
+import time
+import os
+import json
+import typing
+from pprint import pprint
+import looker_sdk
+from looker_sdk.sdk.api31.models import Query, DashboardElement, LookWithQuery, Dashboard
+from looker_sdk.error import SDKError
+
+from dataclasses import dataclass
+
+from confluent_kafka import avro
+from confluent_kafka.avro import AvroProducer
+
+# Configuration
+AVSC_PATH = "../../metadata-events/mxe-schemas/src/renamed/avro/com/linkedin/mxe/MetadataChangeEvent.avsc"
+KAFKA_TOPIC = 'MetadataChangeEvent_v4'
+
+# Set the following environmental variables to hit Looker's API
+# LOOKERSDK_CLIENT_ID=YourClientID
+# LOOKERSDK_CLIENT_SECRET=YourClientSecret
+# LOOKERSDK_BASE_URL=https://company.looker.com:19999
+LOOKERSDK_BASE_URL = os.environ["LOOKERSDK_BASE_URL"] 
+
+EXTRA_KAFKA_CONF = {
+	'bootstrap.servers': 'localhost:9092',
+	'schema.registry.url': 'http://localhost:8081'
+	# 'security.protocol': 'SSL',
+	# 'ssl.ca.location': '',
+	# 'ssl.key.location': '',
+	# 'ssl.certificate.location': ''
+}
+
+# The datahub platform where looker views are stored, must be the same as VIEW_DATAHUB_PLATFORM in lookml_ingestion.py
+VIEW_DATAHUB_PLATFORM = "looker_views"
+# The datahub platform where looker dashboards will be stored
+VISUALIZATION_DATAHUB_PLATFORM = "looker"
+
+
+@dataclass
+class LookerDashboardElement:
+	id: str
+	title: str
+	query_slug: str
+	looker_views: typing.List[str]
+	look_id: typing.Optional[str]
+
+	@property
+	def url(self) -> str:
+		base_url = get_looker_base_url()
+
+		# A dashboard element can use a look or just a raw query against an explore
+		if self.look_id is not None:
+			return base_url + "/looks/" + self.look_id
+		else:
+			return base_url + "/x/" + self.query_slug
+
+	def get_urn_element_id(self):
+		# A dashboard element can use a look or just a raw query against an explore
+		return f"dashboard_elements.{self.id}"
+
+	def get_view_urns(self) -> typing.List[str]:
+		return [f"urn:li:dataset:(urn:li:dataPlatform:{VIEW_DATAHUB_PLATFORM},{v},PROD)" for v in self.looker_views]
+
+
+@dataclass
+class LookerDashboard:
+	id: str
+	title: str
+	description: str
+	dashboard_elements: typing.List[LookerDashboardElement]
+
+	@property
+	def url(self):
+		return get_looker_base_url() + "/dashboards/" + self.id
+
+	def get_urn_dashboard_id(self):
+		return f"dashboards.{self.id}"
+
+
+@dataclass
+class DashboardKafkaEvents:
+	dashboard_mce: typing.Dict
+	chart_mces: typing.List[typing.Dict]
+
+	def all_mces(self) -> typing.List[typing.Dict]:
+		return self.chart_mces + [self.dashboard_mce]
+
+
+def get_looker_base_url():
+	base_url = LOOKERSDK_BASE_URL.split("looker.com")[0] + "looker.com"
+	return base_url
+
+
+def get_actor_and_sys_time():
+	actor, sys_time = "urn:li:corpuser:analysts", int(time.time()) * 1000
+	return actor, sys_time
+
+
+class ProperDatahubEvents:
+	"""
+	This class generates events for "proper" datahub charts and dashboards
+	These events will not be visualized anywhere as of 12/11/2020
+	"""
+	@staticmethod
+	def make_chart_mce(dashboard_element: LookerDashboardElement) -> typing.Dict:
+		actor, sys_time = get_actor_and_sys_time()
+
+		owners = [{
+			"owner": actor,
+			"type": "DEVELOPER"
+		}]
+
+		return {
+			"auditHeader": None,
+			"proposedSnapshot": ("com.linkedin.pegasus2avro.metadata.snapshot.ChartSnapshot", {
+				"urn": f"urn:li:chart:(looker,{dashboard_element.get_urn_element_id()})",
+				"aspects": [
+					("com.linkedin.pegasus2avro.dataset.ChartInfo", {
+						"title": dashboard_element.title,
+						"description": "",
+						"inputs": dashboard_element.get_view_urns(),
+						"url": f"",
+						"lastModified": {"created": {"time": sys_time, "actor": actor}}
+					}),
+					("com.linkedin.pegasus2avro.common.Ownership", {
+						"owners": owners,
+						"lastModified": {
+							"time": sys_time,
+							"actor": actor
+						}
+					})
+				]
+			}),
+			"proposedDelta": None
+		}
+
+	@staticmethod
+	def make_dashboard_mce(looker_dashboard: LookerDashboard) -> DashboardKafkaEvents:
+		actor, sys_time = get_actor_and_sys_time()
+
+		owners = [{
+			"owner": actor,
+			"type": "DEVELOPER"
+		}]
+
+		chart_mces = [ProperDatahubEvents.make_chart_mce(element) for element in looker_dashboard.dashboard_elements]
+
+		dashboard_mce = {
+			"auditHeader": None,
+			"proposedSnapshot": ("com.linkedin.pegasus2avro.metadata.snapshot.DashboardSnapshot", {
+				"urn": 	f"urn:li:dashboard:(looker,{looker_dashboard.get_urn_dashboard_id()},PROD)",
+				"aspects": [
+					("com.linkedin.pegasus2avro.dataset.DashboardInfo", {
+						"title": looker_dashboard.title,
+						"description": looker_dashboard.description,
+						"charts": [mce["proposedSnapshot"][1]["urn"] for mce in chart_mces],
+						"url": looker_dashboard.url,
+						"lastModified": {"created": {"time": sys_time, "actor": actor}}
+					}),
+					("com.linkedin.pegasus2avro.common.Ownership", {
+						"owners": owners,
+						"lastModified": {
+							"time": sys_time,
+							"actor": actor
+						}
+					})
+				]
+			}),
+			"proposedDelta": None
+		}
+
+		return DashboardKafkaEvents(dashboard_mce=dashboard_mce, chart_mces=chart_mces)
+
+
+class WorkaroundDatahubEvents:
+	"""
+	This class generates events for "workaround" datahub charts and dashboards
+	This is so we can display end to end lineage without being blocked on datahub's support for dashboards and charts
+
+	The approach is we generate "charts" and "dashboards" as just "datasets" in datahub under a new platform
+	We then link them together using "UpstreamLineage" just like any other dataset
+	"""
+	@staticmethod
+	def make_chart_mce(dashboard_element: LookerDashboardElement) -> typing.Dict:
+		actor, sys_time = get_actor_and_sys_time()
+
+		owners = [{
+			"owner": actor,
+			"type": "DEVELOPER"
+		}]
+
+		upstreams = [{
+			"auditStamp":{
+				"time": sys_time,
+				"actor": actor
+			},
+			"dataset": view_urn,
+			"type":"TRANSFORMED"
+		} for view_urn in dashboard_element.get_view_urns()]
+
+		doc_elements = [{
+			"url": dashboard_element.url,
+			"description": "Looker chart url",
+			"createStamp": {
+				"time": sys_time,
+				"actor": actor
+			}
+		}]
+
+		return {
+			"auditHeader": None,
+			"proposedSnapshot": ("com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot", {
+				"urn": f"urn:li:dataset:(urn:li:dataPlatform:{VISUALIZATION_DATAHUB_PLATFORM},{dashboard_element.get_urn_element_id()},PROD)",
+				"aspects": [
+					("com.linkedin.pegasus2avro.dataset.UpstreamLineage", {"upstreams": upstreams}),
+					("com.linkedin.pegasus2avro.common.InstitutionalMemory", {"elements": doc_elements}),
+					("com.linkedin.pegasus2avro.dataset.DatasetProperties", {"description": dashboard_element.title, "customProperties": {}}),
+					("com.linkedin.pegasus2avro.common.Ownership", {
+						"owners": owners,
+						"lastModified": {
+							"time": sys_time,
+							"actor": actor
+						}
+					})
+				]
+			}),
+			"proposedDelta": None
+		}
+
+	@staticmethod
+	def make_dashboard_mce(looker_dashboard: LookerDashboard) -> DashboardKafkaEvents:
+		actor, sys_time = get_actor_and_sys_time()
+
+		chart_mces = [WorkaroundDatahubEvents.make_chart_mce(element) for element in looker_dashboard.dashboard_elements]
+
+		owners = [{
+			"owner": actor,
+			"type": "DEVELOPER"
+		}]
+
+		upstreams = [{
+			"auditStamp":{
+				"time": sys_time,
+				"actor": actor
+			},
+			"dataset": chart_urn,
+			"type":"TRANSFORMED"
+		} for chart_urn in [mce["proposedSnapshot"][1]["urn"] for mce in chart_mces]]
+
+		doc_elements = [{
+			"url": looker_dashboard.url,
+			"description": "Looker dashboard url",
+			"createStamp": {
+				"time": sys_time,
+				"actor": actor
+			}
+		}]
+
+		dashboard_mce = {
+			"auditHeader": None,
+			"proposedSnapshot": ("com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot", {
+				"urn": f"urn:li:dataset:(urn:li:dataPlatform:{VISUALIZATION_DATAHUB_PLATFORM},{looker_dashboard.get_urn_dashboard_id()},PROD)",
+				"aspects": [
+					("com.linkedin.pegasus2avro.dataset.UpstreamLineage", {"upstreams": upstreams}),
+					("com.linkedin.pegasus2avro.common.InstitutionalMemory", {"elements": doc_elements}),
+					("com.linkedin.pegasus2avro.dataset.DatasetProperties", {"description": looker_dashboard.title, "customProperties": {}}),
+					("com.linkedin.pegasus2avro.common.Ownership", {
+						"owners": owners,
+						"lastModified": {
+							"time": sys_time,
+							"actor": actor
+						}
+					})
+				]
+			}),
+			"proposedDelta": None
+		}
+
+		return DashboardKafkaEvents(dashboard_mce=dashboard_mce, chart_mces=chart_mces)
+
+
+def delivery_report(err, msg):
+	""" Called once for each message produced to indicate delivery result.
+		Triggered by poll() or flush(). """
+	if err is not None:
+		print('Message delivery failed: {}'.format(err))
+	else:
+		print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+
+def make_kafka_producer(extra_kafka_conf):
+	conf = {
+		"on_delivery": delivery_report,
+		**extra_kafka_conf
+	}
+
+	key_schema = avro.loads('{"type": "string"}')
+	record_schema = avro.load(AVSC_PATH)
+	producer = AvroProducer(conf, default_key_schema=key_schema, default_value_schema=record_schema)
+	return producer
+
+
+def _extract_view_from_field(field: str) -> str:
+	assert field.count(".") == 1, f"Error: A field must be prefixed by a view name, field is: {field}"
+	view_name = field.split(".")[0]
+	return view_name
+
+
+def get_views_from_query(query: Query) -> typing.List[str]:
+	all_views = set()
+
+	# query.dynamic_fields can contain:
+	# - looker table calculations: https://docs.looker.com/exploring-data/using-table-calculations
+	# - looker custom measures: https://docs.looker.com/de/exploring-data/adding-fields/custom-measure
+	# - looker custom dimensions: https://docs.looker.com/exploring-data/adding-fields/custom-measure#creating_a_custom_dimension_using_a_looker_expression
+	dynamic_fields = json.loads(query.dynamic_fields if query.dynamic_fields is not None else '[]')
+	custom_field_to_underlying_field = {}
+	for field in dynamic_fields:
+		# Table calculations can only reference fields used in the fields section, so this will always be a subset of of the query.fields
+		if "table_calculation" in field:
+			continue
+		# Looker custom measures can reference fields in arbitrary views, so this needs to be parsed to find the underlying view field the custom measure is based on
+		if "measure" in field:
+			measure = field["measure"]
+			based_on = field["based_on"]
+			custom_field_to_underlying_field[measure] = based_on
+
+		# Looker custom dimensions can reference fields in arbitrary views, so this needs to be parsed to find the underlying view field the custom measure is based on
+		# However, unlike custom measures custom dimensions can be defined using an arbitrary expression
+		# We are not going to support parsing arbitrary Looker expressions here, so going to ignore these fields for now
+		# TODO: support parsing arbitrary looker expressions
+		if "dimension" in field:
+			dimension = field["dimension"]
+			expression = field["expression"]
+			custom_field_to_underlying_field[dimension] = None
+
+	# A query uses fields defined in views, find the views those fields use
+	fields: typing.Sequence[str] = query.fields if query.fields is not None else []
+	for field in fields:
+		# If the field is a custom field, look up the field it is based on
+		field_name = custom_field_to_underlying_field[field] if field in custom_field_to_underlying_field else field
+		if field_name is None:
+			continue
+		view_name = _extract_view_from_field(field_name)
+		all_views.add(view_name)
+
+	# A query uses fields for filtering and those fields are defined in views, find the views those fields use
+	filters: typing.MutableMapping[str, typing.Any] = query.filters if query.filters is not None else {}
+	for field in filters.keys():
+		# If the field is a custom field, look up the field it is based on
+		field_name = custom_field_to_underlying_field[field] if field in custom_field_to_underlying_field else field
+		if field_name is None:
+			continue
+		view_name = _extract_view_from_field(field_name)
+		all_views.add(view_name)
+
+	return list(all_views)
+
+
+def get_views_from_look(look: LookWithQuery):
+	return get_views_from_query(look.query)
+
+
+def get_looker_dashboard_element(element: DashboardElement)-> typing.Optional[LookerDashboardElement]:
+	# Dashboard elements can use raw queries against explores
+	if element.query is not None:
+		views = get_views_from_query(element.query)
+		return LookerDashboardElement(id=element.id, title=element.title, look_id=None, query_slug=element.query.slug, looker_views=views)
+
+	# Dashboard elements can *alternatively* link to an existing look
+	if element.look is not None:
+		views = get_views_from_look(element.look)
+		return LookerDashboardElement(id=element.id, title=element.title, look_id=element.look_id, query_slug=element.look.query.slug, looker_views=views)
+
+	# This occurs for "text" dashboard elements that just contain static text (ie: no queries)
+	# There is not much meaningful info to extract from these elements, so ignore them
+	return None
+
+
+def get_looker_dashboard(dashboard: Dashboard) -> LookerDashboard:
+	dashboard_elements: typing.List[LookerDashboardElement] = []
+	for element in dashboard.dashboard_elements:
+		looker_dashboard_element = get_looker_dashboard_element(element)
+		if looker_dashboard_element is not None:
+			dashboard_elements.append(looker_dashboard_element)
+
+	looker_dashboard = LookerDashboard(id=dashboard.id, title=dashboard.title, description=dashboard.description, dashboard_elements=dashboard_elements)
+	return looker_dashboard
+
+
+# Perform IO in main
+def main():
+	kafka_producer = make_kafka_producer(EXTRA_KAFKA_CONF)
+	sdk = looker_sdk.init31()
+	dashboard_ids = [dashboard_base.id for dashboard_base in sdk.all_dashboards(fields="id")]
+
+	looker_dashboards = []
+	for dashboard_id in dashboard_ids:
+		try:
+			fields = ["id", "title", "dashboard_elements", "dashboard_filters"]
+			dashboard_object = sdk.dashboard(dashboard_id=dashboard_id, fields=",".join(fields))
+		except SDKError as e:
+			# A looker dashboard could be deleted in between the list and the get
+			print(f"Skipping dashboard with dashboard_id: {dashboard_id}")
+			print(e)
+			continue
+
+		looker_dashboard = get_looker_dashboard(dashboard_object)
+		looker_dashboards.append(looker_dashboard)
+		pprint(looker_dashboard)
+
+	for looker_dashboard in looker_dashboards:
+		workaround_dashboard_kafka_events = WorkaroundDatahubEvents.make_dashboard_mce(looker_dashboard)
+		# Hard to test these events since datahub does not have a UI, for now disable sending them
+		# proper_dashboard_kafka_events = ProperDatahubEvents.make_dashboard_mce(looker_dashboard)
+
+		for mce in workaround_dashboard_kafka_events.all_mces():
+			print(mce)
+			kafka_producer.produce(topic=KAFKA_TOPIC, key=mce['proposedSnapshot'][1]['urn'], value=mce)
+			kafka_producer.flush()
+
+
+if __name__ == "__main__":
+	main()

--- a/contrib/metadata-ingestion/python/looker/dashboard_ingestion/requirements.txt
+++ b/contrib/metadata-ingestion/python/looker/dashboard_ingestion/requirements.txt
@@ -1,0 +1,4 @@
+avro-python3==1.8.2
+confluent-kafka[avro]==1.4.0
+PyYAML==5.3.1
+looker-sdk==0.1.3b20

--- a/contrib/metadata-ingestion/python/looker/lookml_ingestion/README.md
+++ b/contrib/metadata-ingestion/python/looker/lookml_ingestion/README.md
@@ -1,0 +1,20 @@
+## lookml_ingestion.py
+This script ingests Looker view metadata from lookml into datahub. Looker views are essentially like database views that can be either materialized or ephemeral, so we treat them as you would any other dataset in datahub.
+
+Underneath the hood, this script uses the `lkml` python parsing library to parse lkml files and so it comes with all the limitations of that underlying parser.
+
+Roughly how the script works:
+- Point the script at a directory on the filesystem, finds all files named `*.model.lkml` in any level of nesting
+- Finds the viewfile includes in the model file, this indicates that the viewfile is a part of that model (and a model has a single SQL connection associated with it). Does not handle a model importing a view file but *not* using the view in the model since that would require parsing explore blocks and adds complexity.
+- For each viewfile in the model, parses the view files. For each view in the viewfile, resolve the sql table name for the view:
+	- We do not support parsing derived tables using a `sql:` block, this would require parsing SQL to understand dependencies. We only support views using `sql_table_name`. In the future, could support limited SQL parsing for limited SQL dialects.
+	- We support views using the `extends` keyword: https://docs.looker.com/reference/view-params/extends-for-view This is surprisingly painful because views can extend other views in other files. We do this inefficiently right now.
+	- We do not support views using `refinements`. SpotHero does not use refinements right now, so we had no need to implement it: https://docs.looker.com/data-modeling/learning-lookml/refinements
+- After binding views to models and finding the sql table name associated with the views, we generate the MCE events into a separate looker platform in datahub since they are not "real" tables but "virtual" looker tables
+
+## Steps 
+- Use a version of python >= 3.7
+- Make a virtual environment
+- pip install -r requirements.txt
+- Set env var: LOOKER_DIRECTORY to the root path of lkml on your filesystem
+- Modify EXTRA_KAFKA_CONF section of script to point to datahub

--- a/contrib/metadata-ingestion/python/looker/lookml_ingestion/lookml_ingestion.py
+++ b/contrib/metadata-ingestion/python/looker/lookml_ingestion/lookml_ingestion.py
@@ -1,0 +1,333 @@
+import lkml
+import glob
+import time
+import typing
+import os
+
+from confluent_kafka import avro
+from confluent_kafka.avro import AvroProducer
+
+from dataclasses import dataclass, replace
+
+# Configuration
+AVSC_PATH = "../../metadata-events/mxe-schemas/src/renamed/avro/com/linkedin/mxe/MetadataChangeEvent.avsc"
+KAFKA_TOPIC = 'MetadataChangeEvent_v4'
+
+# LOOKER_DIRECTORY = "./test_lookml"
+LOOKER_DIRECTORY = os.environ["LOOKER_DIRECTORY"]
+LOOKER_DIRECTORY = os.path.abspath(LOOKER_DIRECTORY)
+
+EXTRA_KAFKA_CONF = {
+  'bootstrap.servers': 'localhost:9092',
+  'schema.registry.url': 'http://localhost:8081'
+  # 'security.protocol': 'SSL',
+  # 'ssl.ca.location': '',
+  # 'ssl.key.location': '',
+  # 'ssl.certificate.location': ''
+}
+
+# The datahub platform where looker views are stored
+LOOKER_VIEW_PLATFORM = "looker_views"
+
+class LookerViewFileLoader:
+	"""
+	Loads the looker viewfile at a :path and caches the LookerViewFile in memory
+	This is to avoid reloading the same file off of disk many times during the recursive include resolution process
+	"""
+
+	def __init__(self):
+		self.viewfile_cache = {}
+
+	def _load_viewfile(self, path: str) -> typing.Optional["LookerViewFile"]:
+		if path in self.viewfile_cache:
+			return self.viewfile_cache[path]
+
+		try:
+			with open(path, "r") as file:
+				parsed = lkml.load(file)
+				looker_viewfile = LookerViewFile.from_looker_dict(path, parsed)
+				self.viewfile_cache[path] = looker_viewfile
+				return looker_viewfile	
+		except Exception as e:
+			print(e)
+			print(f"Error processing view file {path}. Skipping it")
+
+	def load_viewfile(self, path: str, connection: str):
+		viewfile = self._load_viewfile(path)
+		if viewfile is None:
+			return None
+
+		return replace(viewfile, connection=connection)
+
+
+
+@dataclass
+class LookerModel:
+	connection: str 
+	includes: typing.List[str]
+	resolved_includes: typing.List[str]
+
+	@staticmethod
+	def from_looker_dict(looker_model_dict):
+		connection = looker_model_dict["connection"]
+		includes = looker_model_dict["includes"]
+		resolved_includes = LookerModel.resolve_includes(includes)
+
+		return LookerModel(connection=connection, includes=includes, resolved_includes=resolved_includes)
+
+	@staticmethod
+	def resolve_includes(includes) -> typing.List[str]:
+		resolved = []
+		for inc in includes:
+			# Massage the looker include into a valid glob wildcard expression
+			glob_expr = f"{LOOKER_DIRECTORY}/{inc}"
+			outputs = glob.glob(glob_expr)
+			resolved.extend(outputs)
+		return resolved
+
+
+@dataclass
+class LookerViewFile:
+	absolute_file_path: str
+	connection: typing.Optional[str]
+	includes: typing.List[str]
+	resolved_includes: typing.List[str]
+	views: typing.List[typing.Dict]
+
+	@staticmethod
+	def from_looker_dict(absolute_file_path, looker_view_file_dict):
+		includes = looker_view_file_dict.get("includes", [])
+		resolved_includes = LookerModel.resolve_includes(includes)
+		views = looker_view_file_dict.get("views", [])
+
+		return LookerViewFile(absolute_file_path=absolute_file_path, connection=None, includes=includes, resolved_includes=resolved_includes, views=views)
+
+@dataclass
+class LookerView:
+	absolute_file_path: str
+	connection: str
+	view_name: str
+	sql_table_names: typing.List[str] 
+
+	def get_relative_file_path(self):
+		if LOOKER_DIRECTORY in self.absolute_file_path:
+			return self.absolute_file_path.replace(LOOKER_DIRECTORY, '').lstrip('/')
+		else:
+			raise Exception(f"Found a looker view with name: {view_name} at path: {absolute_file_path} not underneath the base LOOKER_DIRECTORY: {LOOKER_DIRECTORY}. This should not happen")
+
+	@staticmethod
+	def from_looker_dict(looker_view, connection: str, looker_viewfile: LookerViewFile, looker_viewfile_loader: LookerViewFileLoader) -> typing.Optional["LookerView"]:
+		view_name = looker_view["name"]
+		sql_table_name = looker_view.get("sql_table_name", None)
+		# Some sql_table_name fields contain quotes like: optimizely."group", just remove the quotes
+		sql_table_name = ''.join(c for c in sql_table_name if c != '"') if sql_table_name is not None else None
+		derived_table = looker_view.get("derived_table", None)
+
+		# We do not support parsing SQL to extract dependencies right now, load the view but ignore sql_table_names
+		if derived_table is not None:
+			print(f"Skipping sql_table_names for derived table with view_name: {view_name}. Need to parse SQL in the future")
+			return LookerView(absolute_file_path=looker_viewfile.absolute_file_path, connection=connection, view_name=view_name, sql_table_names=[])
+
+		# There is a single dependency in the view, on the sql_table_name
+		if sql_table_name is not None:
+			return LookerView(absolute_file_path=looker_viewfile.absolute_file_path, connection=connection, view_name=view_name, sql_table_names=[sql_table_name])
+
+		# The sql_table_name might be defined in another view and this view is extending that view, try to find it
+		else:
+			extends = looker_view.get("extends", [])
+			if len(extends) == 0:
+				# The view is malformed, the view is not a derived table, does not contain a sql_table_name or an extends
+				print(f"Skipping malformed with view_name: {view_name}. View should have a sql_table_name if it is not a derived table")
+				return None
+
+			extends_to_looker_view =[]
+
+			# The base view could live in the same file
+			for raw_view in looker_viewfile.views:
+				raw_view_name = raw_view["name"]
+				# Make sure to skip loading view we are currently trying to resolve
+				if raw_view_name != view_name:
+					maybe_looker_view = LookerView.from_looker_dict(raw_view, connection, looker_viewfile, looker_viewfile_loader)
+					if maybe_looker_view is not None and maybe_looker_view.view_name in extends:
+						extends_to_looker_view.append(maybe_looker_view)
+
+			# Or it could live in one of the included files, we do not know which file the base view lives in, try them all!
+			for include in looker_viewfile.resolved_includes:
+				looker_viewfile = looker_viewfile_loader.load_viewfile(include, connection)
+				if looker_viewfile is not None:
+					for view in looker_viewfile.views:
+						maybe_looker_view = LookerView.from_looker_dict(view, connection, looker_viewfile, looker_viewfile_loader)
+						if maybe_looker_view is None:
+							continue 
+
+						if maybe_looker_view is not None and maybe_looker_view.view_name in extends:
+							extends_to_looker_view.append(maybe_looker_view)
+
+			if len(extends_to_looker_view) != 1:
+				print(f"Skipping malformed view with view_name: {view_name}. View should have a single view in a view inheritance chain with a sql_table_name")
+				return None
+
+			output_looker_view = LookerView(absolute_file_path=looker_viewfile.absolute_file_path, connection=connection, view_name=view_name, sql_table_names=extends_to_looker_view[0].sql_table_names)
+			return output_looker_view
+
+
+
+
+def get_platform_and_table(view_name: str, connection: str, sql_table_name: str):
+	"""
+	This will depend on what database connections you use in Looker 
+	For SpotHero, we had two database connections in Looker: "redshift_test" (a redshift database) and "presto" (a presto database)
+	Presto supports querying across multiple catalogs, so we infer which underlying database presto is using based on the presto catalog name
+	For SpotHero, we have 3 catalogs in presto: "redshift", "hive", and "hive_emr"
+	"""
+	if connection == "redshift_test":
+		platform = "redshift"
+		table_name = sql_table_name
+		return platform, table_name
+
+	elif connection == "presto":
+		parts = sql_table_name.split(".")
+		catalog = parts[0]
+
+		if catalog == "hive":
+			platform = "hive"
+		elif catalog == "hive_emr":
+			platform = "hive_emr"
+		elif catalog == "redshift":
+			platform = "redshift"
+		else:
+			# Looker lets you exclude a catalog and use a configured default, the default we have configured is to use hive_emr
+			if sql_table_name.count(".") != 1:
+				raise Exception("Unknown catalog for sql_table_name: {sql_table_name} for view_name: {view_name}")
+
+			platform = "hive_emr"
+			return platform, sql_table_name
+
+		table_name = ".".join(parts[1::])
+		return platform, table_name
+	else:
+		raise Exception(f"Could not find a platform for looker view with connection: {connection}")
+
+
+def construct_datalineage_urn(view_name: str, connection: str, sql_table_name: str):
+	platform, table_name = get_platform_and_table(view_name, connection, sql_table_name)
+	return f"urn:li:dataset:(urn:li:dataPlatform:{platform},{table_name},PROD)"
+
+def construct_data_urn(looker_view: LookerView):
+	return f"urn:li:dataset:(urn:li:dataPlatform:{LOOKER_VIEW_PLATFORM},{looker_view.view_name},PROD)"
+
+
+
+def build_dataset_mce(looker_view: LookerView):
+    """
+    Creates MetadataChangeEvent for the dataset, creating upstream lineage links
+    """
+    actor, sys_time = "urn:li:corpuser:etl", int(time.time()) * 1000
+
+    upstreams = [{
+    	"auditStamp":{
+    		"time": sys_time,
+    		"actor":actor
+    	},
+    	"dataset": construct_datalineage_urn(looker_view.view_name, looker_view.connection, sql_table_name),
+    	"type":"TRANSFORMED"
+    } for sql_table_name in looker_view.sql_table_names]
+
+
+    doc_elements = [{
+    	"url":f"https://github.com/spothero/internal-looker-repo/blob/master/{looker_view.get_relative_file_path()}",
+    	"description":"Github looker view definition",
+    	"createStamp":{
+    		"time": sys_time,
+    		"actor": actor
+    	}
+    }]
+
+    owners = [{
+    	"owner": f"urn:li:corpuser:analysts",
+    	"type": "DEVELOPER"
+    }]
+
+    return {
+        "auditHeader": None,
+        "proposedSnapshot":("com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot", {
+            "urn": construct_data_urn(looker_view),
+            "aspects": [
+            	("com.linkedin.pegasus2avro.dataset.UpstreamLineage", {"upstreams": upstreams}),
+            	("com.linkedin.pegasus2avro.common.InstitutionalMemory", {"elements": doc_elements}),
+            	("com.linkedin.pegasus2avro.common.Ownership", {
+            		"owners": owners,
+            		"lastModified":{
+            			"time": sys_time,
+            			"actor": actor
+            		}
+            	})
+            ]
+        }),
+        "proposedDelta": None
+    }
+
+
+def delivery_report(err, msg):
+    """ Called once for each message produced to indicate delivery result.
+        Triggered by poll() or flush(). """
+    if err is not None:
+        print('Message delivery failed: {}'.format(err))
+    else:
+        print('Message delivered to {} [{}]'.format(msg.topic(), msg.partition()))
+
+
+def make_kafka_producer(extra_kafka_conf):
+	conf = {
+		"on_delivery": delivery_report,
+		**extra_kafka_conf
+	}
+
+	key_schema = avro.loads('{"type": "string"}')
+	record_schema = avro.load(AVSC_PATH)
+	producer = AvroProducer(conf, default_key_schema=key_schema, default_value_schema=record_schema)
+	return producer
+
+
+def main():
+	kafka_producer = make_kafka_producer(EXTRA_KAFKA_CONF)
+	viewfile_loader = LookerViewFileLoader()
+
+	looker_models = []
+	all_views = []
+
+	model_files = sorted(f for f in glob.glob(f"{LOOKER_DIRECTORY}/**/*.model.lkml", recursive=True))
+	for f in model_files:
+		try:
+			with open(f, 'r') as file:
+				parsed = lkml.load(file)
+				looker_model = LookerModel.from_looker_dict(parsed)
+				looker_models.append(looker_model)
+		except Exception as e:
+			print(e)
+			print(f"Error processing model file {f}. Skipping it")
+
+
+
+	for model in looker_models:
+		for include in model.resolved_includes:
+			looker_viewfile = viewfile_loader.load_viewfile(include, model.connection)
+			if looker_viewfile is not None:
+				for raw_view in looker_viewfile.views:
+					maybe_looker_view = LookerView.from_looker_dict(raw_view, model.connection, looker_viewfile, viewfile_loader)
+					if maybe_looker_view:
+						all_views.append(maybe_looker_view)
+
+
+	for view in all_views:
+		MCE = build_dataset_mce(view)
+		print(view)
+		print(MCE)
+		kafka_producer.produce(topic=KAFKA_TOPIC, key=MCE['proposedSnapshot'][1]['urn'], value=MCE)
+		kafka_producer.flush()
+
+
+
+if __name__ == "__main__":
+	main()
+

--- a/contrib/metadata-ingestion/python/looker/lookml_ingestion/requirements.txt
+++ b/contrib/metadata-ingestion/python/looker/lookml_ingestion/requirements.txt
@@ -1,0 +1,3 @@
+lkml==0.2.2
+avro-python3==1.8.2
+confluent-kafka[avro]==1.4.0


### PR DESCRIPTION
Adds (very experimental) support for ingesting Looker metadata (views, charts, dashboards) into datahub through scraping LookML and scraping the Looker API. 

SpotHero built this POC a few months ago before datahub officially supported ingesting dashboards into datahub. As a workaround, we created "virtual" datasets corresponding to Looker dashboards/charts so we could test out lineage between dashboards. 

We are sharing these scripts since there is some interest around ingesting Looker metadata into datahub, but SpotHero does not have the time to robustly build this support out. If others are curious and want to try ingesting Looker metadata, this would be a good place to start!