### PR TITLE
feat(react): add padding between tags and description on datasets profile page

### DIFF
--- a/datahub-web-react/src/app/shared/EntityProfile.tsx
+++ b/datahub-web-react/src/app/shared/EntityProfile.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Col, Row, Divider, Layout, Card, Typography } from 'antd';
+import { LayoutProps } from 'antd/lib/layout';
 import styled from 'styled-components';
 import { TagOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
@@ -35,12 +36,20 @@ const TagIcon = styled(TagOutlined)`
     padding-right: 6px;
 `;
 
-type LayoutProps = {
+type LayoutPropsExtended = {
     isCompact: boolean;
 };
 
-const LayoutContent = styled(Layout.Content)<LayoutProps>`
+const LayoutContent = styled(({ isCompact: _, ...props }: LayoutProps & LayoutPropsExtended) => (
+    <Layout.Content {...props} />
+))`
     padding: 0px ${(props) => (props.isCompact ? '0px' : '100px')};
+`;
+
+const LayoutDiv = styled(({ isCompact: _, ...props }: LayoutProps & LayoutPropsExtended) => (
+    <Layout.Content {...props} />
+))`
+    padding-right: ${(props) => (props.isCompact ? '0px' : '24px')};
 `;
 
 const defaultProps = {
@@ -58,44 +67,42 @@ export const EntityProfile = ({ title, tags, header, tabs, titleLink }: EntityPr
     /* eslint-disable spaced-comment */
     return (
         <LayoutContent isCompact={isCompact}>
-            <div>
-                <Row>
-                    <Col md={isCompact ? 24 : 16} sm={24} xs={24}>
-                        <div>
-                            <Row style={{ padding: '20px 0px 10px 0px' }}>
-                                <Col span={24}>
-                                    {titleLink ? (
-                                        <Link to={titleLink}>
-                                            <h1>{title}</h1>
-                                        </Link>
-                                    ) : (
-                                        <h1>{title}</h1>
-                                    )}
-                                </Col>
-                            </Row>
-                            {header}
-                        </div>
-                    </Col>
-                    <Col md={isCompact ? 24 : 8} xs={24} sm={24}>
-                        <TagCard>
-                            <TagsTitle type="secondary" level={4}>
-                                <TagIcon /> Tags
-                            </TagsTitle>
-                            {tags}
-                        </TagCard>
-                    </Col>
-                </Row>
-                {!isCompact && (
-                    <>
-                        <Divider style={{ marginBottom: '0px' }} />
-                        <Row style={{ padding: '0px 0px 10px 0px' }}>
+            <Row>
+                <Col md={isCompact ? 24 : 16} sm={24} xs={24}>
+                    <LayoutDiv isCompact={isCompact}>
+                        <Row style={{ padding: '20px 0px 10px 0px' }}>
                             <Col span={24}>
-                                <RoutedTabs defaultPath={defaultTabPath} tabs={tabs || []} />
+                                {titleLink ? (
+                                    <Link to={titleLink}>
+                                        <h1>{title}</h1>
+                                    </Link>
+                                ) : (
+                                    <h1>{title}</h1>
+                                )}
                             </Col>
                         </Row>
-                    </>
-                )}
-            </div>
+                        {header}
+                    </LayoutDiv>
+                </Col>
+                <Col md={isCompact ? 24 : 8} xs={24} sm={24}>
+                    <TagCard>
+                        <TagsTitle type="secondary" level={4}>
+                            <TagIcon /> Tags
+                        </TagsTitle>
+                        {tags}
+                    </TagCard>
+                </Col>
+            </Row>
+            {!isCompact && (
+                <>
+                    <Divider style={{ marginBottom: '0px' }} />
+                    <Row style={{ padding: '0px 0px 10px 0px' }}>
+                        <Col span={24}>
+                            <RoutedTabs defaultPath={defaultTabPath} tabs={tabs || []} />
+                        </Col>
+                    </Row>
+                </>
+            )}
         </LayoutContent>
     );
 };

--- a/datahub-web-react/src/app/shared/avatar/CustomAvatar.tsx
+++ b/datahub-web-react/src/app/shared/avatar/CustomAvatar.tsx
@@ -12,7 +12,7 @@ const AvatarStyled = styled(Avatar)<{ size?: number }>`
     text-align: center;
     font-size: ${(props) => (props.size ? `${Math.max(props.size / 2.0, 14)}px` : '14px')} !important;
     && > span {
-        transform: scale(1) translateX(-45%) !important;
+        transform: scale(1) translateX(-46%) translateY(-3%) !important;
     }
 `;
 


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)


<img width="1523" alt="Screen Shot 2021-04-13 at 1 05 17 AM" src="https://user-images.githubusercontent.com/16714648/114433391-59738300-9bf4-11eb-8664-8e6c6b9c3561.png">
