### PR TITLE
fix(tags): fixing tag autocomplete caching

### DIFF
--- a/datahub-web-react/src/app/shared/tags/AddTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagModal.tsx
@@ -25,7 +25,9 @@ const TagSelect = styled(Select)`
 const CREATE_TAG_VALUE = '____reserved____.createTagValue';
 
 export default function AddTagModal({ updateTags, globalTags, visible, onClose }: AddTagModalProps) {
-    const [getAutoCompleteResults, { loading, data: suggestionsData }] = useGetAutoCompleteResultsLazyQuery();
+    const [getAutoCompleteResults, { loading, data: suggestionsData }] = useGetAutoCompleteResultsLazyQuery({
+        fetchPolicy: 'no-cache',
+    });
     const [inputValue, setInputValue] = useState('');
     const [selectedTagValue, setSelectedTagValue] = useState('');
     const [showCreateModal, setShowCreateModal] = useState(false);


### PR DESCRIPTION
Tag autocomplete used to cache on the client. This was problematic, since actions taken by the client could create new tags, in which case the cache would be invalid. Here I remove the caching so we always get most up to date autocomplete.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
