### PR TITLE
fix(ingest): fields with defaults should be optional

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -33,7 +33,7 @@ framework_common = {
     "entrypoints",
     "docker",
     "expandvars>=0.6.5",
-    "avro-gen3==0.4.3",
+    "avro-gen3==0.5.0",
     "avro-python3>=1.8.2",
     "python-dateutil",
 }

--- a/metadata-ingestion/src/datahub/configuration/common.py
+++ b/metadata-ingestion/src/datahub/configuration/common.py
@@ -50,7 +50,7 @@ class ConfigurationMechanism(ABC):
 
 
 class AllowDenyPattern(ConfigModel):
-    """ A class to store allow deny regexes"""
+    """A class to store allow deny regexes"""
 
     allow: List[str] = [".*"]
     deny: List[str] = []

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -237,8 +237,6 @@ class SQLAlchemySource(Source):
                 if description is not None:
                     dataset_properties = DatasetPropertiesClass(
                         description=description,
-                        tags=[],
-                        customProperties={},
                         # uri=dataset_name,
                     )
                     dataset_snapshot.aspects.append(dataset_properties)

--- a/metadata-ingestion/tests/unit/test_glue_source.py
+++ b/metadata-ingestion/tests/unit/test_glue_source.py
@@ -142,9 +142,6 @@ def create_metadata_work_unit(timestamp):
     dataset_snapshot.aspects.append(
         DatasetPropertiesClass(
             description="Grilled Food",
-            customProperties={},
-            uri=None,
-            tags=[],
         )
     )
 

--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -104,9 +104,6 @@ def get_initial_mce() -> MetadataChangeEventClass:
             aspects=[
                 DatasetPropertiesClass(
                     description="test.description",
-                    customProperties={},
-                    uri=None,
-                    tags=[],
                 )
             ],
         )

--- a/metadata-ingestion/tests/unit/test_rest_sink.py
+++ b/metadata-ingestion/tests/unit/test_rest_sink.py
@@ -91,7 +91,6 @@ basicAuditStamp = models.AuditStampClass(
                                 lastModified=basicAuditStamp,
                             ),
                             type=models.ChartTypeClass.SCATTER,
-                            customProperties={},
                         ),
                     ],
                 )
@@ -133,7 +132,6 @@ basicAuditStamp = models.AuditStampClass(
                             name="User Deletions",
                             description="Constructs the fct_users_deleted from logging_events",
                             type=models.AzkabanJobTypeClass.SQL,
-                            customProperties={},
                         )
                     ],
                 )


### PR DESCRIPTION
- Fields like `customProperties` and `tags` are now optional, and default to `{}` or `[]`
- Enum fields have documentation from the Avro schema
- The `.from_obj()` method is slightly more strict about what it accepts

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
