### PR TITLE
fix(ingest): don't purge codegen on gradle clean

### DIFF
--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -51,7 +51,6 @@ check.dependsOn lint
 check.dependsOn test
 
 clean {
-  delete 'src/datahub/metadata'
   delete venv_name
   delete 'build'
   delete 'dist'

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -25,7 +25,7 @@ task codegen(type: Exec, dependsOn: [environmentSetup, installPackage, ':metadat
 
 task install(dependsOn: [installPackage, codegen])
 
-task installDev(type: Exec, dependsOn: [environmentSetup, codegen]) {
+task installDev(type: Exec, dependsOn: [install]) {
   commandLine "${venv_name}/bin/pip", 'install', '-e', '.[dev]'
 }
 task lint(type: Exec, dependsOn: installDev) {


### PR DESCRIPTION
Since #2503 was merged, we don't want to remove the `metadata-ingestion/src/datahub/metadata` directory when running clean.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
