### PR TITLE
fix(docker): Nuke ingestion containers when calling docker/nuke.sh

### DIFF
--- a/docker/nuke.sh
+++ b/docker/nuke.sh
@@ -6,3 +6,7 @@ cd $DIR
 # Tear down and clean up all DataHub-related containers, volumes, and network
 docker-compose -p datahub down -v
 docker-compose rm -f -v
+
+# Tear down ingestion container
+cd ingestion
+docker-compose -p datahub down -v

--- a/docker/nuke.sh
+++ b/docker/nuke.sh
@@ -8,4 +8,4 @@ docker-compose -p datahub down -v
 docker-compose rm -f -v
 
 # Tear down ingestion container
-cd ingestion && docker-compose -p datahub down -v
+(cd ingestion && docker-compose -p datahub down -v)

--- a/docker/nuke.sh
+++ b/docker/nuke.sh
@@ -8,5 +8,4 @@ docker-compose -p datahub down -v
 docker-compose rm -f -v
 
 # Tear down ingestion container
-cd ingestion
-docker-compose -p datahub down -v
+cd ingestion && docker-compose -p datahub down -v

--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -50,7 +50,7 @@ class ConfigurationMechanism(ABC):
 
 
 class AllowDenyPattern(ConfigModel):
-    """ A class to store allow deny regexes"""
+    """A class to store allow deny regexes"""
 
     allow: List[str] = [".*"]
     deny: List[str] = []


### PR DESCRIPTION
Current nuke.sh only destroys the containers created by the main docker-compose.yml files. Because ingestion uses a separate docker-compose.yml, these containers are not destroyed. As a result, when we bring up the containers again after nuking, the ingestion script fails as the container points to an old network instance. This change makes sure the ingestion containers are also nuked so that the above issue does not happen. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
