### PR TITLE
revert: "fix(docker): pin containers to golden hash for release (#2654)"

### DIFF
--- a/docker/ingestion/ingestion.sh
+++ b/docker/ingestion/ingestion.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export DATAHUB_VERSION=${DATAHUB_VERSION:-9829576}
+export DATAHUB_VERSION=${DATAHUB_VERSION:-head}
 cd $DIR && docker-compose pull && docker-compose -p datahub up

--- a/docker/quickstart-ember.sh
+++ b/docker/quickstart-ember.sh
@@ -2,7 +2,7 @@
 
 # Quickstarts an Ember-serving variant of DataHub by pulling all images from dockerhub and then running the containers locally.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export DATAHUB_VERSION=${DATAHUB_VERSION:-9829576}
+export DATAHUB_VERSION=${DATAHUB_VERSION:-head}
 cd $DIR && docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ember.yml pull && docker-compose -p datahub \
     -f docker-compose.yml \
     -f docker-compose.override.yml \

--- a/docker/quickstart.sh
+++ b/docker/quickstart.sh
@@ -3,6 +3,6 @@
 # Quickstarts DataHub by pulling all images from dockerhub and then running the containers locally. No images are
 # built locally. Note: by default this pulls the latest (head) version; you can change this to a specific version by setting
 # the DATAHUB_VERSION environment variable.
-export DATAHUB_VERSION=${DATAHUB_VERSION:-9829576}
+export DATAHUB_VERSION=${DATAHUB_VERSION:-head}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR && docker-compose pull && docker-compose -p datahub up


### PR DESCRIPTION
This reverts commit a483933eab6d072ba6d2a414e378eee1e80dbdc6 and moves us back to using HEAD in quickstart on the master branch, since the release has now been cut.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
