### PR TITLE
fix(ingest): streamline codegen init methods

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -32,7 +32,7 @@ framework_common = {
     "toml>=0.10.0",
     "docker",
     "expandvars>=0.6.5",
-    "avro-gen3==0.3.9",
+    "avro-gen3==0.4.0",
     "avro-python3>=1.8.2",
     "python-dateutil",
 }

--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -214,7 +214,6 @@ class GlueSource(Source):
             )
 
         sys_time = int(time.time() * 1000)
-        metadata_record = MetadataChangeEvent()
         dataset_snapshot = DatasetSnapshot(
             urn=f"urn:li:dataset:(urn:li:dataPlatform:glue,{table_name},{self.env})",
             aspects=[],
@@ -225,8 +224,7 @@ class GlueSource(Source):
         dataset_snapshot.aspects.append(get_dataset_properties())
         dataset_snapshot.aspects.append(get_schema_metadata(self))
 
-        metadata_record.proposedSnapshot = dataset_snapshot
-
+        metadata_record = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
         return metadata_record
 
     def get_report(self):

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -89,13 +89,11 @@ class KafkaSource(Source):
         env = "PROD"  # TODO: configure!
         actor, sys_time = "urn:li:corpuser:etl", int(time.time() * 1000)
 
-        metadata_record = MetadataChangeEvent()
         dataset_snapshot = DatasetSnapshot(
             urn=f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset_name},{env})",
             aspects=[],  # we append to this list later on
         )
         dataset_snapshot.aspects.append(Status(removed=False))
-        metadata_record.proposedSnapshot = dataset_snapshot
 
         # Fetch schema from the registry.
         has_schema = True
@@ -130,6 +128,7 @@ class KafkaSource(Source):
             )
             dataset_snapshot.aspects.append(schema_metadata)
 
+        metadata_record = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
         return metadata_record
 
     def get_report(self):

--- a/metadata-ingestion/src/datahub/ingestion/source/ldap.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ldap.py
@@ -163,7 +163,7 @@ class LDAPSource(Source):
         full_name = attrs["cn"][0].decode()
         first_name = attrs["givenName"][0].decode()
         last_name = attrs["sn"][0].decode()
-        email = (attrs["mail"][0]).decode() if "mail" in attrs else None
+        email = (attrs["mail"][0]).decode() if "mail" in attrs else ldap
         display_name = (
             (attrs["displayName"][0]).decode() if "displayName" in attrs else full_name
         )

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -92,9 +92,10 @@ class MongoDBSource(Source):
                     self.report.report_dropped(dataset_name)
                     continue
 
-                mce = MetadataChangeEvent()
-                dataset_snapshot = DatasetSnapshot()
-                dataset_snapshot.urn = f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset_name},{env})"
+                dataset_snapshot = DatasetSnapshot(
+                    urn=f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset_name},{env})",
+                    aspects=[],
+                )
 
                 dataset_properties = DatasetPropertiesClass(
                     tags=[],
@@ -108,8 +109,7 @@ class MongoDBSource(Source):
                 # TODO: use list_indexes() or index_information() to get index information
                 # See https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.list_indexes.
 
-                mce.proposedSnapshot = dataset_snapshot
-
+                mce = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
                 wu = MetadataWorkUnit(id=dataset_name, mce=mce)
                 self.report.report_workunit(wu)
                 yield wu

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -221,10 +221,10 @@ class SQLAlchemySource(Source):
                 # TODO: capture inspector.get_pk_constraint
                 # TODO: capture inspector.get_sorted_table_and_fkc_names
 
-                mce = MetadataChangeEvent()
-
-                dataset_snapshot = DatasetSnapshot()
-                dataset_snapshot.urn = f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset_name},{env})"
+                dataset_snapshot = DatasetSnapshot(
+                    urn=f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset_name},{env})",
+                    aspects=[],
+                )
                 if description is not None:
                     dataset_properties = DatasetPropertiesClass(
                         description=description,
@@ -237,8 +237,8 @@ class SQLAlchemySource(Source):
                     self.report, dataset_name, platform, columns
                 )
                 dataset_snapshot.aspects.append(schema_metadata)
-                mce.proposedSnapshot = dataset_snapshot
 
+                mce = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
                 wu = SqlWorkUnit(id=dataset_name, mce=mce)
                 self.report.report_workunit(wu)
                 yield wu

--- a/metadata-ingestion/tests/integration/ldap/ldap_mce_golden.json
+++ b/metadata-ingestion/tests/integration/ldap/ldap_mce_golden.json
@@ -9,7 +9,7 @@
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
                         "active": true,
                         "displayName": "Bart Simpson",
-                        "email": "",
+                        "email": "bsimpson",
                         "title": "Mr. Boss",
                         "managerUrn": null,
                         "departmentId": null,
@@ -61,7 +61,7 @@
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
                         "active": true,
                         "displayName": "Lisa Simpson",
-                        "email": "",
+                        "email": "lsimpson",
                         "title": null,
                         "managerUrn": null,
                         "departmentId": null,
@@ -87,7 +87,7 @@
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
                         "active": true,
                         "displayName": "Maggie Simpson",
-                        "email": "",
+                        "email": "msimpson",
                         "title": null,
                         "managerUrn": null,
                         "departmentId": null,

--- a/metadata-ingestion/tests/test_helpers/docker_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/docker_helpers.py
@@ -17,7 +17,7 @@ def wait_for_port(
     docker_services: pytest_docker.plugin.Services,
     container_name: str,
     container_port: int,
-    timeout: float=30.0,
+    timeout: float = 30.0,
 ) -> None:
     # port = docker_services.port_for(container_name, container_port)
     docker_services.wait_until_responsive(

--- a/metadata-ingestion/tests/test_helpers/docker_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/docker_helpers.py
@@ -17,7 +17,7 @@ def wait_for_port(
     docker_services: pytest_docker.plugin.Services,
     container_name: str,
     container_port: int,
-    timeout=15.0,
+    timeout=30.0,
 ):
     # port = docker_services.port_for(container_name, container_port)
     docker_services.wait_until_responsive(

--- a/metadata-ingestion/tests/unit/serde/test_serde.py
+++ b/metadata-ingestion/tests/unit/serde/test_serde.py
@@ -72,7 +72,7 @@ def test_serde_to_avro(pytestconfig, json_filename):
     # Check diff
     assert len(mces) == len(in_mces)
     for i in range(len(mces)):
-        assert str(mces[i]) == str(in_mces[i])
+        assert mces[i] == in_mces[i]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Gets rid of the `@overload` hack that was used to make static types work
- Ensures arguments to the constructor are set properly
- Enables normal `==` equality checks between objects
- Fixes a hack used in the glue test to check equality

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
