### PR TITLE
fix(ingest): pin to new mypy version

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -99,8 +99,6 @@ all_exclude_plugins: Set[str] = {
 }
 
 mypy_stubs = {
-    # for Python 3.6 support
-    "dataclasses",
     "types-dataclasses",
     "sqlalchemy-stubs",
     "types-pkg_resources",
@@ -123,7 +121,7 @@ base_dev_requirements = {
     "coverage>=5.1",
     "flake8>=3.8.3",
     "isort>=5.7.0",
-    "mypy>=0.782",
+    "mypy>=0.901",
     "pytest>=6.2.2",
     "pytest-cov>=2.8.1",
     "pytest-docker",


### PR DESCRIPTION
Also removes `dataclasses`, since it's already specified as a dependency elsewhere. Follow up on #2666. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
