### PR TITLE
fix(k8s): Fix permissions issue for SSL certificate directory

### DIFF
--- a/datahub-kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-gms/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
           secret:
-            defaultMode: 256
+            defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
         {{- if .Values.exporters.jmx.enabled }}

--- a/datahub-kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-mae-consumer/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
           secret:
-            defaultMode: 256
+            defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
         {{- if .Values.exporters.jmx.enabled }}

--- a/datahub-kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-mce-consumer/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- if .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
           secret:
-            defaultMode: 256
+            defaultMode: 0444
             secretName: {{ .Values.global.credentialsAndCertsSecrets.name }}
         {{- end }}
         {{- if .Values.exporters.jmx.enabled }}

--- a/datahub-kubernetes/datahub/templates/kafka-setup-job.yml
+++ b/datahub-kubernetes/datahub/templates/kafka-setup-job.yml
@@ -32,7 +32,7 @@ spec:
         {{- with .Values.global.credentialsAndCertsSecrets }}
         - name: datahub-certs-dir
           secret:
-            defaultMode: 256
+            defaultMode: 0444
             secretName: {{ .name }}
         {{- end }}
       {{- with .Values.kafkaSetupJob.extraVolumes }}


### PR DESCRIPTION
Give read permission to the SSL certs directory to all users. This fixes the permissions issue when reading certs from the kubernetes pods. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
