### PR TITLE
Fix 2592 neo4j connection options

### DIFF
--- a/gms/factories/src/main/java/com/linkedin/gms/factory/common/Neo4jDriverFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/gms/factory/common/Neo4jDriverFactory.java
@@ -33,6 +33,9 @@ public class Neo4jDriverFactory {
   @Value("${NEO4J_MAX_TRANSACTION_RETRY_TIME_IN_SECONDS:30}")
   private Long neo4jMaxTransactionRetryTime;
 
+  @Value("${NEO4J_CONNECTION_LIVENESS_CHECK_TIMEOUT_IN_SECONDS:-1}")
+  private Long neo4jConnectionLivenessCheckTimeout;
+
   @Bean(name = "neo4jDriver")
   protected Driver createInstance() {
     Config.ConfigBuilder builder = Config.builder();
@@ -40,6 +43,7 @@ public class Neo4jDriverFactory {
     builder.withConnectionAcquisitionTimeout(neo4jMaxConnectionAcquisitionTimeout, TimeUnit.SECONDS);
     builder.withMaxConnectionLifetime(neo4jMaxConnectionLifetime, TimeUnit.HOURS);
     builder.withMaxTransactionRetryTime(neo4jMaxTransactionRetryTime, TimeUnit.SECONDS);
+    builder.withConnectionLivenessCheckTimeout(neo4jConnectionLivenessCheckTimeout, TimeUnit.SECONDS);
 
     return GraphDatabase.driver(uri, AuthTokens.basic(username, password), builder.build());
   }

--- a/gms/factories/src/main/java/com/linkedin/gms/factory/common/Neo4jDriverFactory.java
+++ b/gms/factories/src/main/java/com/linkedin/gms/factory/common/Neo4jDriverFactory.java
@@ -27,8 +27,12 @@ public class Neo4jDriverFactory {
   @Value("${NEO4J_MAX_CONNECTION_ACQUISITION_TIMEOUT_IN_SECONDS:60}")
   private Long neo4jMaxConnectionAcquisitionTimeout;
 
-  @Value("${NEO4j_MAX_CONNECTION_LIFETIME_IN_HOURS:1}")
-  private Long neo4jMaxConnectionLifetime;
+  // Kept for sake of backwards compatibility. Instead use NEO4j_MAX_CONNECTION_LIFETIME_IN_SECONDS
+  @Value("${NEO4j_MAX_CONNECTION_LIFETIME_IN_HOURS:#{null}}")
+  private Long neo4jMaxConnectionLifetimeInHours;
+
+  @Value("${NEO4j_MAX_CONNECTION_LIFETIME_IN_SECONDS:3600}")
+  private Long neo4jMaxConnectionLifetimeInSeconds;
 
   @Value("${NEO4J_MAX_TRANSACTION_RETRY_TIME_IN_SECONDS:30}")
   private Long neo4jMaxTransactionRetryTime;
@@ -38,13 +42,23 @@ public class Neo4jDriverFactory {
 
   @Bean(name = "neo4jDriver")
   protected Driver createInstance() {
+
     Config.ConfigBuilder builder = Config.builder();
     builder.withMaxConnectionPoolSize(neo4jMaxConnectionPoolSize);
     builder.withConnectionAcquisitionTimeout(neo4jMaxConnectionAcquisitionTimeout, TimeUnit.SECONDS);
-    builder.withMaxConnectionLifetime(neo4jMaxConnectionLifetime, TimeUnit.HOURS);
+    builder.withMaxConnectionLifetime(neo4jMaxConnectionLifetime(), TimeUnit.SECONDS);
     builder.withMaxTransactionRetryTime(neo4jMaxTransactionRetryTime, TimeUnit.SECONDS);
     builder.withConnectionLivenessCheckTimeout(neo4jConnectionLivenessCheckTimeout, TimeUnit.SECONDS);
 
     return GraphDatabase.driver(uri, AuthTokens.basic(username, password), builder.build());
+  }
+
+  private Long neo4jMaxConnectionLifetime() {
+
+    // neo4jMaxConnectionLifetimeInHours has precedence over neo4jMaxConnectionLifetimeInSeconds
+    if (neo4jMaxConnectionLifetimeInHours != null) {
+      return neo4jMaxConnectionLifetimeInHours * 3600;
+    }
+    return neo4jMaxConnectionLifetimeInSeconds;
   }
 }


### PR DESCRIPTION
Makes it possible for a user to fix the issue described in #2592
This change might affect some users since a property got a new name.

I added another Neo4j connection property and changed the name of an existing property. 
I changed the name of `NEO4j_MAX_CONNECTION_LIFETIME_IN_HOURS` since _hours_ isn't granular enough and that _seconds_ are used by all the other connection properties. 

New: **NEO4J_CONNECTION_LIVENESS_CHECK_TIMEOUT_IN_SECONDS**
Changed: 
	old name: **NEO4j_MAX_CONNECTION_LIFETIME_IN_HOURS**
	new name: **NEO4j_MAX_CONNECTION_LIFETIME_IN_SECONDS**

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
