### PR TITLE
fix(k8s): Comment out minikube specific settings for elasticsearch

### DIFF
--- a/datahub-kubernetes/prerequisites/values.yaml
+++ b/datahub-kubernetes/prerequisites/values.yaml
@@ -14,29 +14,29 @@ elasticsearch:
   client:
     replicas: 1
 
-# Uncomment if running on minikube - Reference https://github.com/elastic/helm-charts/blob/master/elasticsearch/examples/minikube/values.yaml
-  # Permit co-located instances for solitary minikube virtual machines.
-  antiAffinity: "soft"
+  # Uncomment if running on minikube - Reference https://github.com/elastic/helm-charts/blob/master/elasticsearch/examples/minikube/values.yaml
+  # # Permit co-located instances for solitary minikube virtual machines.
+  # antiAffinity: "soft"
 
-  # Shrink default JVM heap.
-  esJavaOpts: "-Xmx128m -Xms128m"
+  # # Shrink default JVM heap.
+  # esJavaOpts: "-Xmx128m -Xms128m"
 
-  # Allocate smaller chunks of memory per pod.
-  resources:
-    requests:
-      cpu: "100m"
-      memory: "512M"
-    limits:
-      cpu: "1000m"
-      memory: "512M"
+  # # Allocate smaller chunks of memory per pod.
+  # resources:
+  #   requests:
+  #     cpu: "100m"
+  #     memory: "512M"
+  #   limits:
+  #     cpu: "1000m"
+  #     memory: "512M"
 
-  # Request smaller persistent volumes.
-  volumeClaimTemplate:
-    accessModes: [ "ReadWriteOnce" ]
-    storageClassName: "standard"
-    resources:
-      requests:
-        storage: 100M
+  # # Request smaller persistent volumes.
+  # volumeClaimTemplate:
+  #   accessModes: [ "ReadWriteOnce" ]
+  #   storageClassName: "standard"
+  #   resources:
+  #     requests:
+  #       storage: 100M
 
 # Official neo4j chart uses the Neo4j Enterprise Edition which requires a license
 neo4j:


### PR DESCRIPTION
By default, it should start up elasticsearch with default settings defined in the elasticsearch helm charts. These minikube specific settings should only be set when testing on minikube. (The resource values were intentionally set to a low number since minikube is running on a local machine)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
