### PR TITLE
feat(ingest): capture default values in Avro schemas

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
+++ b/metadata-ingestion/src/datahub/ingestion/extractor/schema_util.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 
 import avro.schema
 
@@ -68,11 +68,15 @@ def _recordschema_to_mce_fields(schema: avro.schema.RecordSchema) -> List[Schema
     fields: List[SchemaField] = []
 
     for parsed_field in schema.fields:
+        description: Optional[str] = parsed_field.doc
+        if parsed_field.has_default:
+            description = description if description else "No description available."
+            description = f"{description}\nField default value: {parsed_field.default}"
         field = SchemaField(
             fieldPath=parsed_field.name,
             nativeDataType=str(parsed_field.type),
             type=_get_column_type(parsed_field.type),
-            description=parsed_field.props.get("doc", None),
+            description=description,
             recursive=False,
             nullable=_is_nullable(parsed_field.type),
         )


### PR DESCRIPTION
Also refactors the tests to use pytest instead of unittest.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
