### PR TITLE
docs(no code): adding documentation to handle backwards incompatibility issues

### DIFF
--- a/docs/modeling/extending-the-metadata-model.md
+++ b/docs/modeling/extending-the-metadata-model.md
@@ -258,7 +258,7 @@ If you're extending an existing Entity, you can skip this step.
 
 If you have updated any existing types or see an `Incompatible changes` warning when building,
 you will need to run
-` ./gradlew :gms:impl:build -Prest.model.compatibility=ignore`
+`./gradlew :gms:impl:build -Prest.model.compatibility=ignore`
 before running `build`.
 
 Then, run `/.gradlew build` from the repository root to rebuild Datahub with access to your new entity.

--- a/docs/modeling/extending-the-metadata-model.md
+++ b/docs/modeling/extending-the-metadata-model.md
@@ -256,7 +256,12 @@ If you're extending an existing Entity, you can skip this step.
 
 ### Step 5: Re-build DataHub to have access to your new or updated entity
 
-Run `/.gradlew build` from the repository root to rebuild Datahub with access to your new entity.
+If you have updated any existing types or see an `Incompatible changes` warning when building,
+you will need to run
+` ./gradlew :gms:impl:build -Prest.model.compatibility=ignore`
+before running `build`.
+
+Then, run `/.gradlew build` from the repository root to rebuild Datahub with access to your new entity.
 
 Then, re-deploy gms, mae-consumer and mce-consumer (see [docker development](../../docker/README.md) for details on how
 to deploy during development). This will allow Datahub to read and write Snapshots of your new entity, along with server


### PR DESCRIPTION
Often times, the `./gradlew :gms:impl:build -Prest.model.compatibility=ignore` command will need to be run when adding or updating an existing entity.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
