### PR TITLE
fix(ingest): Misuseage of the Allow Pattern

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -393,7 +393,7 @@ class LookerDashboardSource(Source):
         )
         for element in elements:
             self.reporter.report_charts_scanned()
-            if element.id is not None and self.source_config.chart_pattern.allowed(
+            if element.id is not None and not self.source_config.chart_pattern.allowed(
                 element.id
             ):
                 self.reporter.report_charts_dropped(element.id)


### PR DESCRIPTION
I'm not sure, but it seems the chart pattern was not well defined since it forced me to define it in the inverted way:

```
    chart_pattern:
        allow: []
        deny: [".*"]
```

@frsann  could you validate it too?

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
