### PR TITLE
test(ingest): simplify docker cleanup commands

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -125,7 +125,7 @@ base_dev_requirements = {
     "mypy>=0.901",
     "pytest>=6.2.2",
     "pytest-cov>=2.8.1",
-    "pytest-docker",
+    "pytest-docker>=0.10.3",
     "tox",
     "deepdiff",
     "requests-mock",

--- a/metadata-ingestion/tests/test_helpers/docker_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/docker_helpers.py
@@ -31,18 +31,11 @@ def wait_for_port(
 def docker_compose_runner(docker_compose_project_name, docker_cleanup):
     @contextlib.contextmanager
     def run(compose_file_path: str, key: str) -> pytest_docker.plugin.Services:
-        try:
-            docker_services = pytest_docker.plugin.get_docker_services(
-                str(compose_file_path),
-                f"{docker_compose_project_name}-{key}",
-                docker_cleanup,
-            )
-            yield docker_services.__enter__()
-        finally:
-            # This setup exists because the underlying pytest_docker library does not
-            # wrap it's cleanup routine in a `finally` block.
-            # See this PR: https://github.com/avast/pytest-docker/pull/58.
-            docker_services.__exit__(None, None, None)
-            print("called docker-compose cleanup")
+        with pytest_docker.plugin.get_docker_services(
+            str(compose_file_path),
+            f"{docker_compose_project_name}-{key}",
+            docker_cleanup,
+        ) as docker_services:
+            yield docker_services
 
     return run


### PR DESCRIPTION
Now that https://github.com/avast/pytest-docker/pull/58 has been merged and published via a release, we can remove the hack that was added to force the context manager into cleaning up containers even if a test failed.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
