### PR TITLE
fix(EntityClient): Make get return Entity type

### DIFF
--- a/gms/client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/gms/client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -78,7 +78,7 @@ public class EntityClient {
     }
 
     @Nonnull
-    public RecordTemplate get(@Nonnull final Urn urn) throws RemoteInvocationException {
+    public Entity get(@Nonnull final Urn urn) throws RemoteInvocationException {
         final GetRequest<Entity> getRequest = ENTITIES_REQUEST_BUILDERS.get()
                 .id(urn.toString())
                 .build();

--- a/gms/client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/gms/client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.data.template.DataTemplateUtil;
 import com.linkedin.data.template.DynamicRecordMetadata;
 import com.linkedin.data.template.FieldDef;
-import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.EntitiesDoAutocompleteRequestBuilder;
 import com.linkedin.entity.EntitiesDoBrowseRequestBuilder;


### PR DESCRIPTION
"get" method in EntityClient incorrectly returned a weakly typed RecordTemplate. This PR updates it to return a strongly Entity object. 

No callers are using the API at this time, so should be a safe fix. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
