### PR TITLE
fix(NoCode): Fix typo in no-code-modeling doc

### DIFF
--- a/docs/advanced/no-code-modeling.md
+++ b/docs/advanced/no-code-modeling.md
@@ -212,7 +212,7 @@ record ServiceKey {
   */
   @Searchable = {
     "fieldType": "TEXT_PARTIAL",
-    "enableAutoComplete": true
+    "enableAutocomplete": true
   }
   name: string
 }


### PR DESCRIPTION
The key should be enableAutocomplete not enableAutoComplete

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
