### PR TITLE
fix(ingest): raise errors in more cases in rest sink

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -128,13 +128,17 @@ class DatahubRestEmitter:
 
             response.raise_for_status()
         except HTTPError as e:
-            response.raise_for_status()
-            info = response.json()
+            try:
+                info = response.json()
+            except Exception as parse_exception:
+                response.raise_for_status()
+                raise OperationalError(
+                    "Unable to parse response from ingestion sink", {"message": str(parse_exception)}
+                ) from e
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", info
             ) from e
         except RequestException as e:
-            response.raise_for_status()
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", {"message": str(e)}
             ) from e

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -128,11 +128,13 @@ class DatahubRestEmitter:
 
             response.raise_for_status()
         except HTTPError as e:
+            response.raise_for_status()
             info = response.json()
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", info
             ) from e
         except RequestException as e:
+            response.raise_for_status()
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", {"message": str(e)}
             ) from e

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -133,7 +133,8 @@ class DatahubRestEmitter:
             except Exception as parse_exception:
                 response.raise_for_status()
                 raise OperationalError(
-                    "Unable to parse response from ingestion sink", {"message": str(parse_exception)}
+                    "Unable to parse response from ingestion sink",
+                    {"message": str(parse_exception)},
                 ) from e
             raise OperationalError(
                 "Unable to emit metadata to DataHub GMS", info


### PR DESCRIPTION
Rest sink would occasionally swallow HTTP errors. Now, if they get a 404 say, the rest sink outputs:

```
[2021-06-03 11:27:21,460] ERROR    {datahub.ingestion.run.pipeline:52} - failed to write record with workunit file://./examples/mce_files/bootstrap_mce.json:36 with 404 Client Error: Not Found for url: http://localhost:9002/entities?action=ingest and info {}
```



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
