### PR TITLE
(fix) DBT metadata ingest can add metadata to existing dataplatforms

### DIFF
--- a/metadata-ingestion/README.md
+++ b/metadata-ingestion/README.md
@@ -595,6 +595,11 @@ Pull metadata from DBT output files:
 - [dbt catalog file](https://docs.getdbt.com/reference/artifacts/catalog-json)
   - This file contains schema data.
   - DBT does not record schema data for Ephemeral models, as such datahub will show Ephemeral models in the lineage, however there will be no associated schema for Ephemeral models
+- target_platform: 
+  - The data platform you are enriching with DBT metadata.
+  - [data platforms](https://github.com/linkedin/datahub/blob/master/gms/impl/src/main/resources/DataPlatformInfo.json)
+- load_schema:
+  - Load schemas from dbt catalog file, not necessary when the underlying data platform already has this data.
 
 ```yml
 source:
@@ -602,6 +607,8 @@ source:
   config:
     manifest_path: "./path/dbt/manifest_file.json"
     catalog_path: "./path/dbt/catalog_file.json"
+    target_platform: "postgres" # optional eg postgres, snowflake etc. 
+    load_schema: True / False
 ```
 
 ## Sinks

--- a/metadata-ingestion/examples/recipes/dbt_to_datahub.yml
+++ b/metadata-ingestion/examples/recipes/dbt_to_datahub.yml
@@ -4,7 +4,8 @@ source:
   config:
     manifest_path: "./your/dbt/manifest.json"
     catalog_path: "./your/dbt/catalog.json"
-
+    target_platform: "[target data platform]"
+    load_schemas: True # or false
 sink:
   type: "datahub-rest"
   config:

--- a/metadata-ingestion/tests/integration/dbt/test_dbt.py
+++ b/metadata-ingestion/tests/integration/dbt/test_dbt.py
@@ -13,6 +13,8 @@ def test_dbt_ingest(pytestconfig, tmp_path, mock_time):
                 "config": {
                     "manifest_path": f"{test_resources_dir}/dbt_manifest.json",
                     "catalog_path": f"{test_resources_dir}/dbt_catalog.json",
+                    "target_platform": "dbt",
+                    "load_schemas": True,
                 },
             },
             "sink": {


### PR DESCRIPTION
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

Driver: https://datahubspace.slack.com/archives/CUMUWQU66/p1619190330199800

TL/DR: DBT metadata will likely be loaded to provide DBT metadata (tags and lineage) and we will want the dbt ingestion tooling to enhance existing data.  That data will likely be loaded from another platform.

IE: 
```
urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)
vs.
urn:li:dataset:(urn:li:dataPlatform:postgresql,pagila.public.payment_p2020_01,PROD)
```

We will provide either the ability to specify a target_platform or infer it from the dbt metadata.