### PR TITLE
fix(ingest): remove datahub.metadata import shortcut

### DIFF
--- a/metadata-ingestion/scripts/avro_codegen.py
+++ b/metadata-ingestion/scripts/avro_codegen.py
@@ -34,7 +34,9 @@ def generate(schema_file: str, outdir: str) -> None:
 
     write_schema_files(redo_spaces, outdir)
     suppress_checks_in_file(f"{outdir}/schema_classes.py")
-    suppress_checks_in_file(f"{outdir}/__init__.py")
+    with open(f"{outdir}/__init__.py", "w"):
+        # Truncate this file.
+        pass
 
 
 if __name__ == "__main__":

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -3,7 +3,7 @@
 import time
 from typing import List, Union
 
-from datahub.metadata import (
+from datahub.metadata.schema_classes import (
     AuditStampClass,
     DatasetLineageTypeClass,
     DatasetSnapshotClass,

--- a/metadata-ingestion/src/datahub/integrations/airflow/lineage_backend.py
+++ b/metadata-ingestion/src/datahub/integrations/airflow/lineage_backend.py
@@ -5,7 +5,7 @@ import dateutil.parser
 from airflow.lineage.backend import LineageBackend
 
 import datahub.emitter.mce_builder as builder
-import datahub.metadata as models
+import datahub.metadata.schema_classes as models
 
 if TYPE_CHECKING:
     from airflow import DAG

--- a/metadata-ingestion/tests/unit/serde/test_serde.py
+++ b/metadata-ingestion/tests/unit/serde/test_serde.py
@@ -7,7 +7,7 @@ import pytest
 from _pytest.config import Config as PytestConfig
 from click.testing import CliRunner
 
-import datahub.metadata as models
+import datahub.metadata.schema_classes as models
 from datahub.entrypoints import datahub
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.source.mce_file import iterate_mce_file

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -3,7 +3,7 @@ import json
 import pytest
 import requests
 
-import datahub.metadata as models
+import datahub.metadata.schema_classes as models
 from datahub.emitter.rest_emitter import DatahubRestEmitter
 
 MOCK_GMS_ENDPOINT = "http://fakegmshost:8080"


### PR DESCRIPTION
We don't need three distinct ways to import the model classes. This is the first step of simplification.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
