### PR TITLE
feat(k8s): Add ability to add service accounts to setup jobs

### DIFF
--- a/contrib/kubernetes/datahub/templates/elasticsearch-setup-job.yml
+++ b/contrib/kubernetes/datahub/templates/elasticsearch-setup-job.yml
@@ -21,6 +21,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.elasticsearchSetupJob.serviceAccount }}
+      serviceAccountName: {{ .Values.elasticsearchSetupJob.serviceAccount }}
+    {{- end }}
       restartPolicy: Never
       securityContext:
         runAsUser: 1000

--- a/contrib/kubernetes/datahub/templates/elasticsearch-setup-job.yml
+++ b/contrib/kubernetes/datahub/templates/elasticsearch-setup-job.yml
@@ -21,8 +21,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.elasticsearchSetupJob.serviceAccount }}
-      serviceAccountName: {{ .Values.elasticsearchSetupJob.serviceAccount }}
+    {{- with .Values.elasticsearchSetupJob.serviceAccount }}
+      serviceAccountName: {{ . }}
     {{- end }}
       restartPolicy: Never
       securityContext:

--- a/contrib/kubernetes/datahub/templates/kafka-setup-job.yml
+++ b/contrib/kubernetes/datahub/templates/kafka-setup-job.yml
@@ -21,8 +21,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.kafkaSetupJob.serviceAccount }}
-      serviceAccountName: {{ .Values.kafkaSetupJob.serviceAccount }}
+    {{- with .Values.kafkaSetupJob.serviceAccount }}
+      serviceAccountName: {{ . }}
     {{- end }}
       restartPolicy: Never
       securityContext:

--- a/contrib/kubernetes/datahub/templates/kafka-setup-job.yml
+++ b/contrib/kubernetes/datahub/templates/kafka-setup-job.yml
@@ -21,6 +21,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.kafkaSetupJob.serviceAccount }}
+      serviceAccountName: {{ .Values.kafkaSetupJob.serviceAccount }}
+    {{- end }}
       restartPolicy: Never
       securityContext:
         runAsUser: 1000

--- a/contrib/kubernetes/datahub/templates/mysql-setup-job.yml
+++ b/contrib/kubernetes/datahub/templates/mysql-setup-job.yml
@@ -21,6 +21,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.mysqlSetupJob.serviceAccount }}
+      serviceAccountName: {{ .Values.mysqlSetupJob.serviceAccount }}
+    {{- end }}
       restartPolicy: Never
       securityContext:
         runAsUser: 1000

--- a/contrib/kubernetes/datahub/templates/mysql-setup-job.yml
+++ b/contrib/kubernetes/datahub/templates/mysql-setup-job.yml
@@ -21,8 +21,8 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.mysqlSetupJob.serviceAccount }}
-      serviceAccountName: {{ .Values.mysqlSetupJob.serviceAccount }}
+    {{- with .Values.mysqlSetupJob.serviceAccount }}
+      serviceAccountName: {{ . }}
     {{- end }}
       restartPolicy: Never
       securityContext:


### PR DESCRIPTION
Add ability to add service accounts to setup jobs. Note if not set, doesn't change. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
