### PR TITLE
fix: remove `restart: always` from docker-compose for consistency

### DIFF
--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -7,7 +7,6 @@ services:
     hostname: mysql
     image: mysql:5.7
     env_file: mysql/env/docker.env
-    restart: always
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     ports:
       - "3306:3306"

--- a/docker/mariadb/docker-compose.mariadb.yml
+++ b/docker/mariadb/docker-compose.mariadb.yml
@@ -7,7 +7,6 @@ services:
     hostname: mariadb
     image: mariadb:10.5
     env_file: env/docker.env
-    restart: always
     ports:
       - '3306:3306'
     volumes:

--- a/docker/mysql/docker-compose.mysql.yml
+++ b/docker/mysql/docker-compose.mysql.yml
@@ -7,7 +7,6 @@ services:
     hostname: mysql
     image: mysql:5.7
     env_file: env/docker.env
-    restart: always
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     ports:
       - "3306:3306"

--- a/docker/postgres/docker-compose.postgres.yml
+++ b/docker/postgres/docker-compose.postgres.yml
@@ -7,7 +7,6 @@ services:
     hostname: postgres
     image: postgres:12.3
     env_file: env/docker.env
-    restart: always
     ports:
       - '5432:5432'
     volumes:


### PR DESCRIPTION
Only the DB containers had `restart: always` specified. This will make the behavior consistent across all the containers. Also fixes a typo: postgre -> postgres. 


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
