### PR TITLE
fix(ingest): use postgres data platform

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/postgres.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/postgres.py
@@ -24,7 +24,7 @@ class PostgresConfig(BasicSQLAlchemyConfig):
 
 class PostgresSource(SQLAlchemySource):
     def __init__(self, config, ctx):
-        super().__init__(config, ctx, "postgresql")
+        super().__init__(config, ctx, "postgres")
 
     @classmethod
     def create(cls, config_dict, ctx):


### PR DESCRIPTION
Standardize on `postgres`, since we already use that in the data platforms JSON file and a couple other spots.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
