### PR TITLE
feat(lineage): support arbitrary entity types in lineage viz

### DIFF
--- a/datahub-web-react/src/app/entity/Entity.tsx
+++ b/datahub-web-react/src/app/entity/Entity.tsx
@@ -1,4 +1,5 @@
 import { EntityType, SearchResult } from '../../types.generated';
+import { FetchedEntity } from '../lineage/types';
 
 export enum PreviewType {
     /**
@@ -58,6 +59,11 @@ export interface Entity<T> {
     isBrowseEnabled: () => boolean;
 
     /**
+     * Returns whether the entity browse is enabled
+     */
+    isLineageEnabled: () => boolean;
+
+    /**
      * Returns the name of the entity as it appears in a URL, e.g. '/dataset/:urn'.
      */
     getPathName: () => string;
@@ -81,4 +87,9 @@ export interface Entity<T> {
      * Renders a search result
      */
     renderSearch: (result: SearchResult) => JSX.Element;
+
+    /**
+     * Constructs config to add entity to lineage viz
+     */
+    getLineageVizConfig?: (entity: T) => FetchedEntity;
 }

--- a/datahub-web-react/src/app/entity/EntityPage.tsx
+++ b/datahub-web-react/src/app/entity/EntityPage.tsx
@@ -26,11 +26,15 @@ export const EntityPage = ({ entityType }: Props) => {
     const isLineageMode = useIsLineageMode();
 
     // TODO(gabe-lyons): pull this logic into the entity registry
-    const isLineageSupported = entityType === EntityType.Dataset;
+    const isLineageSupported = entityRegistry.getLineageEntityTypes().indexOf(entityType) > -1;
 
     return (
         <ContainerPage urn={urn} type={entityType} lineageSupported={isLineageSupported}>
-            {isLineageMode && isLineageSupported ? <LineageExplorer /> : entityRegistry.renderProfile(entityType, urn)}
+            {isLineageMode && isLineageSupported ? (
+                <LineageExplorer type={entityType} urn={urn} />
+            ) : (
+                entityRegistry.renderProfile(entityType, urn)
+            )}
         </ContainerPage>
     );
 };

--- a/datahub-web-react/src/app/entity/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entity/EntityRegistry.tsx
@@ -1,4 +1,5 @@
 import { EntityType, SearchResult } from '../../types.generated';
+import { FetchedEntity } from '../lineage/types';
 import { Entity, IconStyleType, PreviewType } from './Entity';
 
 function validatedGet<K, V>(key: K, map: Map<K, V>): V {
@@ -44,6 +45,10 @@ export default class EntityRegistry {
     }
 
     getBrowseEntityTypes(): Array<EntityType> {
+        return this.entities.filter((entity) => entity.isBrowseEnabled()).map((entity) => entity.type);
+    }
+
+    getLineageEntityTypes(): Array<EntityType> {
         return this.entities.filter((entity) => entity.isBrowseEnabled()).map((entity) => entity.type);
     }
 
@@ -96,5 +101,10 @@ export default class EntityRegistry {
     renderBrowse<T>(type: EntityType, data: T): JSX.Element {
         const entity = validatedGet(type, this.entityTypeToEntity);
         return entity.renderPreview(PreviewType.BROWSE, data);
+    }
+
+    getLineageVizConfig<T>(type: EntityType, data: T): FetchedEntity | undefined {
+        const entity = validatedGet(type, this.entityTypeToEntity);
+        return entity.getLineageVizConfig?.(data) || undefined;
     }
 }

--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -1,9 +1,22 @@
 import { LineChartOutlined } from '@ant-design/icons';
 import * as React from 'react';
 import { Chart, EntityType, SearchResult } from '../../../types.generated';
+import { Direction } from '../../lineage/types';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { ChartPreview } from './preview/ChartPreview';
 import ChartProfile from './profile/ChartProfile';
+
+export default function getChildren(entity: Chart, direction: Direction | null): Array<string> {
+    if (direction === Direction.Upstream) {
+        return entity.info?.inputs?.map((input) => input.urn) || [];
+    }
+
+    if (direction === Direction.Downstream) {
+        return [];
+    }
+
+    return [];
+}
 
 /**
  * Definition of the DataHub Chart entity.
@@ -34,6 +47,8 @@ export class ChartEntity implements Entity<Chart> {
 
     isBrowseEnabled = () => true;
 
+    isLineageEnabled = () => true;
+
     getAutoCompleteFieldName = () => 'title';
 
     getPathName = () => 'chart';
@@ -58,5 +73,15 @@ export class ChartEntity implements Entity<Chart> {
 
     renderSearch = (result: SearchResult) => {
         return this.renderPreview(PreviewType.SEARCH, result.entity as Chart);
+    };
+
+    getLineageVizConfig = (entity: Chart) => {
+        return {
+            urn: entity.urn,
+            name: entity.info?.name || '',
+            type: EntityType.Chart,
+            upstreamChildren: getChildren(entity, Direction.Upstream),
+            downstreamChildren: getChildren(entity, Direction.Downstream),
+        };
     };
 }

--- a/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartProfile.tsx
@@ -34,7 +34,7 @@ export default function ChartProfile({ urn }: { urn: string }) {
     });
 
     if (error || (!loading && !error && !data)) {
-        return <Alert type="error" message={error?.message || 'Entity failed to load'} />;
+        return <Alert type="error" message={error?.message || `Entity failed to load for urn ${urn}`} />;
     }
 
     const getHeader = (chart: Chart) => (

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -1,9 +1,22 @@
 import { DashboardFilled, DashboardOutlined } from '@ant-design/icons';
 import * as React from 'react';
 import { Dashboard, EntityType, SearchResult } from '../../../types.generated';
+import { Direction } from '../../lineage/types';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { DashboardPreview } from './preview/DashboardPreview';
 import DashboardProfile from './profile/DashboardProfile';
+
+export default function getChildren(entity: Dashboard, direction: Direction | null): Array<string> {
+    if (direction === Direction.Upstream) {
+        return entity.info?.charts.map((chart) => chart.urn) || [];
+    }
+
+    if (direction === Direction.Downstream) {
+        return [];
+    }
+
+    return [];
+}
 
 /**
  * Definition of the DataHub Dashboard entity.
@@ -34,6 +47,8 @@ export class DashboardEntity implements Entity<Dashboard> {
 
     isBrowseEnabled = () => true;
 
+    isLineageEnabled = () => true;
+
     getAutoCompleteFieldName = () => 'title';
 
     getPathName = () => 'dashboard';
@@ -58,5 +73,15 @@ export class DashboardEntity implements Entity<Dashboard> {
 
     renderSearch = (result: SearchResult) => {
         return this.renderPreview(PreviewType.SEARCH, result.entity as Dashboard);
+    };
+
+    getLineageVizConfig = (entity: Dashboard) => {
+        return {
+            urn: entity.urn,
+            name: entity.info?.name || '',
+            type: EntityType.Dashboard,
+            upstreamChildren: getChildren(entity, Direction.Upstream),
+            downstreamChildren: getChildren(entity, Direction.Downstream),
+        };
     };
 }

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { DatabaseFilled, DatabaseOutlined } from '@ant-design/icons';
 import { Tag, Typography } from 'antd';
 import styled from 'styled-components';
-import { Dataset, EntityType, SearchResult } from '../../../types.generated';
+import { Dataset, EntityType, RelatedDataset, SearchResult } from '../../../types.generated';
 import { DatasetProfile } from './profile/DatasetProfile';
 import { Entity, IconStyleType, PreviewType } from '../Entity';
 import { Preview } from './preview/Preview';
 import { FIELDS_TO_HIGHLIGHT } from './search/highlights';
+import { Direction } from '../../lineage/types';
 
 const MatchTag = styled(Tag)`
     &&& {
@@ -14,6 +15,18 @@ const MatchTag = styled(Tag)`
         margin-top: 10px;
     }
 `;
+
+export default function getChildren(entity: Dataset, direction: Direction | null): Array<RelatedDataset> {
+    if (direction === Direction.Upstream) {
+        return entity.upstreamLineage?.upstreams || [];
+    }
+
+    if (direction === Direction.Downstream) {
+        return entity.downstreamLineage?.downstreams || [];
+    }
+
+    return [];
+}
 
 /**
  * Definition of the DataHub Dataset entity.
@@ -43,6 +56,8 @@ export class DatasetEntity implements Entity<Dataset> {
     isSearchEnabled = () => true;
 
     isBrowseEnabled = () => true;
+
+    isLineageEnabled = () => true;
 
     getAutoCompleteFieldName = () => 'name';
 
@@ -93,5 +108,15 @@ export class DatasetEntity implements Entity<Dataset> {
                 }
             />
         );
+    };
+
+    getLineageVizConfig = (entity: Dataset) => {
+        return {
+            urn: entity.urn,
+            name: entity.name,
+            type: EntityType.Dataset,
+            upstreamChildren: getChildren(entity, Direction.Upstream).map((child) => child.dataset.urn),
+            downstreamChildren: getChildren(entity, Direction.Downstream).map((child) => child.dataset.urn),
+        };
     };
 }

--- a/datahub-web-react/src/app/entity/tag/Tag.tsx
+++ b/datahub-web-react/src/app/entity/tag/Tag.tsx
@@ -34,6 +34,8 @@ export class TagEntity implements Entity<Tag> {
 
     isBrowseEnabled = () => false;
 
+    isLineageEnabled = () => false;
+
     getAutoCompleteFieldName = () => 'name';
 
     getPathName: () => string = () => 'tag';

--- a/datahub-web-react/src/app/entity/user/User.tsx
+++ b/datahub-web-react/src/app/entity/user/User.tsx
@@ -34,6 +34,8 @@ export class UserEntity implements Entity<CorpUser> {
 
     isBrowseEnabled = () => false;
 
+    isLineageEnabled = () => false;
+
     getAutoCompleteFieldName = () => 'username';
 
     getPathName: () => string = () => 'user';

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -3,7 +3,6 @@ import { Group } from '@vx/group';
 import { LinkHorizontal } from '@vx/shape';
 import styled from 'styled-components';
 
-import { EntityType } from '../../types.generated';
 import { NodeData, Direction } from './types';
 
 function truncate(input, length) {
@@ -76,7 +75,7 @@ export default function LineageEntityNode({
             {node.data.unexploredChildren && (
                 <Group
                     onClick={() => {
-                        onExpandClick({ urn: node.data.urn, type: EntityType.Dataset, direction });
+                        onExpandClick({ urn: node.data.urn, type: node.data.type, direction });
                     }}
                 >
                     <circle
@@ -97,10 +96,10 @@ export default function LineageEntityNode({
             )}
             <Group
                 onClick={() => {
-                    onEntityClick({ urn: node.data.urn, type: EntityType.Dataset });
+                    onEntityClick({ urn: node.data.urn, type: node.data.type });
                 }}
                 onMouseOver={() => {
-                    onHover({ urn: node.data.urn, type: EntityType.Dataset });
+                    onHover({ urn: node.data.urn, type: node.data.type });
                 }}
                 onMouseOut={() => {
                     onHover(undefined);

--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -43,8 +43,6 @@ export default function LineageExplorer({ urn, type }: Props) {
     const [selectedEntity, setSelectedEntity] = useState<EntitySelectParams | undefined>(undefined);
     const [asyncEntities, setAsyncEntities] = useState<FetchedEntities>({});
 
-    console.log(asyncData);
-
     const maybeAddAsyncLoadedEntity = useCallback(
         (entityAndType: EntityAndType) => {
             if (entityAndType?.entity.urn && !asyncEntities[entityAndType?.entity.urn]?.fullyFetched) {

--- a/datahub-web-react/src/app/lineage/LineageExplorer.tsx
+++ b/datahub-web-react/src/app/lineage/LineageExplorer.tsx
@@ -1,18 +1,18 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router';
 
 import { Alert, Drawer } from 'antd';
 import styled from 'styled-components';
 
-import { useGetDatasetLazyQuery, useGetDatasetQuery } from '../../graphql/dataset.generated';
 import { Message } from '../shared/Message';
-import { Dataset } from '../../types.generated';
 import { useEntityRegistry } from '../useEntityRegistry';
 import CompactContext from '../shared/CompactContext';
-import { Direction, EntitySelectParams, FetchedEntities, LineageExpandParams, LineageExplorerParams } from './types';
+import { Direction, EntityAndType, EntitySelectParams, FetchedEntities, LineageExpandParams } from './types';
 import getChildren from './utils/getChildren';
 import LineageViz from './LineageViz';
 import extendAsyncEntities from './utils/extendAsyncEntities';
+import useLazyGetEntityQuery from './utils/useLazyGetEntityQuery';
+import useGetEntityQuery from './utils/useGetEntityQuery';
+import { EntityType } from '../../types.generated';
 
 const LoadingMessage = styled(Message)`
     margin-top: 10%;
@@ -26,42 +26,59 @@ function usePrevious(value) {
     return ref.current;
 }
 
-export default function LineageExplorer() {
-    const { urn } = useParams<LineageExplorerParams>();
+type Props = {
+    urn: string;
+    type: EntityType;
+};
+
+export default function LineageExplorer({ urn, type }: Props) {
     const previousUrn = usePrevious(urn);
 
-    const { loading, error, data } = useGetDatasetQuery({ variables: { urn } });
-    const [getAsyncDataset, { data: asyncDatasetData }] = useGetDatasetLazyQuery();
+    const entityRegistry = useEntityRegistry();
+
+    const { loading, error, data } = useGetEntityQuery(urn, type);
+    console.log({
+        loading,
+        data,
+        error,
+    });
+    const { getAsyncEntity, asyncData } = useLazyGetEntityQuery();
+
     const [isDrawerVisible, setIsDrawVisible] = useState(false);
     const [selectedEntity, setSelectedEntity] = useState<EntitySelectParams | undefined>(undefined);
-    const entityRegistry = useEntityRegistry();
     const [asyncEntities, setAsyncEntities] = useState<FetchedEntities>({});
 
+    console.log(asyncData);
+
     const maybeAddAsyncLoadedEntity = useCallback(
-        ({ entity }: { entity?: Dataset }) => {
-            if (entity?.urn && !asyncEntities[entity?.urn]?.fullyFetched) {
+        (entityAndType: EntityAndType) => {
+            console.log('checking', entityAndType?.entity.urn, asyncEntities);
+            if (entityAndType?.entity.urn && !asyncEntities[entityAndType?.entity.urn]?.fullyFetched) {
+                console.log('setting async data');
                 // record that we have added this entity
-                let newAsyncEntities = extendAsyncEntities(asyncEntities, entity, true);
+                let newAsyncEntities = extendAsyncEntities(asyncEntities, entityRegistry, entityAndType, true);
 
                 // add the partially fetched downstream & upstream datasets
-                getChildren(entity, Direction.Downstream).forEach((downstream) => {
-                    newAsyncEntities = extendAsyncEntities(newAsyncEntities, downstream.dataset, false);
+                getChildren(entityAndType, Direction.Downstream).forEach((downstream) => {
+                    newAsyncEntities = extendAsyncEntities(newAsyncEntities, entityRegistry, downstream, false);
                 });
-                getChildren(entity, Direction.Upstream).forEach((upstream) => {
-                    newAsyncEntities = extendAsyncEntities(newAsyncEntities, upstream.dataset, false);
+                getChildren(entityAndType, Direction.Upstream).forEach((upstream) => {
+                    newAsyncEntities = extendAsyncEntities(newAsyncEntities, entityRegistry, upstream, false);
                 });
                 setAsyncEntities(newAsyncEntities);
             }
         },
-        [asyncEntities, setAsyncEntities],
+        [asyncEntities, setAsyncEntities, entityRegistry],
     );
 
     useEffect(() => {
-        maybeAddAsyncLoadedEntity({ entity: data?.dataset as Dataset });
-        maybeAddAsyncLoadedEntity({
-            entity: asyncDatasetData?.dataset as Dataset,
-        });
-    }, [data, asyncDatasetData, asyncEntities, setAsyncEntities, maybeAddAsyncLoadedEntity, urn, previousUrn]);
+        if (type && data) {
+            maybeAddAsyncLoadedEntity(data);
+        }
+        if (asyncData) {
+            maybeAddAsyncLoadedEntity(asyncData);
+        }
+    }, [data, asyncData, asyncEntities, setAsyncEntities, maybeAddAsyncLoadedEntity, urn, previousUrn, type]);
 
     if (error || (!loading && !error && !data)) {
         return <Alert type="error" message={error?.message || 'Entity failed to load'} />;
@@ -70,18 +87,18 @@ export default function LineageExplorer() {
     return (
         <>
             {loading && <LoadingMessage type="loading" content="Loading..." />}
-            {data?.dataset && (
+            {data && (
                 <div>
                     <LineageViz
                         selectedEntity={selectedEntity}
                         fetchedEntities={asyncEntities}
-                        dataset={data?.dataset}
+                        entityAndType={data}
                         onEntityClick={(params: EntitySelectParams) => {
                             setIsDrawVisible(true);
                             setSelectedEntity(params);
                         }}
                         onLineageExpand={(params: LineageExpandParams) => {
-                            getAsyncDataset({ variables: { urn: params.urn } });
+                            getAsyncEntity(params.urn, params.type);
                         }}
                     />
                 </div>

--- a/datahub-web-react/src/app/lineage/LineageViz.tsx
+++ b/datahub-web-react/src/app/lineage/LineageViz.tsx
@@ -9,7 +9,7 @@ export const defaultMargin = { top: 10, left: 280, right: 280, bottom: 10 };
 
 export default function LineageViz({
     margin = defaultMargin,
-    dataset,
+    entityAndType,
     fetchedEntities,
     onEntityClick,
     onLineageExpand,
@@ -39,7 +39,7 @@ export default function LineageViz({
         >
             {(zoom) => (
                 <LineageVizInsideZoom
-                    dataset={dataset}
+                    entityAndType={entityAndType}
                     width={width}
                     height={height}
                     margin={margin}

--- a/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
+++ b/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
@@ -7,8 +7,8 @@ import { ProvidedZoom, TransformMatrix } from '@vx/zoom/lib/types';
 
 import LineageTree from './LineageTree';
 import constructTree from './utils/constructTree';
-import { Direction, EntitySelectParams, FetchedEntity } from './types';
-import { GetDatasetQuery } from '../../graphql/dataset.generated';
+import { Direction, EntityAndType, EntitySelectParams, FetchedEntity } from './types';
+import { useEntityRegistry } from '../useEntityRegistry';
 
 const ZoomCard = styled(Card)`
     position: absolute;
@@ -28,7 +28,7 @@ const RootSvg = styled.svg<{ isDragging: boolean } & SVGProps<SVGSVGElement>>`
 
 type Props = {
     margin: { top: number; right: number; bottom: number; left: number };
-    dataset: GetDatasetQuery['dataset'];
+    entityAndType?: EntityAndType | null;
     fetchedEntities: { [x: string]: FetchedEntity };
     onEntityClick: (EntitySelectParams) => void;
     onLineageExpand: (LineageExpandParams) => void;
@@ -44,7 +44,7 @@ type Props = {
 export default function LineageVizInsideZoom({
     zoom,
     margin,
-    dataset,
+    entityAndType,
     fetchedEntities,
     onEntityClick,
     onLineageExpand,
@@ -52,22 +52,28 @@ export default function LineageVizInsideZoom({
     width,
     height,
 }: Props) {
+    const entityRegistry = useEntityRegistry();
     const yMax = height - margin?.top - margin?.bottom;
     const xMax = (width - margin?.left - margin?.right) / 2;
 
-    const downstreamData = useMemo(() => hierarchy(constructTree(dataset, fetchedEntities, Direction.Downstream)), [
-        dataset,
-        fetchedEntities,
-    ]);
-    const upstreamData = useMemo(() => hierarchy(constructTree(dataset, fetchedEntities, Direction.Upstream)), [
-        dataset,
-        fetchedEntities,
-    ]);
+    const downstreamData = useMemo(
+        () => hierarchy(constructTree(entityAndType, fetchedEntities, Direction.Downstream, entityRegistry)),
+        [entityAndType, fetchedEntities, entityRegistry],
+    );
+    const upstreamData = useMemo(
+        () => hierarchy(constructTree(entityAndType, fetchedEntities, Direction.Upstream, entityRegistry)),
+        [entityAndType, fetchedEntities, entityRegistry],
+    );
+
+    console.log({
+        downstreamData,
+        upstreamData,
+    });
 
     useEffect(() => {
         zoom.setTransformMatrix({ ...zoom.transformMatrix, translateY: 0, translateX: width / 2 });
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [dataset?.urn]);
+    }, [entityAndType?.entity?.urn]);
     return (
         <>
             <ZoomCard size="small">

--- a/datahub-web-react/src/app/lineage/__tests__/LineageTree.test.tsx
+++ b/datahub-web-react/src/app/lineage/__tests__/LineageTree.test.tsx
@@ -8,6 +8,8 @@ import { Direction, FetchedEntities } from '../types';
 import constructTree from '../utils/constructTree';
 import LineageTree from '../LineageTree';
 import extendAsyncEntities from '../utils/extendAsyncEntities';
+import { getTestEntityRegistry } from '../../../utils/test-utils/TestPageContainer';
+import { EntityType } from '../../../types.generated';
 
 const margin = { top: 10, left: 280, right: 280, bottom: 10 };
 const [windowWidth, windowHeight] = [1000, 500];
@@ -25,6 +27,8 @@ const initialTransform = {
     skewY: 0,
 };
 
+const testEntityRegistry = getTestEntityRegistry();
+
 describe('LineageTree', () => {
     it('renders a tree with many layers', () => {
         const fetchedEntities = [
@@ -33,11 +37,24 @@ describe('LineageTree', () => {
             { entity: dataset6WithLineage, direction: Direction.Upstream, fullyFetched: true },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        const downstreamData = hierarchy(constructTree(dataset3WithLineage, mockFetchedEntities, Direction.Upstream));
+        const downstreamData = hierarchy(
+            constructTree(
+                { entity: dataset3WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        );
 
         const { getByTestId } = render(
             <Zoom

--- a/datahub-web-react/src/app/lineage/__tests__/adjustVXTreeLayout.test.tsx
+++ b/datahub-web-react/src/app/lineage/__tests__/adjustVXTreeLayout.test.tsx
@@ -13,6 +13,10 @@ import constructTree from '../utils/constructTree';
 import extendAsyncEntities from '../utils/extendAsyncEntities';
 import adjustVXTreeLayout from '../utils/adjustVXTreeLayout';
 import { NodeData, Direction, FetchedEntities } from '../types';
+import { getTestEntityRegistry } from '../../../utils/test-utils/TestPageContainer';
+import { EntityType } from '../../../types.generated';
+
+const testEntityRegistry = getTestEntityRegistry();
 
 describe('adjustVXTreeLayout', () => {
     it('adjusts nodes with layers of lineage to make sure identical nodes are given the same coordinates', () => {
@@ -22,11 +26,24 @@ describe('adjustVXTreeLayout', () => {
             { entity: dataset6WithLineage, direction: Direction.Upstream, fullyFetched: true },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        const downstreamData = hierarchy(constructTree(dataset3WithLineage, mockFetchedEntities, Direction.Upstream));
+        const downstreamData = hierarchy(
+            constructTree(
+                { entity: dataset3WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        );
 
         render(
             <Tree<NodeData> root={downstreamData} size={[1000, 1000]}>
@@ -57,11 +74,24 @@ describe('adjustVXTreeLayout', () => {
             { entity: dataset7WithLineage, direction: Direction.Upstream, fullyFetched: true },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        const upstreamData = hierarchy(constructTree(dataset3WithLineage, mockFetchedEntities, Direction.Upstream));
+        const upstreamData = hierarchy(
+            constructTree(
+                { entity: dataset3WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        );
 
         render(
             <Tree<NodeData> root={upstreamData} size={[1000, 1000]}>

--- a/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
+++ b/datahub-web-react/src/app/lineage/__tests__/constructTree.test.ts
@@ -8,14 +8,24 @@ import {
     dataset6WithLineage,
 } from '../../../Mocks';
 import { EntityType } from '../../../types.generated';
+import { getTestEntityRegistry } from '../../../utils/test-utils/TestPageContainer';
 import { Direction, FetchedEntities } from '../types';
 import constructTree from '../utils/constructTree';
 import extendAsyncEntities from '../utils/extendAsyncEntities';
 
+const testEntityRegistry = getTestEntityRegistry();
+
 describe('constructTree', () => {
     it('handles nodes without any lineage', () => {
         const mockFetchedEntities = {};
-        expect(constructTree(dataset3, mockFetchedEntities, Direction.Upstream)).toEqual({
+        expect(
+            constructTree(
+                { entity: dataset3, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        ).toEqual({
             name: 'Yet Another Dataset',
             urn: 'urn:li:dataset:3',
             type: EntityType.Dataset,
@@ -30,11 +40,24 @@ describe('constructTree', () => {
             { entity: dataset5, direction: Direction.Upstream, fullyFetched: false },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        expect(constructTree(dataset6WithLineage, mockFetchedEntities, Direction.Downstream)).toEqual({
+        expect(
+            constructTree(
+                { entity: dataset6WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Downstream,
+                testEntityRegistry,
+            ),
+        ).toEqual({
             name: 'Sixth Test Dataset',
             urn: 'urn:li:dataset:6',
             type: EntityType.Dataset,
@@ -58,11 +81,24 @@ describe('constructTree', () => {
             { entity: dataset5, direction: Direction.Upstream, fullyFetched: false },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        expect(constructTree(dataset6WithLineage, mockFetchedEntities, Direction.Upstream)).toEqual({
+        expect(
+            constructTree(
+                { entity: dataset6WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        ).toEqual({
             name: 'Sixth Test Dataset',
             urn: 'urn:li:dataset:6',
             type: EntityType.Dataset,
@@ -87,11 +123,24 @@ describe('constructTree', () => {
             { entity: dataset6WithLineage, direction: Direction.Upstream, fullyFetched: true },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        expect(constructTree(dataset3WithLineage, mockFetchedEntities, Direction.Upstream)).toEqual({
+        expect(
+            constructTree(
+                { entity: dataset3WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        ).toEqual({
             name: 'Yet Another Dataset',
             urn: 'urn:li:dataset:3',
             type: EntityType.Dataset,
@@ -146,11 +195,22 @@ describe('constructTree', () => {
             { entity: dataset6WithLineage, direction: Direction.Upstream, fullyFetched: true },
         ];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
 
-        const tree = constructTree(dataset3WithLineage, mockFetchedEntities, Direction.Upstream);
+        const tree = constructTree(
+            { entity: dataset3WithLineage, type: EntityType.Dataset },
+            mockFetchedEntities,
+            Direction.Upstream,
+            testEntityRegistry,
+        );
 
         const fifthDatasetIntance1 = tree?.children?.[0]?.children?.[0]?.children?.[0];
         const fifthDatasetIntance2 = tree?.children?.[0]?.children?.[1];
@@ -163,11 +223,23 @@ describe('constructTree', () => {
     it('handles partially fetched graph with layers of lineage', () => {
         const fetchedEntities = [{ entity: dataset4WithLineage, direction: Direction.Upstream, fullyFetched: false }];
         const mockFetchedEntities = fetchedEntities.reduce(
-            (acc, entry) => extendAsyncEntities(acc, entry.entity, entry.fullyFetched),
+            (acc, entry) =>
+                extendAsyncEntities(
+                    acc,
+                    testEntityRegistry,
+                    { entity: entry.entity, type: EntityType.Dataset },
+                    entry.fullyFetched,
+                ),
             {} as FetchedEntities,
         );
-
-        expect(constructTree(dataset3WithLineage, mockFetchedEntities, Direction.Upstream)).toEqual({
+        expect(
+            constructTree(
+                { entity: dataset3WithLineage, type: EntityType.Dataset },
+                mockFetchedEntities,
+                Direction.Upstream,
+                testEntityRegistry,
+            ),
+        ).toEqual({
             name: 'Yet Another Dataset',
             urn: 'urn:li:dataset:3',
             type: EntityType.Dataset,

--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -1,5 +1,4 @@
-import { GetDatasetQuery } from '../../graphql/dataset.generated';
-import { EntityType } from '../../types.generated';
+import { Chart, Dashboard, Dataset, EntityType } from '../../types.generated';
 
 export type EntitySelectParams = {
     type: EntityType;
@@ -19,7 +18,7 @@ export type FetchedEntity = {
     // children?: Array<string>;
     upstreamChildren?: Array<string>;
     downstreamChildren?: Array<string>;
-    fullyFetched: boolean;
+    fullyFetched?: boolean;
 };
 
 export type NodeData = {
@@ -47,10 +46,24 @@ export type LineageExplorerParams = {
 
 export type TreeProps = {
     margin?: { top: number; right: number; bottom: number; left: number };
-    dataset: GetDatasetQuery['dataset'];
+    entityAndType?: EntityAndType | null;
     fetchedEntities: { [x: string]: FetchedEntity };
     onEntityClick: (EntitySelectParams) => void;
     onLineageExpand: (LineageExpandParams) => void;
     selectedEntity?: EntitySelectParams;
     hoveredEntity?: EntitySelectParams;
 };
+
+export type EntityAndType =
+    | {
+          type: EntityType.Dataset;
+          entity: Dataset;
+      }
+    | {
+          type: EntityType.Chart;
+          entity: Chart;
+      }
+    | {
+          type: EntityType.Dashboard;
+          entity: Dashboard;
+      };

--- a/datahub-web-react/src/app/lineage/utils/constructTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/constructTree.ts
@@ -1,26 +1,28 @@
-import { GetDatasetQuery } from '../../../graphql/dataset.generated';
-import { Dataset } from '../../../types.generated';
-import { Direction, FetchedEntities, NodeData } from '../types';
+import EntityRegistry from '../../entity/EntityRegistry';
+import { Direction, EntityAndType, FetchedEntities, NodeData } from '../types';
 import constructFetchedNode from './constructFetchedNode';
 import getChildren from './getChildren';
 
 export default function constructTree(
-    dataset: GetDatasetQuery['dataset'],
+    entityAndType: EntityAndType | null | undefined,
     fetchedEntities: FetchedEntities,
     direction: Direction,
+    entityRegistry: EntityRegistry,
 ): NodeData {
-    if (!dataset) return { name: 'loading...', children: [] };
+    if (!entityAndType?.entity) return { name: 'loading...', children: [] };
     const constructedNodes = {};
 
+    const fetchedEntity = entityRegistry.getLineageVizConfig(entityAndType.type, entityAndType.entity);
+
     const root: NodeData = {
-        name: dataset?.name,
-        urn: dataset?.urn,
-        type: dataset?.type,
+        name: fetchedEntity?.name || '',
+        urn: fetchedEntity?.urn,
+        type: fetchedEntity?.type,
         unexploredChildren: 0,
     };
-    root.children = getChildren(dataset as Dataset, direction)
+    root.children = getChildren(entityAndType, direction)
         .map((child) => {
-            return constructFetchedNode(child.dataset.urn, fetchedEntities, direction, constructedNodes);
+            return constructFetchedNode(child.entity.urn, fetchedEntities, direction, constructedNodes);
         })
         ?.filter(Boolean) as Array<NodeData>;
     return root;

--- a/datahub-web-react/src/app/lineage/utils/extendAsyncEntities.ts
+++ b/datahub-web-react/src/app/lineage/utils/extendAsyncEntities.ts
@@ -1,23 +1,24 @@
-import { Dataset } from '../../../types.generated';
-import { Direction, FetchedEntities } from '../types';
-import getChildren from './getChildren';
+import EntityRegistry from '../../entity/EntityRegistry';
+import { EntityAndType, FetchedEntities } from '../types';
 
 export default function extendAsyncEntities(
     fetchedEntities: FetchedEntities,
-    entity: Dataset,
+    entityRegistry: EntityRegistry,
+    entityAndType: EntityAndType,
     fullyFetched = false,
 ): FetchedEntities {
-    if (fetchedEntities[entity.urn]?.fullyFetched) {
+    if (fetchedEntities[entityAndType.entity.urn]?.fullyFetched) {
         return fetchedEntities;
     }
+
+    const lineageVizConfig = entityRegistry.getLineageVizConfig(entityAndType.type, entityAndType.entity);
+
+    if (!lineageVizConfig) return fetchedEntities;
+
     return {
         ...fetchedEntities,
-        [entity.urn]: {
-            urn: entity.urn,
-            name: entity.name,
-            type: entity.type,
-            upstreamChildren: getChildren(entity, Direction.Upstream).map((child) => child.dataset.urn),
-            downstreamChildren: getChildren(entity, Direction.Downstream).map((child) => child.dataset.urn),
+        [entityAndType.entity.urn]: {
+            ...lineageVizConfig,
             fullyFetched,
         },
     };

--- a/datahub-web-react/src/app/lineage/utils/getChildren.ts
+++ b/datahub-web-react/src/app/lineage/utils/getChildren.ts
@@ -1,13 +1,43 @@
-import { Dataset, RelatedDataset } from '../../../types.generated';
-import { Direction } from '../types';
+import { EntityType } from '../../../types.generated';
+import { Direction, EntityAndType } from '../types';
 
-export default function getChildren(entity: Dataset, direction: Direction | null): Array<RelatedDataset> {
+export default function getChildren(entityAndType: EntityAndType, direction: Direction | null): Array<EntityAndType> {
     if (direction === Direction.Upstream) {
-        return entity.upstreamLineage?.upstreams || [];
+        if (entityAndType.type === EntityType.Dataset) {
+            return (
+                entityAndType.entity.upstreamLineage?.upstreams.map((upstream) => ({
+                    type: EntityType.Dataset,
+                    entity: upstream.dataset,
+                })) || []
+            );
+        }
+        if (entityAndType.type === EntityType.Chart) {
+            return (
+                entityAndType.entity.info?.inputs?.map((dataset) => ({
+                    type: EntityType.Dataset,
+                    entity: dataset,
+                })) || []
+            );
+        }
+        if (entityAndType.type === EntityType.Dashboard) {
+            return (
+                entityAndType.entity.info?.charts.map((chart) => ({
+                    type: EntityType.Chart,
+                    entity: chart,
+                })) || []
+            );
+        }
     }
 
     if (direction === Direction.Downstream) {
-        return entity.downstreamLineage?.downstreams || [];
+        if (entityAndType.type === EntityType.Dataset) {
+            return (
+                entityAndType.entity.downstreamLineage?.downstreams.map((downstreams) => ({
+                    type: EntityType.Dataset,
+                    entity: downstreams.dataset,
+                })) || []
+            );
+        }
     }
 
     return [];

--- a/datahub-web-react/src/app/lineage/utils/useGetEntityQuery.ts
+++ b/datahub-web-react/src/app/lineage/utils/useGetEntityQuery.ts
@@ -1,0 +1,99 @@
+import { useMemo } from 'react';
+import { useGetChartQuery } from '../../../graphql/chart.generated';
+import { useGetDashboardQuery } from '../../../graphql/dashboard.generated';
+import { useGetDatasetQuery } from '../../../graphql/dataset.generated';
+import { EntityType } from '../../../types.generated';
+import { EntityAndType } from '../types';
+
+export default function useGetEntityQuery(urn: string, entityType?: EntityType) {
+    console.log({ urn, entityType });
+    const allResults = {
+        [EntityType.Dataset]: useGetDatasetQuery({
+            variables: { urn },
+            skip: entityType !== EntityType.Dataset,
+        }),
+        [EntityType.Chart]: useGetChartQuery({
+            variables: { urn },
+            skip: entityType !== EntityType.Chart,
+        }),
+        [EntityType.Dashboard]: useGetDashboardQuery({
+            variables: { urn },
+            skip: entityType !== EntityType.Dashboard,
+        }),
+    };
+
+    const returnEntityAndType: EntityAndType | undefined = useMemo(() => {
+        let returnData;
+        switch (entityType) {
+            case EntityType.Dataset:
+                returnData = allResults[EntityType.Dataset].data?.dataset;
+                if (returnData) {
+                    return {
+                        entity: returnData,
+                        type: EntityType.Dataset,
+                    } as EntityAndType;
+                }
+                break;
+            case EntityType.Chart:
+                returnData = allResults[EntityType.Chart]?.data?.chart;
+                if (returnData) {
+                    return {
+                        entity: returnData,
+                        type: EntityType.Chart,
+                    } as EntityAndType;
+                }
+                break;
+            case EntityType.Dashboard:
+                returnData = allResults[EntityType.Dashboard]?.data?.dashboard;
+                if (returnData) {
+                    return {
+                        entity: returnData,
+                        type: EntityType.Dashboard,
+                    } as EntityAndType;
+                }
+                break;
+            default:
+                break;
+        }
+        return undefined;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        urn,
+        entityType,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        allResults[EntityType.Dataset],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        allResults[EntityType.Chart],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        allResults[EntityType.Dashboard],
+    ]);
+
+    const returnObject = useMemo(() => {
+        if (!entityType) {
+            return {
+                loading: false,
+                error: null,
+                data: null,
+            };
+        }
+
+        return {
+            data: returnEntityAndType,
+            loading: allResults[entityType].loading,
+            error: allResults[entityType].error,
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        urn,
+        entityType,
+        returnEntityAndType,
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        allResults[EntityType.Dataset],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        allResults[EntityType.Chart],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        allResults[EntityType.Dashboard],
+    ]);
+
+    return returnObject;
+}

--- a/datahub-web-react/src/app/lineage/utils/useGetEntityQuery.ts
+++ b/datahub-web-react/src/app/lineage/utils/useGetEntityQuery.ts
@@ -6,7 +6,6 @@ import { EntityType } from '../../../types.generated';
 import { EntityAndType } from '../types';
 
 export default function useGetEntityQuery(urn: string, entityType?: EntityType) {
-    console.log({ urn, entityType });
     const allResults = {
         [EntityType.Dataset]: useGetDatasetQuery({
             variables: { urn },

--- a/datahub-web-react/src/app/lineage/utils/useLazyGetEntityQuery.ts
+++ b/datahub-web-react/src/app/lineage/utils/useLazyGetEntityQuery.ts
@@ -1,0 +1,69 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useGetChartLazyQuery } from '../../../graphql/chart.generated';
+import { useGetDashboardLazyQuery } from '../../../graphql/dashboard.generated';
+import { useGetDatasetLazyQuery } from '../../../graphql/dataset.generated';
+import { EntityType } from '../../../types.generated';
+import { EntityAndType } from '../types';
+
+export default function useLazyGetEntityQuery() {
+    const [fetchedEntityType, setFetchedEntityType] = useState<EntityType | undefined>(undefined);
+    const [getAsyncDataset, { data: asyncDatasetData }] = useGetDatasetLazyQuery();
+    const [getAsyncChart, { data: asyncChartData }] = useGetChartLazyQuery();
+    const [getAsyncDashboard, { data: asyncDashboardData }] = useGetDashboardLazyQuery();
+
+    const getAsyncEntity = useCallback(
+        (urn: string, type: EntityType) => {
+            if (type === EntityType.Dataset) {
+                setFetchedEntityType(type);
+                getAsyncDataset({ variables: { urn } });
+            }
+            if (type === EntityType.Chart) {
+                setFetchedEntityType(type);
+                getAsyncChart({ variables: { urn } });
+            }
+            if (type === EntityType.Dashboard) {
+                setFetchedEntityType(type);
+                getAsyncDashboard({ variables: { urn } });
+            }
+        },
+        [setFetchedEntityType, getAsyncChart, getAsyncDataset, getAsyncDashboard],
+    );
+
+    const returnEntityAndType: EntityAndType | undefined = useMemo(() => {
+        let returnData;
+        switch (fetchedEntityType) {
+            case EntityType.Dataset:
+                returnData = asyncDatasetData?.dataset;
+                if (returnData) {
+                    return {
+                        entity: returnData,
+                        type: EntityType.Dataset,
+                    } as EntityAndType;
+                }
+                break;
+            case EntityType.Chart:
+                returnData = asyncChartData?.chart;
+                if (returnData) {
+                    return {
+                        entity: returnData,
+                        type: EntityType.Chart,
+                    } as EntityAndType;
+                }
+                break;
+            case EntityType.Dashboard:
+                returnData = asyncDashboardData?.dashboard;
+                if (returnData) {
+                    return {
+                        entity: returnData,
+                        type: EntityType.Dashboard,
+                    } as EntityAndType;
+                }
+                break;
+            default:
+                break;
+        }
+        return undefined;
+    }, [asyncDatasetData, asyncChartData, asyncDashboardData, fetchedEntityType]);
+
+    return { getAsyncEntity, asyncData: returnEntityAndType };
+}

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -44,6 +44,22 @@ query getChart($urn: String!) {
                         time
                     }
                 }
+                downstreamLineage {
+                    downstreams {
+                        type
+                        dataset {
+                            urn
+                        }
+                    }
+                }
+                upstreamLineage {
+                    upstreams {
+                        type
+                        dataset {
+                            urn
+                        }
+                    }
+                }
             }
             url
             type

--- a/datahub-web-react/src/graphql/dashboard.graphql
+++ b/datahub-web-react/src/graphql/dashboard.graphql
@@ -14,6 +14,9 @@ query getDashboard($urn: String!) {
                 info {
                     name
                     description
+                    inputs {
+                        urn
+                    }
                 }
                 ownership {
                     owners {

--- a/metadata-ingestion/plugin_requirements.txt
+++ b/metadata-ingestion/plugin_requirements.txt
@@ -1,9 +1,0 @@
-pymysql>=1.0.2  # Driver for MySQL
-sqlalchemy-pytds>=0.3  # Driver for MS-SQL
-pyhive[hive]  # Driver for Hive
-psycopg2-binary  # Driver for Postgres
-snowflake-sqlalchemy  # Driver for Snowflake
-pybigquery  # Driver for BigQuery
-python-ldap>=2.4  # LDAP client library
-PyAthena[SQLAlchemy]<2.0.0 # Driver for Aws Athena
-

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -61,14 +61,7 @@ plugins: Dict[str, Set[str]] = {
     # Source plugins
     "kafka": kafka_common,
     "athena": sql_common | {"PyAthena[SQLAlchemy]"},
-    "bigquery": sql_common
-    | {
-        # This will change to a normal reference to pybigquery once a new version is released to PyPI.
-        # We need to use this custom version in order to correctly get table descriptions.
-        # See this PR by hsheth2 for details: https://github.com/tswast/pybigquery/pull/82.
-        # "pybigquery @ git+https://github.com/tswast/pybigquery@3250fa796b28225cb1c89d7afea3c2e2a2bf2305#egg=pybigquery"
-        "pybigquery"
-    },
+    "bigquery": sql_common | {"pybigquery >= 0.6.0"},
     "hive": sql_common | {"pyhive[hive]"},
     "mssql": sql_common | {"sqlalchemy-pytds>=0.3"},
     "mysql": sql_common | {"pymysql>=1.0.2"},


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2455694/114076600-adc8dc80-985b-11eb-9bd7-baf06d7396c2.png)

Initially, the lineage viz only supported dataset <> dataset relationships. This adds support for onboarding any type of entity to the lineage graph.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
