### PR TITLE
fix(GMS): Adding Rest.li Validation in GMS

### DIFF
--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
@@ -4,7 +4,6 @@ import com.linkedin.common.urn.UrnValidator;
 import com.linkedin.data.schema.validation.ValidateDataAgainstSchema;
 import com.linkedin.data.schema.validation.ValidationOptions;
 import com.linkedin.data.schema.validation.ValidationResult;
-import com.linkedin.data.schema.validator.DataSchemaAnnotationValidator;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.RestLiServiceException;
@@ -27,10 +26,11 @@ public class ResourceUtils {
         record,
         DEFAULT_VALIDATION_OPTIONS,
         URN_VALIDATOR);
-    if (!result.isValid())
-    {
+    if (!result.isValid()) {
       throw new RestLiServiceException(status, result.getMessages().toString());
     }
   }
+
+  private ResourceUtils() { }
 
 }

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
@@ -1,0 +1,35 @@
+package com.linkedin.metadata.resources;
+
+import com.linkedin.common.urn.UrnValidator;
+import com.linkedin.data.schema.validation.ValidateDataAgainstSchema;
+import com.linkedin.data.schema.validation.ValidationOptions;
+import com.linkedin.data.schema.validation.ValidationResult;
+import com.linkedin.data.schema.validator.DataSchemaAnnotationValidator;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.RestLiServiceException;
+
+
+public class ResourceUtils {
+
+  private static final ValidationOptions DEFAULT_VALIDATION_OPTIONS = new ValidationOptions();
+
+  /**
+   * Validates a {@link RecordTemplate} and throws {@link com.linkedin.restli.server.RestLiServiceException}
+   * if validation fails.
+   *
+   * @param record record to be validated.
+   * @param status the status code to return to the client on failure.
+   */
+  public static void validateRecord(RecordTemplate record, HttpStatus status) {
+    final ValidationResult result = ValidateDataAgainstSchema.validate(
+        record,
+        DEFAULT_VALIDATION_OPTIONS,
+        new UrnValidator());
+    if (!result.isValid())
+    {
+      throw new RestLiServiceException(status, result.getMessages().toString());
+    }
+  }
+
+}

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/ResourceUtils.java
@@ -13,6 +13,7 @@ import com.linkedin.restli.server.RestLiServiceException;
 public class ResourceUtils {
 
   private static final ValidationOptions DEFAULT_VALIDATION_OPTIONS = new ValidationOptions();
+  private static final UrnValidator URN_VALIDATOR = new UrnValidator();
 
   /**
    * Validates a {@link RecordTemplate} and throws {@link com.linkedin.restli.server.RestLiServiceException}
@@ -25,7 +26,7 @@ public class ResourceUtils {
     final ValidationResult result = ValidateDataAgainstSchema.validate(
         record,
         DEFAULT_VALIDATION_OPTIONS,
-        new UrnValidator());
+        URN_VALIDATOR);
     if (!result.isValid())
     {
       throw new RestLiServiceException(status, result.getMessages().toString());

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -5,6 +5,7 @@ import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.restli.RestliUtils;
 import com.linkedin.parseq.Task;
+import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.annotations.Optional;
 import com.linkedin.restli.server.annotations.QueryParam;
 import com.linkedin.restli.server.annotations.RestLiCollection;
@@ -17,6 +18,9 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static com.linkedin.metadata.resources.ResourceUtils.*;
+
 
 /**
  * Single unified resource for fetching, updating, searching, & browsing DataHub entities
@@ -46,9 +50,10 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
       final VersionedAspect aspect = _entityService.getVersionedAspect(urn, aspectName, version);
       if (aspect == null) {
         throw RestliUtils.resourceNotFoundException();
+      } else {
+        validateRecord(aspect, HttpStatus.S_500_INTERNAL_SERVER_ERROR);
       }
       return aspect;
     });
   }
-
 }

--- a/li-utils/src/main/javaPegasus/com/linkedin/common/urn/UrnValidator.java
+++ b/li-utils/src/main/javaPegasus/com/linkedin/common/urn/UrnValidator.java
@@ -1,0 +1,30 @@
+package com.linkedin.common.urn;
+
+import com.linkedin.data.message.Message;
+import com.linkedin.data.schema.DataSchema;
+import com.linkedin.data.schema.NamedDataSchema;
+import com.linkedin.data.schema.validator.Validator;
+import com.linkedin.data.schema.validator.ValidatorContext;
+import java.net.URISyntaxException;
+
+
+/**
+ * Rest.li Validator responsible for ensuring that {@link Urn} objects are well-formed.
+ *
+ * Note that this validator does not validate the integrity of strongly typed urns,
+ * or validate Urn objects against their associated key aspect.
+ */
+public class UrnValidator implements Validator {
+  @Override
+  public void validate(ValidatorContext context) {
+    if (DataSchema.Type.TYPEREF.equals(context.dataElement().getSchema().getType())
+        && ((NamedDataSchema) context.dataElement().getSchema()).getName().endsWith("Urn")) {
+      try {
+        Urn.createFromString((String) context.dataElement().getValue());
+      } catch (URISyntaxException e) {
+        context.addResult(new Message(context.dataElement().path(), "\"Provided urn %s\" is invalid", context.dataElement().getValue()));
+        context.setHasFix(false);
+      }
+    }
+  }
+}


### PR DESCRIPTION

Previously, Rest.li endpoints were not validating incoming data against their respective schema. Typically, this is performed inside of a Rest.li Validation Filter that runs before the endpoints are hit. However, that filter does not support Action method requests. Thus, we've had to implement our own manual validation for Entity ingestion. This PR does exactly that.

Before
- Model validation issues would go undiscovered until read time :(

With these changes
- Model validation happens at Rest.li endpoint level, the front door. :) 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
