### PR TITLE
fix(React): Disable analytics link display

### DIFF
--- a/datahub-frontend/app/react/controllers/GraphQLController.java
+++ b/datahub-frontend/app/react/controllers/GraphQLController.java
@@ -52,8 +52,8 @@ public class GraphQLController extends Controller {
         /*
          * Initialize GraphQL Engine
          */
-        _engine = buildExtendedEngine(environment, analyticsService);
         _config = config;
+        _engine = buildExtendedEngine(environment, analyticsService);
     }
 
     @Security.Authenticated(Authenticator.class)

--- a/datahub-frontend/app/react/controllers/GraphQLController.java
+++ b/datahub-frontend/app/react/controllers/GraphQLController.java
@@ -26,6 +26,7 @@ import play.mvc.Security;
 import react.resolver.AnalyticsChartTypeResolver;
 import react.resolver.GetChartsResolver;
 import react.resolver.GetHighlightsResolver;
+import react.resolver.IsAnalyticsEnabledResolver;
 
 public class GraphQLController extends Controller {
 
@@ -33,6 +34,8 @@ public class GraphQLController extends Controller {
 
     private static final String QUERY_TYPE = "Query";
     private static final String ANALYTICS_CHART_TYPE = "AnalyticsChart";
+
+    private static final String IS_ANALYTICS_ENABLED_QUERY = "isAnalyticsEnabled";
     private static final String GET_ANALYTICS_CHARTS_QUERY = "getAnalyticsCharts";
     private static final String GET_HIGHLIGHTS_QUERY = "getHighlights";
 
@@ -49,9 +52,7 @@ public class GraphQLController extends Controller {
         /*
          * Initialize GraphQL Engine
          */
-        _engine = isAnalyticsEnabled(config)
-                ? buildExtendedEngine(environment, analyticsService)
-                : GmsGraphQLEngine.get();
+        _engine = buildExtendedEngine(environment, analyticsService);
         _config = config;
     }
 
@@ -114,6 +115,7 @@ public class GraphQLController extends Controller {
                 .addSchema(schemaString)
                 .configureRuntimeWiring(builder -> builder
                         .type(QUERY_TYPE, typeWiring -> typeWiring
+                                .dataFetcher(IS_ANALYTICS_ENABLED_QUERY, new IsAnalyticsEnabledResolver(isAnalyticsEnabled(_config)))
                                 .dataFetcher(GET_ANALYTICS_CHARTS_QUERY, new GetChartsResolver(analyticsService))
                                 .dataFetcher(GET_HIGHLIGHTS_QUERY, new GetHighlightsResolver(analyticsService)))
                         .type(ANALYTICS_CHART_TYPE, typeWiring -> typeWiring

--- a/datahub-frontend/app/react/resolver/IsAnalyticsEnabledResolver.java
+++ b/datahub-frontend/app/react/resolver/IsAnalyticsEnabledResolver.java
@@ -1,0 +1,21 @@
+package react.resolver;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * Returns true if analytics feature flag is enabled, false otherwise.
+ */
+public class IsAnalyticsEnabledResolver implements DataFetcher<Boolean> {
+
+        private final Boolean _isAnalyticsEnabled;
+
+        public IsAnalyticsEnabledResolver(final Boolean isAnalyticsEnabled) {
+            _isAnalyticsEnabled = isAnalyticsEnabled;
+        }
+
+        @Override
+        public final Boolean get(DataFetchingEnvironment environment) throws Exception {
+            return _isAnalyticsEnabled;
+        }
+}

--- a/datahub-frontend/conf/datahub-frontend.graphql
+++ b/datahub-frontend/conf/datahub-frontend.graphql
@@ -1,4 +1,5 @@
 extend type Query {
+    isAnalyticsEnabled: Boolean!
     getAnalyticsCharts: [AnalyticsChartGroup!]!
     getHighlights: [Highlight!]!
 }

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -8,6 +8,7 @@ import { useGetAuthenticatedUser } from '../useGetAuthenticatedUser';
 import { useEntityRegistry } from '../useEntityRegistry';
 import { navigateToSearchUrl } from '../search/utils/navigateToSearchUrl';
 import { GetSearchResultsQuery, useGetAutoCompleteResultsLazyQuery } from '../../graphql/search.generated';
+import { useIsAnalyticsEnabledQuery } from '../../graphql/analytics.generated';
 import { useGetAllEntitySearchResults } from '../../utils/customGraphQL/useGetAllEntitySearchResults';
 import { EntityType } from '../../types.generated';
 import analytics, { EventType } from '../analytics';
@@ -110,6 +111,9 @@ export const HomePageHeader = () => {
     const [getAutoCompleteResults, { data: suggestionsData }] = useGetAutoCompleteResultsLazyQuery();
     const themeConfig = useTheme();
 
+    const { data } = useIsAnalyticsEnabledQuery();
+    const isAnalyticsEnabled = data && data.isAnalyticsEnabled;
+
     const onSearch = (query: string) => {
         analytics.event({
             type: EventType.SearchEvent,
@@ -175,7 +179,7 @@ export const HomePageHeader = () => {
                     )}
                 </WelcomeText>
                 <NavGroup>
-                    <AnalyticsLink />
+                    {isAnalyticsEnabled && <AnalyticsLink />}
                     <ManageAccount
                         urn={user?.urn || ''}
                         pictureLink={user?.editableInfo?.pictureLink || ''}

--- a/datahub-web-react/src/graphql/analytics.graphql
+++ b/datahub-web-react/src/graphql/analytics.graphql
@@ -1,3 +1,7 @@
+query isAnalyticsEnabled {
+    isAnalyticsEnabled
+}
+
 query getAnalyticsCharts {
     getAnalyticsCharts {
         title


### PR DESCRIPTION
**Scope**
These changes affect the React app and GraphQL server in datahub-frontend.

**Changes**
This change disables the "Analytics[Beta]" link from appearing on the HomePage of DataHub when analytics feature flag has been disabled. 

Validated locally!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
