### PR TITLE
Fix(Analytics): use seperate env variable for tracking topic in MAE-Consumer

### DIFF
--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -13,6 +13,12 @@ NEO4J_URI=bolt://neo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=datahub
 
+# Uncomment to configure kafka topic names
+# Make sure these names are consistent across the whole deployment
+# METADATA_AUDIT_EVENT_NAME=MetadataAuditEvent_v4
+# METADATA_CHANGE_EVENT_NAME=MetadataChangeEvent_v4
+# FAILED_METADATA_CHANGE_EVENT_NAME=FailedMetadataChangeEvent_v4
+
 # Uncomment and set these to support SSL connection to Elasticsearch
 # ELASTICSEARCH_USE_SSL=true
 # ELASTICSEARCH_SSL_PROTOCOL=TLSv1.2

--- a/docker/datahub-mae-consumer/env/docker.env
+++ b/docker/datahub-mae-consumer/env/docker.env
@@ -12,6 +12,11 @@ GMS_PORT=8080
 # Uncomment to disable persistence of client-side analytics events
 # DATAHUB_ANALYTICS_ENABLED=false
 
+# Uncomment to configure topic names
+# Make sure these names are consistent across the whole deployment
+# KAFKA_TOPIC_NAME=MetadataAuditEvent_v4
+# DATAHUB_USAGE_EVENT_NAME=DataHubUsageEvent_v1
+
 # Uncomment and set these to support SSL connection to Elasticsearch
 # ELASTICSEARCH_USE_SSL=
 # ELASTICSEARCH_SSL_PROTOCOL=

--- a/docker/datahub-mce-consumer/env/docker.env
+++ b/docker/datahub-mce-consumer/env/docker.env
@@ -3,6 +3,11 @@ KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
 GMS_HOST=datahub-gms
 GMS_PORT=8080
 
+# Uncomment to configure kafka topic names
+# Make sure these names are consistent across the whole deployment
+# KAFKA_MCE_TOPIC_NAME=MetadataChangeEvent_v4
+# KAFKA_FMCE_TOPIC_NAME=FailedMetadataChangeEvent_v4
+
 # Uncomment and set these to support SSL connection to GMS
 # NOTE: Currently GMS itself does not offer SSL support, these settings are intended for when there is a proxy in front
 #       of GMS that handles SSL, such as an EC2 Load Balancer.

--- a/docker/kafka-setup/env/docker.env
+++ b/docker/kafka-setup/env/docker.env
@@ -2,9 +2,11 @@ KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
 KAFKA_BOOTSTRAP_SERVER=broker:29092
 
 # Configure the topics that are created by kafka-setup
+# Make sure these names are consistent across the whole deployment
 # METADATA_AUDIT_EVENT_NAME=MetadataAuditEvent_v4
 # METADATA_CHANGE_EVENT_NAME=MetadataChangeEvent_v4
 # FAILED_METADATA_CHANGE_EVENT_NAME=FailedMetadataChangeEvent_v4
+# DATAHUB_USAGE_EVENT_NAME=DataHubUsageEvent_v1
 # PARTITIONS=1
 # REPLICATION_FACTOR=1
 

--- a/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/DataHubUsageEventsProcessor.java
+++ b/metadata-jobs/mae-consumer-job/src/main/java/com/linkedin/metadata/kafka/DataHubUsageEventsProcessor.java
@@ -35,7 +35,7 @@ public class DataHubUsageEventsProcessor {
   }
 
   @KafkaListener(id = "${KAFKA_CONSUMER_GROUP_ID:datahub-usage-event-consumer-job-client}", topics =
-      "${KAFKA_TOPIC_NAME:" + Topics.DATAHUB_USAGE_EVENT + "}", containerFactory = "stringSerializedKafkaListener")
+      "${DATAHUB_USAGE_EVENT_NAME:" + Topics.DATAHUB_USAGE_EVENT + "}", containerFactory = "stringSerializedKafkaListener")
   public void consume(final ConsumerRecord<String, String> consumerRecord) {
     final String record = consumerRecord.value();
     log.debug("Got DHUE");


### PR DESCRIPTION
Both Kafka Listeners from DataHubUsageEventProcessor and MetadataAuditEventProcessor used the same environment variable for the topic name. This results in both listening on the same topic if this env variable is set.

Additionally, I documented the env variables for topic names in the docker.env files similar to all the SSL-Options to make them more accessible. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
