### PR TITLE
fix(ingest): bump pybigquery version

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -61,14 +61,7 @@ plugins: Dict[str, Set[str]] = {
     # Source plugins
     "kafka": kafka_common,
     "athena": sql_common | {"PyAthena[SQLAlchemy]"},
-    "bigquery": sql_common
-    | {
-        # This will change to a normal reference to pybigquery once a new version is released to PyPI.
-        # We need to use this custom version in order to correctly get table descriptions.
-        # See this PR by hsheth2 for details: https://github.com/tswast/pybigquery/pull/82.
-        # "pybigquery @ git+https://github.com/tswast/pybigquery@3250fa796b28225cb1c89d7afea3c2e2a2bf2305#egg=pybigquery"
-        "pybigquery"
-    },
+    "bigquery": sql_common | {"pybigquery >= 0.6.0"},
     "hive": sql_common | {"pyhive[hive]"},
     "mssql": sql_common | {"sqlalchemy-pytds>=0.3"},
     "mysql": sql_common | {"pymysql>=1.0.2"},


### PR DESCRIPTION
Now that https://github.com/googleapis/python-bigquery-sqlalchemy/pull/116 has been merged and version 0.6.0 has been released, we no longer need to install `pybigquery` from source via Git.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
