### PR TITLE
feat(ingest): :lock: - Add AWS IAM Roles Support to the Glue Source

### DIFF
--- a/metadata-ingestion/README.md
+++ b/metadata-ingestion/README.md
@@ -428,6 +428,7 @@ source:
     # See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html
     aws_secret_access_key # Optional.
     aws_session_token # Optional.
+    aws_role # Optional (Role chaining supported by using a sorted list).
 ```
 
 ### Druid `druid`

--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -97,7 +97,7 @@ class GlueSourceConfig(ConfigModel):
                         role_arn, self.aws_region, new_credentials
                     ),
                     self.aws_role,
-                    None,
+                    {},
                 )
             return boto3.client(
                 "glue",


### PR DESCRIPTION
This PR aims to add IAM Roles support to the existing Glue Source. This could allow importing the Glue Metadata cross AWS accounts by chaining roles or by allowing the current instance to assume an external role.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
