### PR TITLE
fix(ingest): upgrade acryl-pyhive to use sasl3 instead of sasl

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -77,7 +77,7 @@ plugins: Dict[str, Set[str]] = {
     | {
         # Acryl Data maintains a fork of PyHive, which adds support for table comments
         # and column comments, and also releases HTTP and HTTPS transport schemes.
-        "acryl-pyhive[hive]>=0.6.6"
+        "acryl-pyhive[hive]>=0.6.7"
     },
     "ldap": {"python-ldap>=2.4"},
     "looker": {"looker-sdk==21.6.0"},


### PR DESCRIPTION
This resolves some MacOS build issues, which stem from the release of XCode10. See https://github.com/cloudera/python-sasl/pull/13 for details about the issue itself. The [python-sasl3 fork](https://github.com/sparkur/python-sasl3) contains these changes.

The change to acryl-pyhive is here: https://github.com/hsheth2/PyHive/commit/a02428fc018095dc948bf0bd71251c0d8b0a4149.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
