### PR TITLE
feat(K8s) Generalizes CronJob metadata ingestion resource for custom logic

### DIFF
--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/Chart.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/README.md
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/README.md
@@ -13,7 +13,10 @@ A Helm chart for datahub's metadata-ingestion framework with kerberos authentica
 | labels | string | `{}` | Metadata labels to be added to each crawling cron job |
 | crons | type | `{}` | A map of crawling parameters per different technology being crawler, the key in the object will be used as the name for the new cron job |
 | crons.schedule | string | `"0 0 * * *"` | Cron expression (default is daily at midnight) for crawler jobs |
-| crons.command | array | `["/bin/sh", "-c", "datahub ingest -c config.yml"]` | Array of strings denoting the crawling command to be invoked in the cron job. Provided example assumes a top-level file called `config.yml` has been mounted and is a valid [datahub crawling recipe](https://github.com/linkedin/datahub/tree/master/metadata-ingestion#recipes). |
+| crons.recipe | object | `{}` | Recipe configuration to be executed (required) |
+| crons.recipe.configmapName | string | `""` | Name of configmap to be mounted containing recipe to be executed |
+| crons.recipe.fileName | string | `""` | Name of property within configMap referenced by `recipe.configName` with the concrete recipe definition |
+| crons.command | array | `["/bin/sh", "-c", "datahub ingest -c /etc/recipe/<crons.recipe.fileName>"]` | Array of strings denoting the crawling command to be invoked in the cron job. By default it will execute the recipe defined in the `crons.recipe` object. Cron crawling customization is possible by having extra volumes with custom logic to be executed. |
 | crons.hostAliases | array | `[]` | host aliases |
 | crons.env | object | `{}` | Environment variables to add to the cronjob container |
 | crons.envFromSecrets | object | `{}` | Environment variables from secrets to the cronjob container |

--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/README.md
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/README.md
@@ -11,10 +11,9 @@ A Helm chart for datahub's metadata-ingestion framework with kerberos authentica
 | image.tag | string | `"latest"` | DataHub Ingestion image tag |
 | imagePullSecrets | array | `[]` (does not add image pull secrets to deployed pods) | Docker registry secret names as an array |
 | labels | string | `{}` | Metadata labels to be added to each crawling cron job |
-| crons | type | `[]` | A list of crawling parameters per different technology being crawler |
-| crons.name | string | `crawler` | Name of the crawler container |
-| crons.schedule | string | `""0 0 * * *"` | Cron expression (daily at midnight) for crawler jobs |
-| crons.crawlerConfigPath | string | N/A | Path to metadata configuration file. This must explicitly defined as a mount and is **required**. |
+| crons | type | `{}` | A map of crawling parameters per different technology being crawler, the key in the object will be used as the name for the new cron job |
+| crons.schedule | string | `"0 0 * * *"` | Cron expression (default is daily at midnight) for crawler jobs |
+| crons.command | array | `["/bin/sh", "-c", "datahub ingest -c config.yml"]` | Array of strings denoting the crawling command to be invoked in the cron job. Provided example assumes a top-level file called `config.yml` has been mounted and is a valid [datahub crawling recipe](https://github.com/linkedin/datahub/tree/master/metadata-ingestion#recipes). |
 | crons.hostAliases | array | `[]` | host aliases |
 | crons.env | object | `{}` | Environment variables to add to the cronjob container |
 | crons.envFromSecrets | object | `{}` | Environment variables from secrets to the cronjob container |

--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/templates/cron.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/templates/cron.yaml
@@ -1,6 +1,7 @@
 {{- $baseName := include "datahub-ingestion-cron.fullname" .}}
 {{- $labels := include "datahub-ingestion-cron.labels" .}}
 {{- range $jobName, $val := .Values.crons }}
+{{- $defaultCommand := printf "datahub ingest -c /etc/recipe/%s" $val.recipe.fileName }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -29,9 +30,11 @@ spec:
             imagePullPolicy: {{ $.Values.image.pullPolicy }}
             {{- if .extraVolumeMounts }}
             volumeMounts:
+              - name: recipe
+                mountPath: /etc/recipe
               {{- toYaml .extraVolumeMounts | nindent 14 }}
             {{- end }}
-            command: ["/bin/sh", "-c", {{ default "datahub ingest -c config.yml" .command }} ]
+            command: ["/bin/sh", "-c", {{ default $defaultCommand .command }} ]
             env:
               {{- if .env }}
               {{- range $key,$value := .env }}
@@ -49,8 +52,11 @@ spec:
               {{- end }}
               {{- end }}
           restartPolicy: OnFailure
-          {{- if .extraVolumes }}
           volumes:
+            - name: recipe
+              configMap:
+                name: {{ required "A valid .recipe.configmapName entry is required!" $val.recipe.configmapName }}
+          {{- if .extraVolumes }}
             {{- toYaml .extraVolumes | nindent 12 }}
           {{- end }}
 ---

--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/templates/cron.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/templates/cron.yaml
@@ -1,10 +1,10 @@
 {{- $baseName := include "datahub-ingestion-cron.fullname" .}}
 {{- $labels := include "datahub-ingestion-cron.labels" .}}
-{{- range $job, $val := .Values.crons }}
+{{- range $jobName, $val := .Values.crons }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "{{ $baseName }}-{{ .name }}"
+  name: "{{ $baseName }}-{{ $jobName }}"
   labels: {{- $labels | nindent 4 }}
 spec:
   schedule: {{ default "0 0 * * *" .schedule | quote}}
@@ -24,17 +24,14 @@ spec:
           hostAliases: {{- include "common.tplvalues.render" (dict "value" .hostAliases "context" $) | nindent 10 }}
         {{- end }}
           containers:
-          - name: {{ default "crawler" .name }}
+          - name: {{ $jobName }}-crawler
             image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
             imagePullPolicy: {{ $.Values.image.pullPolicy }}
             {{- if .extraVolumeMounts }}
             volumeMounts:
               {{- toYaml .extraVolumeMounts | nindent 14 }}
             {{- end }}
-            command:
-            - /bin/sh
-            - -c
-            - datahub ingest -c {{ required "Path to configuration file is required" .crawlerConfigPath }}
+            command: ["/bin/sh", "-c", {{ default "datahub ingest -c config.yml" .command }} ]
             env:
               {{- if .env }}
               {{- range $key,$value := .env }}

--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/values.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/values.yaml
@@ -15,8 +15,12 @@ crons: {}
     ## Daily at midnight (we may want to offset this to not conflict with other processes)
     #schedule: "0 0 * * *"
 
+    #recipe:
+    #  configmapName:
+    #  fileName:
+
     ## Command to be executed
-    #command: ["/bin/sh", "-c", "datahub ingest -c config.yml"]
+    #command: ["/bin/sh", "-c", "datahub ingest -c <recipe.fileName>"]
 
     ## Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/

--- a/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/values.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-ingestion-cron/values.yaml
@@ -9,34 +9,40 @@ image:
 
 imagePullSecrets: []
 
-crons: []
+crons: {}
   #### Example data
-  ## Metadata ingestion name
-  ##
-  #name: "crawler"
+  #hive:
+    ## Daily at midnight (we may want to offset this to not conflict with other processes)
+    #schedule: "0 0 * * *"
 
-  ## Daily at midnight (we may want to offset this to not conflict with other processes)
-  #schedule: "0 0 * * *"
+    ## Command to be executed
+    #command: ["/bin/sh", "-c", "datahub ingest -c config.yml"]
 
-  ## Deployment pod host aliases
-  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
-  ##
-  #hostAliases: []
+    ## Deployment pod host aliases
+    ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    ##
+    #hostAliases: []
 
-  ## Environment variables.
-  #env: {}
+    ## Environment variables.
+    #env: {}
 
-  ## Environment variables from Secret resources.
-  #envFromSecrets: {}
+    ## Environment variables from Secret resources.
+    #envFromSecrets: {}
 
-  ## Additional primary volume mounts
-  ##
-  #extraVolumeMounts: []
+    ## Additional primary volume mounts
+    ##
+    #extraVolumeMounts:
+    #- name: configmap-volume
+    #  mountPath: config.yml
+    #  subPath: config.yml
 
-  ## Additional primary volumes
-  ##
-  #extraVolumes: []
+    ## Additional primary volumes
+    ##
+    #extraVolumes:
+    #- name: configmap-volume
+    #  configMap:
+    #    name: crawler-config
 
-  ## Add your own init container or uncomment and modify the given example.
-  ##
-  #extraInitContainers: {}
+    ## Add your own init container or uncomment and modify the given example.
+    ##
+    #extraInitContainers: {}


### PR DESCRIPTION
This PR allows users of the DataHub Metadata Ingestion Chart Component to run custom logic beyond that which is available by the `datahub ingest` command line python tool.

This is being used in production at DefinedCrowd to manipulate metadata models crawled from Druid datasources prior to sending them to DataHub. 

At the time [transformations](https://datahubproject.io/docs/metadata-ingestion/#transformations) were not ready as far we knew, so it is unlikely that an exact use-case should require the same method. Regardless we feel this greater flexibility in this component makes sense for less trivial scenarios.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
