### PR TITLE
test(ingest): rename TestSource -> FakeSource

### DIFF
--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -38,7 +38,7 @@ class PipelineTest(unittest.TestCase):
 
         pipeline = Pipeline.create(
             {
-                "source": {"type": "tests.unit.test_pipeline.TestSource"},
+                "source": {"type": "tests.unit.test_pipeline.FakeSource"},
                 "transformers": [
                     {"type": "tests.unit.test_pipeline.AddStatusRemovedTransformer"}
                 ],
@@ -76,7 +76,7 @@ class AddStatusRemovedTransformer(Transformer):
             yield record_envelope
 
 
-class TestSource(Source):
+class FakeSource(Source):
     def __init__(self):
         self.source_report = SourceReport()
         self.work_units: List[MetadataWorkUnit] = [
@@ -85,7 +85,8 @@ class TestSource(Source):
 
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "Source":
-        return TestSource()
+        assert not config_dict
+        return FakeSource()
 
     def get_workunits(self) -> Iterable[WorkUnit]:
         return self.work_units


### PR DESCRIPTION
Class names that start with Test are picked up by pytest, so this resolves that warning.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
