### PR TITLE
chore(ingest): remove unused `plugin_requirements.txt` file

### DIFF
--- a/metadata-ingestion/plugin_requirements.txt
+++ b/metadata-ingestion/plugin_requirements.txt
@@ -1,9 +1,0 @@
-pymysql>=1.0.2  # Driver for MySQL
-sqlalchemy-pytds>=0.3  # Driver for MS-SQL
-pyhive[hive]  # Driver for Hive
-psycopg2-binary  # Driver for Postgres
-snowflake-sqlalchemy  # Driver for Snowflake
-pybigquery  # Driver for BigQuery
-python-ldap>=2.4  # LDAP client library
-PyAthena[SQLAlchemy]<2.0.0 # Driver for Aws Athena
-


### PR DESCRIPTION
We have already transitioned to using setup.py extra requirements
instead of this separate file. I must've missed this file as part of
those changes.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
