### PR TITLE
fix(gms): Return empty snapshots when one does not exist

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -18,7 +18,6 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.snapshot.Snapshot;
 import java.net.URISyntaxException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -171,9 +171,9 @@ public abstract class EntityService {
   }
 
   /**
-   * Retrieves multiple entities of <b>the same type</b>.
+   * Retrieves multiple entities.
    *
-   * @param urns set of urns of the same entity type to fetch
+   * @param urns set of urns to fetch
    * @param aspectNames set of aspects to fetch
    * @return a map of {@link Urn} to {@link Entity} object
    */

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -181,11 +181,7 @@ public abstract class EntityService {
     if (urns.isEmpty()) {
       return Collections.emptyMap();
     }
-    final String entityType = getEntityTypeFromUrns(urns);
-    final Set<String> aspectsToFetch = aspectNames.isEmpty()
-        ? getEntityAspectNames(entityType)
-        : aspectNames;
-    return getSnapshotUnions(urns, aspectsToFetch).entrySet().stream()
+    return getSnapshotUnions(urns, aspectNames).entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, entry -> toEntity(entry.getValue())));
   }
 
@@ -346,18 +342,4 @@ public abstract class EntityService {
   }
 
   public abstract void setWritable();
-
-  private String getEntityTypeFromUrns(final Set<Urn> urns) {
-    String entityType = null;
-    for (final Urn urn : urns) {
-      if (entityType == null) {
-        entityType = urnToEntityName(urn);
-      } else {
-        if (!entityType.equals(urnToEntityName(urn))) {
-          throw new IllegalArgumentException("All entities being retrieved must be of the same entity type.");
-        }
-      }
-    }
-    return entityType;
-  }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -53,10 +53,14 @@ public class EbeanEntityService extends EntityService {
   public Map<Urn, List<RecordTemplate>> getLatestAspects(@Nonnull final Set<Urn> urns, @Nonnull final Set<String> aspectNames) {
     // Create DB keys
     final Set<EbeanAspectV2.PrimaryKey> dbKeys = urns.stream()
-        .map(urn -> aspectNames.stream()
-            .map(aspectName -> new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, LATEST_ASPECT_VERSION))
-            .collect(Collectors.toList())
-        )
+        .map(urn -> {
+          final Set<String> aspectsToFetch = aspectNames.isEmpty()
+              ? getEntityAspectNames(urn)
+              : aspectNames;
+          return aspectsToFetch.stream()
+                  .map(aspectName -> new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, LATEST_ASPECT_VERSION))
+                  .collect(Collectors.toList());
+        })
         .flatMap(List::stream)
         .collect(Collectors.toSet());
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -53,31 +53,33 @@ public class EbeanEntityService extends EntityService {
   public Map<Urn, List<RecordTemplate>> getLatestAspects(@Nonnull final Set<Urn> urns, @Nonnull final Set<String> aspectNames) {
     // Create DB keys
     final Set<EbeanAspectV2.PrimaryKey> dbKeys = urns.stream()
-        .map(urn -> {
-          final Set<String> aspectsToFetch = aspectNames.isEmpty()
-              ? getEntityAspectNames(urn)
-              : aspectNames;
-          return aspectsToFetch.stream()
-              .map(aspectName -> new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, LATEST_ASPECT_VERSION))
-              .collect(Collectors.toList());
-        })
+        .map(urn -> aspectNames.stream()
+            .map(aspectName -> new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, LATEST_ASPECT_VERSION))
+            .collect(Collectors.toList())
+        )
         .flatMap(List::stream)
         .collect(Collectors.toSet());
 
     // Fetch from db and populate urn -> aspect map.
     final Map<Urn, List<RecordTemplate>> urnToAspects = new HashMap<>();
+
+    // Each urn should have some result, regardless of whether aspects are found in the DB.
+    for (Urn urn: urns) {
+      urnToAspects.putIfAbsent(urn, new ArrayList<>());
+    }
+
+    // Add "key" aspects for each urn. TODO: Replace this with a materialized key aspect.
+    urnToAspects.keySet().forEach(key -> {
+      final RecordTemplate keyAspect = buildKeyAspect(key);
+      urnToAspects.get(key).add(keyAspect);
+    });
+
     _entityDao.batchGet(dbKeys).forEach((key, aspectEntry) -> {
       final Urn urn = toUrn(key.getUrn());
       final String aspectName = key.getAspect();
       final RecordTemplate aspectRecord = toAspectRecord(urn, aspectName, aspectEntry.getMetadata());
       urnToAspects.putIfAbsent(urn, new ArrayList<>());
       urnToAspects.get(urn).add(aspectRecord);
-    });
-
-    // Add "key" aspects to any non null keys.
-    urnToAspects.keySet().forEach(key -> {
-      final RecordTemplate keyAspect = buildKeyAspect(key);
-      urnToAspects.get(key).add(keyAspect);
     });
 
     return urnToAspects;

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -55,11 +55,11 @@ public class EbeanEntityService extends EntityService {
     final Set<EbeanAspectV2.PrimaryKey> dbKeys = urns.stream()
         .map(urn -> {
           final Set<String> aspectsToFetch = aspectNames.isEmpty()
-              ? getEntityAspectNames(urn)
-              : aspectNames;
+            ? getEntityAspectNames(urn)
+            : aspectNames;
           return aspectsToFetch.stream()
-                  .map(aspectName -> new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, LATEST_ASPECT_VERSION))
-                  .collect(Collectors.toList());
+            .map(aspectName -> new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, LATEST_ASPECT_VERSION))
+            .collect(Collectors.toList());
         })
         .flatMap(List::stream)
         .collect(Collectors.toSet());

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
@@ -70,12 +70,12 @@ public class EbeanEntityServiceTest {
     assertEquals(2, readEntity.getValue().getCorpUserSnapshot().getAspects().size()); // Key + Info aspect.
     assertTrue(DataTemplateUtil.areEqual(
         writeEntity.getValue().getCorpUserSnapshot().getAspects().get(0),
-        readEntity.getValue().getCorpUserSnapshot().getAspects().get(0)));
+        readEntity.getValue().getCorpUserSnapshot().getAspects().get(1)));
     CorpUserKey expectedKey = new CorpUserKey();
     expectedKey.setUsername("test");
     assertTrue(DataTemplateUtil.areEqual(
         expectedKey,
-        readEntity.getValue().getCorpUserSnapshot().getAspects().get(1).getCorpUserKey()
+        readEntity.getValue().getCorpUserSnapshot().getAspects().get(0).getCorpUserKey()
     )); // Key + Info aspect.
 
     verify(_mockProducer, times(1)).produceMetadataAuditEvent(
@@ -108,12 +108,12 @@ public class EbeanEntityServiceTest {
     assertEquals(2, readEntity1.getValue().getCorpUserSnapshot().getAspects().size()); // Key + Info aspect.
     assertTrue(DataTemplateUtil.areEqual(
         writeEntity1.getValue().getCorpUserSnapshot().getAspects().get(0),
-        readEntity1.getValue().getCorpUserSnapshot().getAspects().get(0)));
+        readEntity1.getValue().getCorpUserSnapshot().getAspects().get(1)));
     CorpUserKey expectedKey1 = new CorpUserKey();
     expectedKey1.setUsername("tester1");
     assertTrue(DataTemplateUtil.areEqual(
         expectedKey1,
-        readEntity1.getValue().getCorpUserSnapshot().getAspects().get(1).getCorpUserKey()
+        readEntity1.getValue().getCorpUserSnapshot().getAspects().get(0).getCorpUserKey()
     )); // Key + Info aspect.
 
     // Entity 2
@@ -121,12 +121,12 @@ public class EbeanEntityServiceTest {
     assertEquals(2, readEntity2.getValue().getCorpUserSnapshot().getAspects().size()); // Key + Info aspect.
     assertTrue(DataTemplateUtil.areEqual(
         writeEntity2.getValue().getCorpUserSnapshot().getAspects().get(0),
-        readEntity2.getValue().getCorpUserSnapshot().getAspects().get(0)));
+        readEntity2.getValue().getCorpUserSnapshot().getAspects().get(1)));
     CorpUserKey expectedKey2 = new CorpUserKey();
     expectedKey2.setUsername("tester2");
     assertTrue(DataTemplateUtil.areEqual(
         expectedKey2,
-        readEntity2.getValue().getCorpUserSnapshot().getAspects().get(1).getCorpUserKey()
+        readEntity2.getValue().getCorpUserSnapshot().getAspects().get(0).getCorpUserKey()
     )); // Key + Info aspect.
 
     verify(_mockProducer, times(1)).produceMetadataAuditEvent(


### PR DESCRIPTION
Previously, "shell" entities were returned when GMS could not find aspects for a requested entity (get or batchGet). Matching this behavior in NoCode to maintain active deployment's functionality.

Note that we are considering materialization of all references nodes in the graph in the DB, such that every node has at minimum a single aspect associated with it once it's been created or referenced by another node. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
