### PR TITLE
test(ingest): use different mysql test port

### DIFF
--- a/metadata-ingestion/tests/integration/mysql/docker-compose.yml
+++ b/metadata-ingestion/tests/integration/mysql/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: example
     ports:
-      - 53306:3306
+      - 53307:3306
     volumes:
       - ./setup:/setup
       - ./setup/setup.sql:/docker-entrypoint-initdb.d/setup.sql

--- a/metadata-ingestion/tests/integration/mysql/mysql_to_file.yml
+++ b/metadata-ingestion/tests/integration/mysql/mysql_to_file.yml
@@ -6,7 +6,7 @@ source:
     username: root
     password: example
     database: metagalaxy
-    host_port: localhost:53306
+    host_port: localhost:53307
     schema_pattern:
       allow:
         - "^metagalaxy"


### PR DESCRIPTION
Somehow the 53306 port is often in use on the CI machines and causes
conflicts. This changes to a slightly different port number.

For example, from https://github.com/linkedin/datahub/runs/2604009138:
```
E           ERROR: for testmysql  Cannot start service testmysql: driver failed programming external connectivity on endpoint testmysql (c764a27faba8d8643e59c223bfe06200665704ac4572e254140387e6aa382080): Error starting userland proxy: listen tcp4 0.0.0.0:53306: bind: address already in use
E           Encountered errors while bringing up the project.
E           """.
```

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
