### PR TITLE
fix(react): fix access to pictureLink in charts and dashboards

### DIFF
--- a/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
@@ -37,7 +37,7 @@ export default function ChartHeader({ platform, description, ownership, url, las
                         key={owner.owner.urn}
                         name={owner.owner.info?.fullName}
                         url={`/${entityRegistry.getPathName(EntityType.CorpUser)}/${owner.owner.urn}`}
-                        photoUrl={owner.owner.editableInfo.pictureLink}
+                        photoUrl={owner.owner.editableInfo?.pictureLink}
                     />
                 ))}
             </Avatar.Group>

--- a/datahub-web-react/src/app/entity/dashboard/profile/DashboardHeader.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/profile/DashboardHeader.tsx
@@ -36,7 +36,7 @@ export default function DashboardHeader({ platform, description, ownership, url,
                         key={owner.owner.urn}
                         name={owner.owner.info?.fullName}
                         url={`/${entityRegistry.getPathName(EntityType.CorpUser)}/${owner.owner.urn}`}
-                        photoUrl={owner.owner.editableInfo.pictureLink}
+                        photoUrl={owner.owner.editableInfo?.pictureLink}
                     />
                 ))}
             </Avatar.Group>


### PR DESCRIPTION
This makes access to pictureLink in charts & dashboards safe in the case no editableInfo aspect exists.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
