### PR TITLE
docs: Fix spelling error

### DIFF
--- a/docs/docker/development.md
+++ b/docs/docker/development.md
@@ -66,7 +66,7 @@ applies.
 running. If you, for some reason, wish to change this behavior, check out these example commands.
 
 ```
-docker-compose -p datahub -f docker-compose.yml -f docker-compose.overrides.yml -f docker-compose.dev.yml up datahub-gms
+docker-compose -p datahub -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml up datahub-gms
 ```
 Will only start `datahub-gms` and its dependencies.
 


### PR DESCRIPTION
The correct file name in `datahub/docker` is `docker-compose.override.yml`

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
