### PR TITLE
fix(react) Fetch userUrn from cookie while uploading document

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/Documentation.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/Documentation.tsx
@@ -1,8 +1,10 @@
 import { Button, Form, Input, Space, Table, Typography } from 'antd';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import Cookies from 'js-cookie';
 import { EntityType, InstitutionalMemoryMetadata, InstitutionalMemoryUpdate } from '../../../../types.generated';
 import { useEntityRegistry } from '../../../useEntityRegistry';
+import { GlobalCfg } from '../../../../conf';
 
 export type Props = {
     documents: Array<InstitutionalMemoryMetadata>;
@@ -70,7 +72,7 @@ export default function Documentation({ documents, updateDocumentation }: Props)
         const newDoc = {
             url: '',
             description: '',
-            author: localStorage.getItem('userUrn') as string,
+            author: Cookies.get(GlobalCfg.CLIENT_AUTH_COOKIE) as string,
             created: {
                 time: Date.now(),
             },


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] #2471 
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

Here in document.tsx we are fetching userUrn from cookie rather than localstorage as we are not storing anything in localstorage anywhere.
