### PR TITLE
Add Sphinx Docstrings to Airflow Modules 

### DIFF
--- a/metadata-ingestion/src/datahub_provider/hooks/datahub.py
+++ b/metadata-ingestion/src/datahub_provider/hooks/datahub.py
@@ -22,6 +22,19 @@ if AIRFLOW_1:
 
 
 class DatahubRestHook(BaseHook):
+    """
+    Creates a DataHub Rest API connection used to send metadata to DataHub. 
+    Takes the endpoint for your DataHub Rest API in the Server Endpoint(host) field.
+
+    URI example: ::
+
+        AIRFLOW_CONN_DATAHUB_REST_DEFAULT='datahub-rest://rest-endpoint'
+
+    :param datahub_rest_conn_id: Reference to the DataHub Rest connection. 
+    :type datahub_rest_conn_id: str
+    """
+
+
     conn_name_attr = "datahub_rest_conn_id"
     default_conn_name = "datahub_rest_default"
     conn_type = "datahub_rest"
@@ -63,6 +76,19 @@ class DatahubRestHook(BaseHook):
 
 
 class DatahubKafkaHook(BaseHook):
+    """
+    Creates a DataHub Kafka connection used to send metadata to DataHub. 
+    Takes your kafka broker in the Kafka Broker(host) field.
+
+    URI example: ::
+
+        AIRFLOW_CONN_DATAHUB_KAFKA_DEFAULT='datahub-kafka://kafka-broker'
+
+    :param datahub_kafka_conn_id: Reference to the DataHub Kafka connection. 
+    :type datahub_kafka_conn_id: str
+    """
+
+
     conn_name_attr = "datahub_kafka_conn_id"
     default_conn_name = "datahub_kafka_default"
     conn_type = "datahub_kafka"
@@ -121,6 +147,15 @@ class DatahubKafkaHook(BaseHook):
 
 
 class DatahubGenericHook(BaseHook):
+    """
+    Emits Metadata Change Events using either the DatahubRestHook or the 
+    DatahubKafkaHook. Set up a DataHub Rest or Kafka connection to use.
+
+    :param datahub_conn_id: Reference to the DataHub connection. 
+    :type datahub_conn_id: str
+    """
+
+
     def __init__(self, datahub_conn_id: str) -> None:
         super().__init__(*_default_hook_args)
         self.datahub_conn_id = datahub_conn_id

--- a/metadata-ingestion/src/datahub_provider/hooks/datahub.py
+++ b/metadata-ingestion/src/datahub_provider/hooks/datahub.py
@@ -23,17 +23,16 @@ if AIRFLOW_1:
 
 class DatahubRestHook(BaseHook):
     """
-    Creates a DataHub Rest API connection used to send metadata to DataHub. 
+    Creates a DataHub Rest API connection used to send metadata to DataHub.
     Takes the endpoint for your DataHub Rest API in the Server Endpoint(host) field.
 
     URI example: ::
 
         AIRFLOW_CONN_DATAHUB_REST_DEFAULT='datahub-rest://rest-endpoint'
 
-    :param datahub_rest_conn_id: Reference to the DataHub Rest connection. 
+    :param datahub_rest_conn_id: Reference to the DataHub Rest connection.
     :type datahub_rest_conn_id: str
     """
-
 
     conn_name_attr = "datahub_rest_conn_id"
     default_conn_name = "datahub_rest_default"
@@ -77,17 +76,16 @@ class DatahubRestHook(BaseHook):
 
 class DatahubKafkaHook(BaseHook):
     """
-    Creates a DataHub Kafka connection used to send metadata to DataHub. 
+    Creates a DataHub Kafka connection used to send metadata to DataHub.
     Takes your kafka broker in the Kafka Broker(host) field.
 
     URI example: ::
 
         AIRFLOW_CONN_DATAHUB_KAFKA_DEFAULT='datahub-kafka://kafka-broker'
 
-    :param datahub_kafka_conn_id: Reference to the DataHub Kafka connection. 
+    :param datahub_kafka_conn_id: Reference to the DataHub Kafka connection.
     :type datahub_kafka_conn_id: str
     """
-
 
     conn_name_attr = "datahub_kafka_conn_id"
     default_conn_name = "datahub_kafka_default"
@@ -148,13 +146,12 @@ class DatahubKafkaHook(BaseHook):
 
 class DatahubGenericHook(BaseHook):
     """
-    Emits Metadata Change Events using either the DatahubRestHook or the 
+    Emits Metadata Change Events using either the DatahubRestHook or the
     DatahubKafkaHook. Set up a DataHub Rest or Kafka connection to use.
 
-    :param datahub_conn_id: Reference to the DataHub connection. 
+    :param datahub_conn_id: Reference to the DataHub connection.
     :type datahub_conn_id: str
     """
-
 
     def __init__(self, datahub_conn_id: str) -> None:
         super().__init__(*_default_hook_args)

--- a/metadata-ingestion/src/datahub_provider/lineage/datahub.py
+++ b/metadata-ingestion/src/datahub_provider/lineage/datahub.py
@@ -36,6 +36,26 @@ def get_lineage_config() -> DatahubLineageConfig:
 
 
 class DatahubLineageBackend(LineageBackend):
+    """
+    Sends lineage data from tasks to DataHub.
+
+    Configurable via ``airflow.cfg`` as follows: ::
+
+        # For REST-based:
+        airflow connections add  --conn-type 'datahub_rest' 'datahub_rest_default' --conn-host 'http://localhost:8080'
+        # For Kafka-based (standard Kafka sink config can be passed via extras):
+        airflow connections add  --conn-type 'datahub_kafka' 'datahub_kafka_default' --conn-host 'broker:9092' --conn-extra '{}'
+        
+        [lineage]
+        backend = datahub_provider.lineage.datahub.DatahubLineageBackend
+        datahub_kwargs = {
+            "datahub_conn_id": "datahub_rest_default",
+            "capture_ownership_info": true,
+            "capture_tags_info": true,
+            "graceful_exceptions": true }
+        # The above indentation is important!
+    """
+
     def __init__(self) -> None:
         super().__init__()
 

--- a/metadata-ingestion/src/datahub_provider/lineage/datahub.py
+++ b/metadata-ingestion/src/datahub_provider/lineage/datahub.py
@@ -45,7 +45,7 @@ class DatahubLineageBackend(LineageBackend):
         airflow connections add  --conn-type 'datahub_rest' 'datahub_rest_default' --conn-host 'http://localhost:8080'
         # For Kafka-based (standard Kafka sink config can be passed via extras):
         airflow connections add  --conn-type 'datahub_kafka' 'datahub_kafka_default' --conn-host 'broker:9092' --conn-extra '{}'
-        
+
         [lineage]
         backend = datahub_provider.lineage.datahub.DatahubLineageBackend
         datahub_kwargs = {

--- a/metadata-ingestion/src/datahub_provider/operators/datahub.py
+++ b/metadata-ingestion/src/datahub_provider/operators/datahub.py
@@ -15,6 +15,7 @@ class DatahubBaseOperator(BaseOperator):
     """
     The DatahubBaseOperator is used as a base operator all DataHub operators.
     """
+
     ui_color = "#4398c8"
 
     hook: Union[DatahubRestHook, DatahubKafkaHook]
@@ -37,12 +38,13 @@ class DatahubBaseOperator(BaseOperator):
 
 class DatahubEmitterOperator(DatahubBaseOperator):
     """
-    Emits a Metadata Change Event to DataHub using either a DataHub 
+    Emits a Metadata Change Event to DataHub using either a DataHub
     Rest or Kafka connection.
 
     :param datahub_conn_id: Reference to the DataHub Rest or Kafka Connection.
     :type datahub_conn_id: str
     """
+
     # See above for why these mypy type issues are ignored here.
     @apply_defaults  # type: ignore[misc]
     def __init__(  # type: ignore[no-untyped-def]

--- a/metadata-ingestion/src/datahub_provider/operators/datahub.py
+++ b/metadata-ingestion/src/datahub_provider/operators/datahub.py
@@ -12,6 +12,9 @@ from datahub_provider.hooks.datahub import (
 
 
 class DatahubBaseOperator(BaseOperator):
+    """
+    The DatahubBaseOperator is used as a base operator all DataHub operators.
+    """
     ui_color = "#4398c8"
 
     hook: Union[DatahubRestHook, DatahubKafkaHook]
@@ -33,6 +36,13 @@ class DatahubBaseOperator(BaseOperator):
 
 
 class DatahubEmitterOperator(DatahubBaseOperator):
+    """
+    Emits a Metadata Change Event to DataHub using either a DataHub 
+    Rest or Kafka connection.
+
+    :param datahub_conn_id: Reference to the DataHub Rest or Kafka Connection.
+    :type datahub_conn_id: str
+    """
     # See above for why these mypy type issues are ignored here.
     @apply_defaults  # type: ignore[misc]
     def __init__(  # type: ignore[no-untyped-def]


### PR DESCRIPTION
This PR adds Sphinx templated docstrings to the Airflow modules in the datahub_provider package. Sphinx docstrings are the usual way Airflow modules are documented and these docstrings will be rendered by the Astronomer Registry. Suggestions welcome!
