### PR TITLE
feat(sql_views): added views as datasets for SQLAlchemy DBs

### DIFF
--- a/metadata-ingestion/README.md
+++ b/metadata-ingestion/README.md
@@ -194,8 +194,8 @@ We have two options for the underlying library used to connect to SQL Server: (1
 
 Extracts:
 
-- List of databases, schema, and tables
-- Column types associated with each table
+- List of databases, schema, tables and (optionally) views
+- Column types associated with each table/view
 
 ```yml
 source:
@@ -205,6 +205,7 @@ source:
     password: pass
     host_port: localhost:1433
     database: DemoDatabase
+    include_views: True
     table_pattern:
       deny:
         - "^.*\\.sys_.*" # deny all tables that start with sys_

--- a/metadata-ingestion/README.md
+++ b/metadata-ingestion/README.md
@@ -194,7 +194,7 @@ We have two options for the underlying library used to connect to SQL Server: (1
 
 Extracts:
 
-- List of databases, schema, tables and (optionally) views
+- List of databases, schema, tables and views
 - Column types associated with each table/view
 
 ```yml

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import warnings
 from abc import abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Type
@@ -41,7 +42,9 @@ class SQLSourceReport(SourceReport):
     views_scanned: int = 0
     filtered: List[str] = field(default_factory=list)
 
-    report_table_scanned
+    def report_table_scanned(self, table_name: str) -> None:
+        warnings.warn("report_table_scanned is deprecated, please use report_entity_scanned with argument `table`")
+        self.tables_scanned += 1
 
     def report_entity_scanned(self, name: str, ent_type: str = "table") -> None:
         """
@@ -232,7 +235,7 @@ class SQLAlchemySource(Source):
                 for table in inspector.get_table_names(schema):
                     schema, table = sql_config.standardize_schema_table_names(schema, table)
                     dataset_name = sql_config.get_identifier(schema, table)
-                    self.report.report_table_scanned(dataset_name)
+                    self.report.report_entity_scanned(dataset_name, ent_type="table")
 
                     if not sql_config.table_pattern.allowed(dataset_name):
                         self.report.report_dropped(dataset_name)
@@ -279,7 +282,7 @@ class SQLAlchemySource(Source):
                     # TODO : change "standardize_schema_table_names" function name: it will be the same for tables and views
                     schema, view = sql_config.standardize_schema_table_names(schema, view)
                     dataset_name = sql_config.get_identifier(schema, view)
-                    self.report.report_view_scanned(dataset_name)
+                    self.report.report_entity_scanned(dataset_name, ent_type="view")
 
                     if not sql_config.view_pattern.allowed(dataset_name):
                         self.report.report_dropped(dataset_name)

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -72,8 +72,8 @@ class SQLAlchemyConfig(ConfigModel):
     table_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
 
-    include_views: bool = False
-    include_tables: bool = True
+    include_views: Optional[bool] = False
+    include_tables: Optional[bool] = True
 
     @abstractmethod
     def get_sql_alchemy_url(self):


### PR DESCRIPTION
Tested with MS SQL Server, this solution should work with other SQLAlchemy manageable DBs.

Now the ingestion recipe accept, optionally, two more options:

    include_views: False
    include_tables: True

To assure retro-compatibility they can be omitted, and in such case the default arguments are those ones expressed up here.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [-] Links to related issues (if applicable)
- [-] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
