### PR TITLE
fix(tags): check description existence on tags

### DIFF
--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/tag/Tags.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/tag/Tags.java
@@ -104,7 +104,9 @@ public final class Tags extends BaseSearchableEntityResource<
         final Tag value = new Tag().setName(snapshot.getUrn().getName());
         ModelUtils.getAspectsFromSnapshot(snapshot).forEach(aspect -> {
             if (aspect instanceof TagProperties) {
-                value.setDescription(TagProperties.class.cast(aspect).getDescription());
+                if (TagProperties.class.cast(aspect).hasDescription()) {
+                    value.setDescription(TagProperties.class.cast(aspect).getDescription());
+                }
                 value.setName(TagProperties.class.cast(aspect).getName());
             } else if (aspect instanceof Ownership) {
                 value.setOwnership((Ownership) aspect);


### PR DESCRIPTION
Description is optional. If we try to set it when the value is null in the aspect, GMS will raise an error

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
