### PR TITLE
fix(ProductAnalytics): Add support for AWS Elasticsearch

### DIFF
--- a/gms/impl/src/main/resources/index/usage-event/aws_es_index_template.json
+++ b/gms/impl/src/main/resources/index/usage-event/aws_es_index_template.json
@@ -1,0 +1,25 @@
+{
+  "index_patterns": ["datahub_usage_event-*"],
+  "mappings": {
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "timestamp": {
+        "type": "date"
+      },
+      "userAgent": {
+        "type": "keyword"
+      },
+      "browserId": {
+        "type": "keyword"
+      }
+    }
+  },
+  "settings": {
+    "index.opendistro.index_state_management.rollover_alias": "datahub_usage_event"
+  }
+}

--- a/gms/impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
+++ b/gms/impl/src/main/resources/index/usage-event/aws_es_ism_policy.json
@@ -1,0 +1,58 @@
+{
+  "policy": {
+    "policy_id": "datahub_usage_event_policy",
+    "default_state": "Rollover",
+    "schema_version": 1,
+    "states": [
+      {
+        "name": "Rollover",
+        "actions": [
+          {
+            "rollover": {
+              "min_index_age": "1d"
+            }
+          }
+        ],
+        "transitions": [
+          {
+            "state_name": "ReadOnly",
+            "conditions": {
+              "min_index_age": "7d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "ReadOnly",
+        "actions": [
+          {
+            "read_only": {}
+          }
+        ],
+        "transitions": [
+          {
+            "state_name": "Delete",
+            "conditions": {
+              "min_index_age": "60d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Delete",
+        "actions": [
+          {
+            "delete": {}
+          }
+        ],
+        "transitions": []
+      }
+    ],
+    "ism_template": {
+      "index_patterns": [
+        "datahub_usage_event-*"
+      ],
+      "priority": 100
+    }
+  }
+}

--- a/gms/impl/src/main/resources/index/usage-event/policy.json
+++ b/gms/impl/src/main/resources/index/usage-event/policy.json
@@ -9,7 +9,7 @@
         }
       },
       "delete": {
-        "min_age": "90d",
+        "min_age": "60d",
         "actions": {
           "delete": {}
         }


### PR DESCRIPTION
AWS Elasticsearch uses OpenDistro version of elasticsearch which does not support index lifecycle policies and data streams. Add separate policies and templates for AWS elasticsearch. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
