### PR TITLE
fix(ingest): do not load metadata from the dbt manifest file when load_catalog is false

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -97,15 +97,18 @@ def extract_dbt_entities(
         node = nodes[key]
         dbtNode = DBTNode()
 
+        if key not in catalog and load_catalog is False:
+            continue
+
+        if "identifier" in node and load_catalog is False:
+            dbtNode.name = node["identifier"]
+        else:
+            dbtNode.name = node["name"]
         dbtNode.dbt_name = key
         dbtNode.database = node["database"]
         dbtNode.schema = node["schema"]
         dbtNode.dbt_file_path = node["original_file_path"]
         dbtNode.node_type = node["resource_type"]
-        if "identifier" in node and load_catalog is False:
-            dbtNode.name = node["identifier"]
-        else:
-            dbtNode.name = node["name"]
 
         if "materialized" in node["config"].keys():
             # It's a model


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

This PR avoid loading additional metadata found in the dbt manifest such as tests, macros, etc. that are not present in the catalog and should not be ingested when `load_catalog` is false (see https://docs.getdbt.com/reference/artifacts/manifest-json and https://docs.getdbt.com/reference/artifacts/catalog-json).

In fact entities/nodes in the manifest file should probably not be ingested at all and be only used to build the upstream/downstream lineage...