### PR TITLE
feat(mysql-setup): Add the ability to specify database name for mysql-setup

### DIFF
--- a/docker/mysql-setup/Dockerfile
+++ b/docker/mysql-setup/Dockerfile
@@ -3,6 +3,9 @@ FROM jwilder/dockerize:0.6.1
 RUN apk add --no-cache mysql-client
 
 COPY docker/mysql-setup/init.sql /init.sql
+COPY docker/mysql-setup/init.sh /init.sh
+RUN chmod 755 init.sh
 
-CMD dockerize -wait tcp://$MYSQL_HOST:$MYSQL_PORT -timeout 240s \
-      mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /init.sql
+ENV DATAHUB_DB_NAME = "datahub"
+
+CMD dockerize -wait tcp://$MYSQL_HOST:$MYSQL_PORT -timeout 240s /init.sh

--- a/docker/mysql-setup/init.sh
+++ b/docker/mysql-setup/init.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+sed -i -e "s/DATAHUB_DB_NAME/${DATAHUB_DB_NAME}/g" /init.sql
+cat /init.sql
+mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /init.sql

--- a/docker/mysql-setup/init.sh
+++ b/docker/mysql-setup/init.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
 sed -i -e "s/DATAHUB_DB_NAME/${DATAHUB_DB_NAME}/g" /init.sql
-cat /init.sql
 mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /init.sql

--- a/docker/mysql-setup/init.sql
+++ b/docker/mysql-setup/init.sql
@@ -1,6 +1,6 @@
 -- create datahub database
-CREATE DATABASE IF NOT EXISTS datahub;
-USE datahub;
+CREATE DATABASE IF NOT EXISTS DATAHUB_DB_NAME;
+USE DATAHUB_DB_NAME;
 
 -- create metadata aspect table
 create table if not exists metadata_aspect (


### PR DESCRIPTION
Add the ability to specify database name for mysql-setup
Does a simple string replace on the init.sql to change the db name. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
