### PR TITLE
fix(k8s): Add helm dep update command to readme

### DIFF
--- a/datahub-kubernetes/README.md
+++ b/datahub-kubernetes/README.md
@@ -55,6 +55,7 @@ The above commands sets the passwords to "datahub" as an example. Change to any 
 Second, deploy the dependencies by running the following
 
 ```(shell)
+(cd prerequisites && helm dep update)
 helm install prerequisites prerequisites/
 ```
 


### PR DESCRIPTION
You need to run `helm dep update` in the prerequisites directory to run helm install. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
