### PR TITLE
fix(lineage): add upstream arrows back in

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageViz.tsx
+++ b/datahub-web-react/src/app/lineage/LineageViz.tsx
@@ -103,6 +103,18 @@ export default function LineageViz({
                             >
                                 <path d="M 0 0 L 10 5 L 0 10 z" fill="#000" />
                             </marker>
+                            <marker
+                                id="triangle-upstream"
+                                viewBox="0 0 10 10"
+                                refX="0"
+                                refY="5"
+                                markerUnits="strokeWidth"
+                                markerWidth="10"
+                                markerHeight="10"
+                                orient="auto"
+                            >
+                                <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#000" />
+                            </marker>
                             <linearGradient id="gradient-Downstream" x1="1" x2="0" y1="0" y2="0">
                                 <stop offset="0%" stopColor="black" />
                                 <stop offset="100%" stopColor="black" stopOpacity="0" />


### PR DESCRIPTION
This marker was removed in consecutive merging of a few lineage followups. This adds it back in.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
