### PR TITLE
feat(react): add optional subtitle to home page

### DIFF
--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -44,6 +44,7 @@ const styles = {
     searchContainer: { width: '100%', marginTop: '40px' },
     logoImage: { width: 140 },
     searchBox: { width: 540, margin: '40px 0px' },
+    subtitle: { marginTop: '28px', color: '#FFFFFF', fontSize: 12 },
     subHeaderLabel: { marginTop: '-16px', color: '#FFFFFF', fontSize: 12 },
 };
 
@@ -193,10 +194,7 @@ export const HomePageHeader = () => {
             <HeaderContainer>
                 <Image src={themeConfig.assets.logoUrl} preview={false} style={styles.logoImage} />
                 {themeConfig.content.subtitle && (
-                    <>
-                        <br />
-                        <Typography.Text style={styles.subHeaderLabel}>{themeConfig.content.subtitle}</Typography.Text>
-                    </>
+                    <Typography.Text style={styles.subtitle}>{themeConfig.content.subtitle}</Typography.Text>
                 )}
                 <AutoComplete
                     style={styles.searchBox}

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -192,6 +192,12 @@ export const HomePageHeader = () => {
             </Row>
             <HeaderContainer>
                 <Image src={themeConfig.assets.logoUrl} preview={false} style={styles.logoImage} />
+                {themeConfig.content.subtitle && (
+                    <>
+                        <br />
+                        <Typography.Text style={styles.subHeaderLabel}>{themeConfig.content.subtitle}</Typography.Text>
+                    </>
+                )}
                 <AutoComplete
                     style={styles.searchBox}
                     options={suggestionsData?.autoComplete?.suggestions.map((result: string) => ({

--- a/datahub-web-react/src/conf/theme/types.ts
+++ b/datahub-web-react/src/conf/theme/types.ts
@@ -24,6 +24,7 @@ export type Theme = {
     };
     content: {
         title: string;
+        subtitle?: string;
         homepage: {
             homepageMessage: string;
         };


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [n/a] Links to related issues (if applicable)
- [n/a] Tests for the changes have been added/updated (if applicable)
- [n/a] Docs related to the changes have been added/updated (if applicable)

If subtitle is provided in the theme config file, looks like this:
<img width="1440" alt="Screen Shot 2021-05-21 at 9 29 48 AM" src="https://user-images.githubusercontent.com/16002775/119145094-4df75100-ba17-11eb-9190-9a075362f418.png">

Otherwise it looks unchanged.
