### PR TITLE
feat(react): Add label to edited dataset descriptions

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/SchemaDescriptionField.tsx
@@ -36,6 +36,12 @@ const EditIcon = styled(EditOutlined)`
     margin-top: 4px;
 `;
 
+const EditedMessage = styled(Typography.Text)`
+    padding-left: 8px;
+    color: rgb(150, 150, 150);
+    font-style: italic;
+`;
+
 const MessageKey = 'UpdateSchemaDescription';
 
 type Props = {
@@ -104,6 +110,7 @@ export default function DescriptionField({ description, updatedDescription, onHo
                     </Form>
                 </Modal>
             )}
+            {updatedDescription && <EditedMessage>(edited)</EditedMessage>}
         </DescriptionContainer>
     );
 }

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/SchemaDescriptionField.tsx
@@ -36,7 +36,7 @@ const EditIcon = styled(EditOutlined)`
     margin-top: 4px;
 `;
 
-const EditedMessage = styled(Typography.Text)`
+const EditedLabel = styled(Typography.Text)`
     padding-left: 8px;
     color: rgb(150, 150, 150);
     font-style: italic;
@@ -110,7 +110,7 @@ export default function DescriptionField({ description, updatedDescription, onHo
                     </Form>
                 </Modal>
             )}
-            {updatedDescription && <EditedMessage>(edited)</EditedMessage>}
+            {updatedDescription && <EditedLabel>(edited)</EditedLabel>}
         </DescriptionContainer>
     );
 }


### PR DESCRIPTION
If there is an edited description, the UI will display a "(edited)" label
As brought up in #2506 
![image](https://user-images.githubusercontent.com/52515015/118749588-6ef75080-b823-11eb-8d4c-5516df2f539b.png)
![image](https://user-images.githubusercontent.com/52515015/118749645-94845a00-b823-11eb-9722-b84c3036db46.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
