### PR TITLE
Added node_pattern in dbt yml config file

### DIFF
--- a/metadata-ingestion/README.md
+++ b/metadata-ingestion/README.md
@@ -669,7 +669,9 @@ Pull metadata from dbt artifacts files:
   - [data platforms](https://github.com/linkedin/datahub/blob/master/gms/impl/src/main/resources/DataPlatformInfo.json)
 - load_schemas:
   - Load schemas from dbt catalog file, not necessary when the underlying data platform already has this data.
-
+- node_pattern: 
+  - Use this filter to exclude and include nodes using allow or deny method
+  
 ```yml
 source:
   type: "dbt"
@@ -678,6 +680,12 @@ source:
     catalog_path: "./path/dbt/catalog_file.json"
     target_platform: "postgres" # optional, eg "postgres", "snowflake", etc.
     load_schemas: True or False
+    node_pattern:  # optional, default AllowDenyPattern.allow_all()
+      deny:
+        - test
+      allow: 
+        - "^.*"  
+    
 ```
 
 Note: when `load_schemas` is False, models that use [identifiers](https://docs.getdbt.com/reference/resource-properties/identifier) to reference their source tables are ingested using the model identifier as the model name to preserve the lineage.


### PR DESCRIPTION
The dbt datahub ingest command is failing due to long test case names (Data too long for column 'urn' at row 1) and I guess it is not a useful dataset so you can filter out node like test, seed, etc using the node_pattern allow or deny options in the dbt source YAML file.

PR - fix(dbt-ingest): added node filter to eliminate nodes like test based on dbt config file #2694



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
