### PR TITLE
feat(business glossary): hiding business glossary until all features completed

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
@@ -29,9 +29,9 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
         );
     };
 
-    isSearchEnabled = () => true;
+    isSearchEnabled = () => false;
 
-    isBrowseEnabled = () => true;
+    isBrowseEnabled = () => false;
 
     getAutoCompleteFieldName = () => 'name';
 


### PR DESCRIPTION
Let's hide the business glossary from the homepage and search until we are ready to show it to the community. For now, folks working on the feature can revert these changes for local development

fyi @saxo-lalrishav @shubham49 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
