### PR TITLE
ci(docker): disable GitHub Docker registry

### DIFF
--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -56,7 +56,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-elasticsearch-setup
-            docker.pkg.github.com/linkedin/datahub/datahub-elasticsearch-setup
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -65,12 +64,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -42,7 +42,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -57,7 +57,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-frontend-react
-            docker.pkg.github.com/linkedin/datahub/datahub-frontend-react
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -66,12 +65,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -57,7 +57,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-gms
-            docker.pkg.github.com/linkedin/datahub/datahub-gms
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -66,12 +65,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup

--- a/.github/workflows/docker-ingestion.yml
+++ b/.github/workflows/docker-ingestion.yml
@@ -57,7 +57,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-ingestion
-            docker.pkg.github.com/linkedin/datahub/datahub-ingestion
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -66,12 +65,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-ingestion.yml
+++ b/.github/workflows/docker-ingestion.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup

--- a/.github/workflows/docker-kafka-setup.yml
+++ b/.github/workflows/docker-kafka-setup.yml
@@ -54,7 +54,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-kafka-setup
-            docker.pkg.github.com/linkedin/datahub/datahub-kafka-setup
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -63,12 +62,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-kafka-setup.yml
+++ b/.github/workflows/docker-kafka-setup.yml
@@ -40,7 +40,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -57,7 +57,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-mae-consumer
-            docker.pkg.github.com/linkedin/datahub/datahub-mae-consumer
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -66,12 +65,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -57,7 +57,6 @@ jobs:
           # list of Docker images to use as base name for tags
           images: |
             linkedin/datahub-mce-consumer
-            docker.pkg.github.com/linkedin/datahub/datahub-mce-consumer
           # add git short SHA as Docker tag
           tag-custom: ${{ needs.setup.outputs.tag }}
           tag-custom-only: true
@@ -66,12 +65,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Login to GitHub
-        uses: docker/login-action@v1
-        with:
-          registry: docker.pkg.github.com
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Enable publish: ${{ env.ENABLE_PUBLISH != '' }}"
           echo "::set-output name=publish::${{ env.ENABLE_PUBLISH != '' }}"
   push_to_registries:
-    name: Build and Push Docker Image to dockerhub and github registries
+    name: Build and Push Docker Image to Docker Hub
     runs-on: ubuntu-latest
     if: ${{ needs.setup.outputs.publish == 'true' }}
     needs: setup


### PR DESCRIPTION
The GitHub Docker registry (docker.pkg.github.com) is [deprecated](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry) and
will be removed. We're already starting to see build flakiness due to
the instability of the image push operations, so this PR disables it
entirely.

Given that almost all DataHub users rely on the Docker Hub images and
[almost nobody](https://github.com/orgs/linkedin/packages?repo_name=datahub) uses the GitHub Docker registry images, we should be clear
to simply disable them. As such, I'm not migrating to the newer GitHub
Container registry (ghcr.io) right now. Additionally, I suggest that we
also remove the images currently present on GitHub, or the `latest` tags
on those images at a minimum.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
