### PR TITLE
fix(ingest): use entrypoints lib instead of pkg_resources

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -30,6 +30,7 @@ framework_common = {
     "click>=6.0.0",
     "PyYAML",
     "toml>=0.10.0",
+    "entrypoints",
     "docker",
     "expandvars>=0.6.5",
     "avro-gen3==0.4.3",

--- a/metadata-ingestion/src/datahub/ingestion/api/registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/registry.py
@@ -2,7 +2,7 @@ import importlib
 import inspect
 from typing import Dict, Generic, Type, TypeVar, Union
 
-import pkg_resources
+import entrypoints
 import typing_inspect
 
 from datahub import __package_name__
@@ -48,7 +48,8 @@ class Registry(Generic[T]):
         return not isinstance(tp, Exception)
 
     def load(self, entry_point_key: str) -> None:
-        for entry_point in pkg_resources.iter_entry_points(entry_point_key):
+        entry_point: entrypoints.EntryPoint
+        for entry_point in entrypoints.get_group_all(entry_point_key):
             name = entry_point.name
 
             try:

--- a/metadata-ingestion/tests/unit/test_plugin_system.py
+++ b/metadata-ingestion/tests/unit/test_plugin_system.py
@@ -1,6 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
+import datahub as datahub_metadata
 from datahub.configuration.common import ConfigurationError
 from datahub.entrypoints import datahub
 from datahub.ingestion.api.registry import Registry
@@ -9,6 +10,13 @@ from datahub.ingestion.extractor.extractor_registry import extractor_registry
 from datahub.ingestion.sink.console import ConsoleSink
 from datahub.ingestion.sink.sink_registry import sink_registry
 from datahub.ingestion.source.source_registry import source_registry
+
+
+def test_datahub_version():
+    # Simply importing pkg_resources checks for unsatisfied dependencies.
+    import pkg_resources
+
+    assert pkg_resources.get_distribution(datahub_metadata.__package_name__).version
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Makes the datahub CLI tool a bit snappier by speeding up the loading of plugins by using the `entrypoints` library (https://entrypoints.readthedocs.io/en/latest/)

Before:
```
❯ /usr/bin/time datahub --version
acryl-datahub, version 0.1.3
        0.72 real         0.66 user         0.06 sys
```

After:
```
❯ /usr/bin/time datahub --version
acryl-datahub, version unavailable (installed editable via git)
        0.30 real         0.25 user         0.04 sys
```

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
