### PR TITLE
fix(version aspects): fixes for version aspect fetching

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/ResolverUtils.java
@@ -96,7 +96,7 @@ public class ResolverUtils {
         Object localContext = environment.getLocalContext();
         // if we have context & the version is 0, we should try to retrieve it from the fetched entity
         // otherwise, we should just fetch the entity from the aspect resource
-        if (localContext == null && version == 0 || version == null) {
+        if (localContext != null && version == 0 || version == null) {
             if (localContext instanceof Map) {
                 // de-register the prefetched aspect from local context. Since aspects will only
                 // ever be first-class properties of an entity type, local context will always

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -95,7 +95,7 @@ public class EbeanEntityService extends EntityService {
   @Nullable
   public RecordTemplate getAspect(@Nonnull final Urn urn, @Nonnull final String aspectName, @Nonnull long version) {
     if (version < 0) {
-      version = _entityDao.getMaxVersion(urn.toString(), aspectName) - version + 1;
+      version = _entityDao.getMaxVersion(urn.toString(), aspectName) + version + 1;
     }
     final EbeanAspectV2.PrimaryKey primaryKey = new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, version);
     final Optional<EbeanAspectV2> maybeAspect = Optional.ofNullable(_entityDao.getAspect(primaryKey));

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -97,15 +97,16 @@ public class EbeanEntityService extends EntityService {
    * the maximum version, we need to add 1 to the final result.
    */
   private long calculateVersionNumber(@Nonnull final Urn urn, @Nonnull final String aspectName, @Nonnull long version) {
-    return _entityDao.getMaxVersion(urn.toString(), aspectName) + version + 1;
+    if (version < 0) {
+      return _entityDao.getMaxVersion(urn.toString(), aspectName) + version + 1;
+    }
+    return version;
   }
 
   @Override
   @Nullable
   public RecordTemplate getAspect(@Nonnull final Urn urn, @Nonnull final String aspectName, @Nonnull long version) {
-    if (version < 0) {
-      version = calculateVersionNumber(urn, aspectName, version);
-    }
+    version = calculateVersionNumber(urn, aspectName, version);
     final EbeanAspectV2.PrimaryKey primaryKey = new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, version);
     final Optional<EbeanAspectV2> maybeAspect = Optional.ofNullable(_entityDao.getAspect(primaryKey));
     return maybeAspect
@@ -117,9 +118,7 @@ public class EbeanEntityService extends EntityService {
   public VersionedAspect getVersionedAspect(@Nonnull Urn urn, @Nonnull String aspectName, long version) {
     VersionedAspect result = new VersionedAspect();
 
-    if (version < 0) {
-      version = calculateVersionNumber(urn, aspectName, version);
-    }
+    version = calculateVersionNumber(urn, aspectName, version);
 
     final EbeanAspectV2.PrimaryKey primaryKey = new EbeanAspectV2.PrimaryKey(urn.toString(), aspectName, version);
     final Optional<EbeanAspectV2> maybeAspect = Optional.ofNullable(_entityDao.getAspect(primaryKey));


### PR DESCRIPTION
1) fixes case where the aspect was not fetched from local context because of an incorrect null comparison

2) updates getAspect logic for negative versions. Currently, this code path is not hit so tests did not catch it.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
