### PR TITLE
feat(search): Add search for field level description and tags

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/search/highlights.ts
+++ b/datahub-web-react/src/app/entity/dataset/search/highlights.ts
@@ -1,2 +1,6 @@
 export const FIELDS_TO_HIGHLIGHT = new Map();
 FIELDS_TO_HIGHLIGHT.set('fieldPaths', 'column');
+FIELDS_TO_HIGHLIGHT.set('fieldDescriptions', 'column description');
+FIELDS_TO_HIGHLIGHT.set('fieldTags', 'column tag');
+FIELDS_TO_HIGHLIGHT.set('editedFieldDescriptions', 'column description');
+FIELDS_TO_HIGHLIGHT.set('editedFieldTags', 'column tag');

--- a/gms/impl/src/main/java/com/linkedin/metadata/configs/DatasetSearchConfig.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/configs/DatasetSearchConfig.java
@@ -53,6 +53,7 @@ public class DatasetSearchConfig extends BaseSearchConfigWithConvention<DatasetD
   @Override
   @Nullable
   public List<String> getFieldsToHighlightMatch() {
-    return ImmutableList.of("name", "fieldPaths");
+    return ImmutableList.of("name", "fieldPaths", "description", "tags", "fieldDescriptions", "fieldTags",
+        "editedFieldDescriptions", "editedFieldTags");
   }
 }

--- a/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
+++ b/gms/impl/src/main/resources/datasetESSearchQueryTemplate.json
@@ -10,7 +10,9 @@
                 "name^1000",
                 "platform",
                 "tags",
-                "fieldPaths"
+                "fieldPaths",
+                "fieldTags^0.5",
+                "editedFieldTags^0.5"
               ],
               "default_operator": "and",
               "analyzer": "custom_keyword"
@@ -25,7 +27,12 @@
                 "name.delimited",
                 "fieldPaths.delimited^0.2",
                 "name.ngram^0.125",
-                "tags.ngram^0.0625"
+                "tags.ngram^0.0625",
+                "description^0.5",
+                "fieldDescriptions^0.125",
+                "fieldTags.ngram^0.0125",
+                "editedFieldDescriptions^0.125",
+                "editedFieldTags.ngram^0.0125"
               ],
               "default_operator": "and",
               "analyzer": "whitespace_lowercase"

--- a/gms/impl/src/main/resources/index/dataset/mappings.json
+++ b/gms/impl/src/main/resources/index/dataset/mappings.json
@@ -26,11 +26,7 @@
     },
     "description": {
       "type": "text",
-      "fields": {
-        "keyword": {
-          "type": "keyword"
-        }
-      }
+      "analyzer": "delimit"
     },
     "hasOwners": {
       "type": "boolean"
@@ -81,6 +77,34 @@
         }
       },
       "normalizer": "my_normalizer"
+    },
+    "fieldDescriptions": {
+      "type": "text",
+      "analyzer": "delimit"
+    },
+    "fieldTags": {
+      "type": "keyword",
+      "normalizer": "my_normalizer",
+      "fields": {
+        "ngram": {
+          "type": "text",
+          "analyzer": "custom_ngram"
+        }
+      }
+    },
+    "editedFieldDescriptions": {
+      "type": "text",
+      "analyzer": "delimit"
+    },
+    "editedFieldTags": {
+      "type": "keyword",
+      "normalizer": "my_normalizer",
+      "fields": {
+        "ngram": {
+          "type": "text",
+          "analyzer": "custom_ngram"
+        }
+      }
     },
     "num_downstream_datasets": {
       "type": "long"

--- a/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
+++ b/metadata-builders/src/test/java/com/linkedin/metadata/builders/search/DatasetIndexBuilderTest.java
@@ -183,6 +183,7 @@ public class DatasetIndexBuilderTest {
   public void schemaMetadata() {
     // given
     final SchemaFieldArray schemaFieldArray = new SchemaFieldArray(new SchemaField().setFieldPath("foo.bar.baz")
+        .setDescription("test description")
         .setType(new SchemaFieldDataType().setType(SchemaFieldDataType.Type.create(new BooleanType())))
         .setNullable(false)
         .setNativeDataType("boolean")
@@ -191,8 +192,11 @@ public class DatasetIndexBuilderTest {
     final SchemaMetadata schemaMetadata = new SchemaMetadata().setFields(schemaFieldArray);
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, schemaMetadata)));
-    final DatasetDocument expectedDocument1 =
-        new DatasetDocument().setUrn(datasetUrn).setHasSchema(true).setFieldPaths(new StringArray("foo.bar.baz"));
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn)
+        .setHasSchema(true)
+        .setFieldPaths(new StringArray("foo.bar.baz"))
+        .setFieldDescriptions(new StringArray("test description"))
+        .setFieldTags(new StringArray());
     final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)
@@ -213,8 +217,7 @@ public class DatasetIndexBuilderTest {
     final Status status = new Status().setRemoved(true);
     final DatasetSnapshot datasetSnapshot = ModelUtils.newSnapshot(DatasetSnapshot.class, datasetUrn,
         Collections.singletonList(ModelUtils.newAspectUnion(DatasetAspect.class, status)));
-    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn)
-        .setRemoved(true);
+    final DatasetDocument expectedDocument1 = new DatasetDocument().setUrn(datasetUrn).setRemoved(true);
     final DatasetDocument expectedDocument2 = new DatasetDocument().setUrn(datasetUrn)
         .setBrowsePaths(new StringArray("/prod/foo/bar"))
         .setOrigin(FabricType.PROD)

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/search/DatasetDocument.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/search/DatasetDocument.pdl
@@ -72,4 +72,24 @@ record DatasetDocument includes BaseDocument {
    * List of tags for this dataset
    */
   tags: optional array[string]
+
+  /**
+   * List of field descriptions
+   */
+  fieldDescriptions: optional array[string]
+
+  /**
+   * List of tags applied to fields
+   */
+  fieldTags: optional array[string]
+
+  /**
+   * List of field descriptions
+   */
+  editedFieldDescriptions: optional array[string]
+
+  /**
+   * List of tags applied to fields
+   */
+  editedFieldTags: optional array[string]
 }


### PR DESCRIPTION
Add search for field level description and tags. Also add search for dataset description. 

For field-level description and tags, we have two sources - one from ingest one from UI (editable). We simply add multiple search fields instead of merging them. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
