### PR TITLE
feat(lineage): adding ghost edges indicating hidden dependencies

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -123,7 +123,7 @@ export default function LineageEntityNode({
                 </text>
                 {unexploredHiddenChildren && isHovered && (
                     <text dy=".33em" fontSize={14} fontFamily="Arial" textAnchor="middle" fill="black" y={centerY - 20}>
-                        {unexploredHiddenChildren} hidden {direction.toLowerCase()}{' '}
+                        {unexploredHiddenChildren} hidden {direction === Direction.Upstream ? 'downstream' : 'upstream'}{' '}
                         {unexploredHiddenChildren > 1 ? 'dependencies' : 'dependency'}
                     </text>
                 )}

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Group } from '@vx/group';
+import { LinkHorizontal } from '@vx/shape';
 import styled from 'styled-components';
 
 import { EntityType } from '../../types.generated';
@@ -31,6 +32,7 @@ export default function LineageEntityNode({
     onExpandClick,
     direction,
     isCenterNode,
+    nodesToRenderByUrn,
 }: {
     node: { x: number; y: number; data: Omit<NodeData, 'children'> };
     isSelected: boolean;
@@ -40,9 +42,37 @@ export default function LineageEntityNode({
     onHover: (EntitySelectParams) => void;
     onExpandClick: (LineageExpandParams) => void;
     direction: Direction;
+    nodesToRenderByUrn: { [key: string]: { x: number; y: number; data: Omit<NodeData, 'children'> }[] };
 }) {
+    const unexploredHiddenChildren =
+        node?.data?.countercurrentChildrenUrns?.filter((urn) => !(urn in nodesToRenderByUrn))?.length || 0;
+
     return (
         <PointerGroup data-testid={`node-${node.data.urn}-${direction}`} top={node.x} left={node.y}>
+            {unexploredHiddenChildren && (
+                <Group>
+                    {[...Array(unexploredHiddenChildren)].map((_, index) => {
+                        const link = {
+                            source: {
+                                x: 0,
+                                y: direction === Direction.Upstream ? 70 : -70,
+                            },
+                            target: {
+                                x: (0.5 / (index + 1)) * 80 * (index % 2 === 0 ? 1 : -1),
+                                y: direction === Direction.Upstream ? 150 : -150,
+                            },
+                        };
+                        return (
+                            <LinkHorizontal
+                                data={link}
+                                stroke={`url(#gradient-${direction})`}
+                                strokeWidth="1"
+                                fill="none"
+                            />
+                        );
+                    })}
+                </Group>
+            )}
             {node.data.unexploredChildren && (
                 <Group
                     onClick={() => {
@@ -91,6 +121,12 @@ export default function LineageEntityNode({
                 <text dy=".33em" fontSize={14} fontFamily="Arial" textAnchor="middle" fill="black">
                     {truncate(node.data.name?.split('.').slice(-1)[0], 16)}
                 </text>
+                {unexploredHiddenChildren && isHovered && (
+                    <text dy=".33em" fontSize={14} fontFamily="Arial" textAnchor="middle" fill="black" y={centerY - 20}>
+                        {unexploredHiddenChildren} hidden {direction.toLowerCase()}{' '}
+                        {unexploredHiddenChildren > 1 ? 'dependencies' : 'dependency'}
+                    </text>
+                )}
             </Group>
         </PointerGroup>
     );

--- a/datahub-web-react/src/app/lineage/LineageTreeNodeAndEdgeRenderer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageTreeNodeAndEdgeRenderer.tsx
@@ -78,7 +78,7 @@ export default function LineageTreeNodeAndEdgeRenderer({
 }: Props) {
     const [hoveredEntity, setHoveredEntity] = useState<EntitySelectParams | undefined>(undefined);
 
-    const { nodesToRender, edgesToRender } = useMemo(() => {
+    const { nodesToRender, edgesToRender, nodesByUrn } = useMemo(() => {
         return adjustVXTreeLayout({ tree, direction });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [tree, direction, xCanvasScale, yCanvasScale]);
@@ -142,6 +142,7 @@ export default function LineageTreeNodeAndEdgeRenderer({
                         onExpandClick={onLineageExpand}
                         direction={direction}
                         isCenterNode={tree.data.urn === node.data.urn}
+                        nodesToRenderByUrn={nodesByUrn}
                     />
                 );
             })}

--- a/datahub-web-react/src/app/lineage/LineageViz.tsx
+++ b/datahub-web-react/src/app/lineage/LineageViz.tsx
@@ -103,18 +103,14 @@ export default function LineageViz({
                             >
                                 <path d="M 0 0 L 10 5 L 0 10 z" fill="#000" />
                             </marker>
-                            <marker
-                                id="triangle-upstream"
-                                viewBox="0 0 10 10"
-                                refX="0"
-                                refY="5"
-                                markerUnits="strokeWidth"
-                                markerWidth="10"
-                                markerHeight="10"
-                                orient="auto"
-                            >
-                                <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#000" />
-                            </marker>
+                            <linearGradient id="gradient-Downstream" x1="1" x2="0" y1="0" y2="0">
+                                <stop offset="0%" stopColor="black" />
+                                <stop offset="100%" stopColor="black" stopOpacity="0" />
+                            </linearGradient>
+                            <linearGradient id="gradient-Upstream" x1="0" x2="1" y1="0" y2="0">
+                                <stop offset="0%" stopColor="black" />
+                                <stop offset="100%" stopColor="black" stopOpacity="0" />
+                            </linearGradient>
                         </defs>
                         <rect width={width} height={height} fill="#f6f8fa" />
                         <LineageTree

--- a/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
+++ b/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
@@ -45,6 +45,7 @@ describe('constructTree', () => {
                     type: EntityType.Dataset,
                     unexploredChildren: 0,
                     urn: 'urn:li:dataset:4',
+                    countercurrentChildrenUrns: [],
                     children: [],
                 },
             ],
@@ -68,6 +69,7 @@ describe('constructTree', () => {
             unexploredChildren: 0,
             children: [
                 {
+                    countercurrentChildrenUrns: [],
                     name: 'Fifth Test Dataset',
                     type: EntityType.Dataset,
                     unexploredChildren: 0,
@@ -100,12 +102,14 @@ describe('constructTree', () => {
                     type: EntityType.Dataset,
                     unexploredChildren: 0,
                     urn: 'urn:li:dataset:4',
+                    countercurrentChildrenUrns: ['urn:li:dataset:3'],
                     children: [
                         {
                             name: 'Sixth Test Dataset',
                             type: 'DATASET',
                             unexploredChildren: 0,
                             urn: 'urn:li:dataset:6',
+                            countercurrentChildrenUrns: ['urn:li:dataset:4'],
                             children: [
                                 {
                                     name: 'Fifth Test Dataset',
@@ -113,6 +117,11 @@ describe('constructTree', () => {
                                     unexploredChildren: 0,
                                     urn: 'urn:li:dataset:5',
                                     children: [],
+                                    countercurrentChildrenUrns: [
+                                        'urn:li:dataset:7',
+                                        'urn:li:dataset:6',
+                                        'urn:li:dataset:4',
+                                    ],
                                 },
                             ],
                         },
@@ -122,6 +131,7 @@ describe('constructTree', () => {
                             unexploredChildren: 0,
                             urn: 'urn:li:dataset:5',
                             children: [],
+                            countercurrentChildrenUrns: ['urn:li:dataset:7', 'urn:li:dataset:6', 'urn:li:dataset:4'],
                         },
                     ],
                 },
@@ -169,6 +179,7 @@ describe('constructTree', () => {
                     unexploredChildren: 2,
                     urn: 'urn:li:dataset:4',
                     children: [],
+                    countercurrentChildrenUrns: ['urn:li:dataset:3'],
                 },
             ],
         });

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -28,6 +28,9 @@ export type NodeData = {
     type?: EntityType;
     children?: Array<NodeData>;
     unexploredChildren?: number;
+    // Hidden children are unexplored but in the opposite direction of the flow of the graph.
+    // Currently our visualization does not support expanding in two directions
+    countercurrentChildrenUrns?: string[];
 };
 
 export type FetchedEntities = { [x: string]: FetchedEntity };

--- a/datahub-web-react/src/app/lineage/utils/adjustVXTreeLayout.ts
+++ b/datahub-web-react/src/app/lineage/utils/adjustVXTreeLayout.ts
@@ -62,5 +62,5 @@ export default function adjustVXTreeLayout({
         },
     }));
 
-    return { nodesToRender: nodesToReturn, edgesToRender: edgesToReturn };
+    return { nodesToRender: nodesToReturn, edgesToRender: edgesToReturn, nodesByUrn };
 }

--- a/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructFetchedNode.ts
@@ -21,6 +21,8 @@ export default function constructFetchedNode(
                 fetchedNode?.[direction === Direction.Upstream ? 'upstreamChildren' : 'downstreamChildren']?.filter(
                     (childUrn) => !(childUrn in fetchedEntities),
                 ).length || 0,
+            countercurrentChildrenUrns:
+                fetchedNode?.[direction === Direction.Downstream ? 'upstreamChildren' : 'downstreamChildren'],
             children: [],
         };
 


### PR DESCRIPTION
When we are not able to expand out all the dependencies of a node, we will show a ghost edge indicating a dependency does exist. This dependency can then be viewed when the user focuses on that node specifically.

![image](https://user-images.githubusercontent.com/2455694/113639875-00718100-962f-11eb-91eb-88f86b3116f7.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
