### PR TITLE
fix(setup-jobs): Fix env variable setup for kafka/mysql-setup docker containers

### DIFF
--- a/docker/kafka-setup/Dockerfile
+++ b/docker/kafka-setup/Dockerfile
@@ -1,9 +1,9 @@
 # This "container" is a workaround to pre-create topics
 FROM confluentinc/cp-kafka:5.4.0
 
-ENV METADATA_AUDIT_EVENT_NAME = "MetadataAuditEvent_v4"
-ENV METADATA_CHANGE_EVENT_NAME = "MetadataChangeEvent_v4"
-ENV FAILED_METADATA_CHANGE_EVENT_NAME = "FailedMetadataChangeEvent_v4"
+ENV METADATA_AUDIT_EVENT_NAME="MetadataAuditEvent_v4"
+ENV METADATA_CHANGE_EVENT_NAME="MetadataChangeEvent_v4"
+ENV FAILED_METADATA_CHANGE_EVENT_NAME="FailedMetadataChangeEvent_v4"
 
 CMD echo Waiting for Kafka to be ready... && \
     cub kafka-ready -b $KAFKA_BOOTSTRAP_SERVER 1 60 && \

--- a/docker/mysql-setup/Dockerfile
+++ b/docker/mysql-setup/Dockerfile
@@ -6,6 +6,6 @@ COPY docker/mysql-setup/init.sql /init.sql
 COPY docker/mysql-setup/init.sh /init.sh
 RUN chmod 755 init.sh
 
-ENV DATAHUB_DB_NAME = "datahub"
+ENV DATAHUB_DB_NAME="datahub"
 
 CMD dockerize -wait tcp://$MYSQL_HOST:$MYSQL_PORT -timeout 240s /init.sh

--- a/docker/mysql-setup/init.sh
+++ b/docker/mysql-setup/init.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-sed -i -e "s/DATAHUB_DB_NAME/${DATAHUB_DB_NAME}/g" /init.sql
-mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /init.sql
+sed -e "s/DATAHUB_DB_NAME/${DATAHUB_DB_NAME}/g" /init.sql | tee -a /tmp/init-final.sql
+mysql -u $MYSQL_USERNAME -p"$MYSQL_PASSWORD" -h $MYSQL_HOST < /tmp/init-final.sql


### PR DESCRIPTION
Fix env variable setup for kafka/mysql-setup docker containers

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
