### PR TITLE
feat(react): add null state indicator in user profile when no entities

### DIFF
--- a/datahub-web-react/src/app/browse/BrowseResults.tsx
+++ b/datahub-web-react/src/app/browse/BrowseResults.tsx
@@ -69,7 +69,9 @@ export const BrowseResults = ({
                                 </>
                             )}
                             bordered
-                            locale={{ emptyText: <Empty description="No Entities" /> }}
+                            locale={{
+                                emptyText: <Empty description="No Entities" image={Empty.PRESENTED_IMAGE_SIMPLE} />,
+                            }}
                         />
                     )}
                     <Col span={24}>

--- a/datahub-web-react/src/app/entity/user/UserDetails.tsx
+++ b/datahub-web-react/src/app/entity/user/UserDetails.tsx
@@ -1,4 +1,4 @@
-import { Menu } from 'antd';
+import { Menu, Empty } from 'antd';
 import { MenuProps } from 'antd/lib/menu';
 import React from 'react';
 import { useHistory } from 'react-router-dom';
@@ -75,7 +75,11 @@ export default function UserDetails({ ownerships, subview, item, urn }: Props) {
                 </Menu>
             </MenuWrapper>
             <Content>
-                {subview === Subview.Ownership && <UserOwnership ownerships={ownerships} entityPath={item} />}
+                {ownershipMenuOptions && ownershipMenuOptions.length > 0 ? (
+                    subview === Subview.Ownership && <UserOwnership ownerships={ownerships} entityPath={item} />
+                ) : (
+                    <Empty description="Looks like you don't own any datasets" />
+                )}
             </Content>
         </DetailWrapper>
     );

--- a/datahub-web-react/src/app/entity/user/UserDetails.tsx
+++ b/datahub-web-react/src/app/entity/user/UserDetails.tsx
@@ -78,7 +78,7 @@ export default function UserDetails({ ownerships, subview, item, urn }: Props) {
                 {ownershipMenuOptions && ownershipMenuOptions.length > 0 ? (
                     subview === Subview.Ownership && <UserOwnership ownerships={ownerships} entityPath={item} />
                 ) : (
-                    <Empty description="Looks like you don't own any datasets" />
+                    <Empty description="Looks like you don't own any datasets" image={Empty.PRESENTED_IMAGE_SIMPLE} />
                 )}
             </Content>
         </DetailWrapper>


### PR DESCRIPTION
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)


<img width="1737" alt="Screen Shot 2021-04-10 at 2 26 39 AM" src="https://user-images.githubusercontent.com/16714648/114224957-57b38080-99a4-11eb-824e-852990b86c5a.png">

