### PR TITLE
feat(lineage): adding directionality to lineage edges to make the visualization more clear

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -13,8 +13,8 @@ function truncate(input, length) {
     return input;
 }
 
-const width = 140;
-const height = 80;
+export const width = 140;
+export const height = 80;
 const centerX = -width / 2;
 const centerY = -height / 2;
 

--- a/datahub-web-react/src/app/lineage/LineageTreeNodeAndEdgeRenderer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageTreeNodeAndEdgeRenderer.tsx
@@ -119,6 +119,8 @@ export default function LineageTreeNodeAndEdgeRenderer({
                         fill="none"
                         key={`edge-${link.source.data.urn}-${link.target.data.urn}-${direction}`}
                         data-testid={`edge-${link.source.data.urn}-${link.target.data.urn}-${direction}`}
+                        markerEnd="url(#triangle-downstream)"
+                        markerStart="url(#triangle-upstream)"
                     />
                 );
             })}

--- a/datahub-web-react/src/app/lineage/LineageViz.tsx
+++ b/datahub-web-react/src/app/lineage/LineageViz.tsx
@@ -92,9 +92,9 @@ export default function LineageViz({
                     >
                         <defs>
                             <marker
-                                id="triangle"
+                                id="triangle-downstream"
                                 viewBox="0 0 10 10"
-                                refX="80"
+                                refX="10"
                                 refY="5"
                                 markerUnits="strokeWidth"
                                 markerWidth="10"
@@ -102,6 +102,18 @@ export default function LineageViz({
                                 orient="auto"
                             >
                                 <path d="M 0 0 L 10 5 L 0 10 z" fill="#000" />
+                            </marker>
+                            <marker
+                                id="triangle-upstream"
+                                viewBox="0 0 10 10"
+                                refX="0"
+                                refY="5"
+                                markerUnits="strokeWidth"
+                                markerWidth="10"
+                                markerHeight="10"
+                                orient="auto"
+                            >
+                                <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#000" />
                             </marker>
                         </defs>
                         <rect width={width} height={height} fill="#f6f8fa" />

--- a/datahub-web-react/src/app/lineage/utils/adjustVXTreeLayout.ts
+++ b/datahub-web-react/src/app/lineage/utils/adjustVXTreeLayout.ts
@@ -1,5 +1,6 @@
 import { HierarchyPointNode } from '@vx/hierarchy/lib/types';
 import { NodeData, Direction } from '../types';
+import { width as nodeWidth } from '../LineageEntityNode';
 
 export default function adjustVXTreeLayout({
     tree,
@@ -49,12 +50,12 @@ export default function adjustVXTreeLayout({
     const edgesToReturn = tree.links().map((linkToCopy) => ({
         target: {
             x: linkToCopy.target.x,
-            y: linkToCopy.target.y,
+            y: linkToCopy.target.y + (direction === Direction.Upstream ? 0 : -(nodeWidth / 2)),
             data: { ...linkToCopy.target.data },
         },
         source: {
             x: linkToCopy.source.x,
-            y: linkToCopy.source.y,
+            y: linkToCopy.source.y + (direction === Direction.Upstream ? -(nodeWidth / 2) : 0),
             data: { ...linkToCopy.source.data },
         },
     }));


### PR DESCRIPTION
Shift line positioning so lines terminate at the beginning of the nodes rather than the centers. Also adds arrows at the vertices of the downstream node.

![image](https://user-images.githubusercontent.com/2455694/113540396-ed11d780-9594-11eb-9e18-8337ad329f33.png)



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
