### PR TITLE
fix(frontend): auth session ttl specified in hours instead of days. M…

### DIFF
--- a/datahub-frontend/app/react/auth/AuthModule.java
+++ b/datahub-frontend/app/react/auth/AuthModule.java
@@ -143,7 +143,7 @@ public class AuthModule extends AbstractModule {
                 context.getJavaSession().put(ACTOR, actorUrn);
                 return result.withCookies(createActorCookie(actorUrn, _configs.hasPath(SESSION_TTL_CONFIG_PATH)
                         ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
-                        : DEFAULT_SESSION_TTL_DAYS));
+                        : DEFAULT_SESSION_TTL_HOURS));
             } else {
                 throw new RuntimeException(
                         String.format("Failed to extract DataHub username from username claim %s using regex %s",

--- a/datahub-frontend/app/react/auth/AuthUtils.java
+++ b/datahub-frontend/app/react/auth/AuthUtils.java
@@ -8,8 +8,8 @@ import java.time.temporal.ChronoUnit;
 
 public class AuthUtils {
 
-    public static final String SESSION_TTL_CONFIG_PATH = "auth.session.ttlInDays";
-    public static final Integer DEFAULT_SESSION_TTL_DAYS = 30;
+    public static final String SESSION_TTL_CONFIG_PATH = "auth.session.ttlInHours";
+    public static final Integer DEFAULT_SESSION_TTL_HOURS = 24;
     public static final CorpuserUrn DEFAULT_ACTOR_URN = new CorpuserUrn("datahub");
 
     public static final String LOGIN_ROUTE = "/login";
@@ -30,15 +30,15 @@ public class AuthUtils {
     }
 
     /**
-     * Creates a client authentication cookie (actor cookie) with a specified TTL in days.
+     * Creates a client authentication cookie (actor cookie) with a specified TTL in hours.
      *
      * @param actorUrn the urn of the authenticated actor, e.g. "urn:li:corpuser:datahub"
-     * @param ttlInDays the number of days until the actor cookie expires after being set
+     * @param ttlInHours the number of hours until the actor cookie expires after being set
      */
-    public static Http.Cookie createActorCookie(final String actorUrn, final Integer ttlInDays) {
+    public static Http.Cookie createActorCookie(final String actorUrn, final Integer ttlInHours) {
         return Http.Cookie.builder(ACTOR, actorUrn)
                 .withHttpOnly(false)
-                .withMaxAge(Duration.of(ttlInDays, ChronoUnit.DAYS))
+                .withMaxAge(Duration.of(ttlInHours, ChronoUnit.HOURS))
                 .build();
     }
 

--- a/datahub-frontend/app/react/controllers/AuthenticationController.java
+++ b/datahub-frontend/app/react/controllers/AuthenticationController.java
@@ -78,7 +78,7 @@ public class AuthenticationController extends Controller {
         session().put(ACTOR, DEFAULT_ACTOR_URN.toString());
         return redirect("/").withCookies(createActorCookie(DEFAULT_ACTOR_URN.toString(), _configs.hasPath(SESSION_TTL_CONFIG_PATH)
                 ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
-                : DEFAULT_SESSION_TTL_DAYS));
+                : DEFAULT_SESSION_TTL_HOURS));
     }
 
     /**


### PR DESCRIPTION
…ore reasonable default 24 hours instead of 30 days.

Fixes: #2680



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
