### PR TITLE
fix(elastic-as-graph): adding elasticsearch setup back in

### DIFF
--- a/docker/docker-compose-without-neo4j.yml
+++ b/docker/docker-compose-without-neo4j.yml
@@ -99,6 +99,18 @@ services:
         start_period: 2m
         retries: 4
 
+  # This "container" is a workaround to pre-create search indices
+  elasticsearch-setup:
+    build:
+      context: ../
+      dockerfile: docker/elasticsearch-setup/Dockerfile
+    image: linkedin/datahub-elasticsearch-setup:${DATAHUB_VERSION:-head}
+    env_file: elasticsearch-setup/env/docker.env
+    hostname: elasticsearch-setup
+    container_name: elasticsearch-setup
+    depends_on:
+      - elasticsearch
+
   datahub-gms:
     build:
         context: ../

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -85,6 +85,16 @@ services:
     - 9200:9200
     volumes:
     - esdata:/usr/share/elasticsearch/data
+  elasticsearch-setup:
+    container_name: elasticsearch-setup
+    depends_on:
+    - elasticsearch
+    environment:
+    - ELASTICSEARCH_HOST=elasticsearch
+    - ELASTICSEARCH_PORT=9200
+    - ELASTICSEARCH_PROTOCOL=http
+    hostname: elasticsearch-setup
+    image: linkedin/datahub-elasticsearch-setup:${DATAHUB_VERSION:-head}
   kafka-setup:
     container_name: kafka-setup
     depends_on:

--- a/docker/quickstart/generate_and_compare.sh
+++ b/docker/quickstart/generate_and_compare.sh
@@ -11,10 +11,19 @@ source venv/bin/activate
 pip install -r requirements.txt
 python generate_docker_quickstart.py ../docker-compose.yml ../docker-compose.override.yml temp.quickstart.yml
 
+python generate_docker_quickstart.py ../docker-compose-without-neo4j.yml ../docker-compose-without-neo4j.override.yml temp-without-neo4j.quickstart.yml
+
 if cmp docker-compose.quickstart.yml temp.quickstart.yml; then
     printf 'docker-compose.quickstart.yml is up to date.'
-    exit 0
 else
     printf 'docker-compose.quickstart.yml is out of date.'
+    exit 1
+fi
+
+if cmp docker-compose-without-neo4j.quickstart.yml temp-without-neo4j.quickstart.yml; then
+    printf 'docker-compose-without-neo4j.quickstart.yml is up to date.'
+		exit 0
+else
+    printf 'docker-compose-without-neo4j.quickstart.yml is out of date.'
     exit 1
 fi

--- a/docker/quickstart/generate_and_compare.sh
+++ b/docker/quickstart/generate_and_compare.sh
@@ -22,7 +22,7 @@ fi
 
 if cmp docker-compose-without-neo4j.quickstart.yml temp-without-neo4j.quickstart.yml; then
     printf 'docker-compose-without-neo4j.quickstart.yml is up to date.'
-		exit 0
+    exit 0
 else
     printf 'docker-compose-without-neo4j.quickstart.yml is out of date.'
     exit 1


### PR DESCRIPTION
This was removed spuriously- we still need it for product analytics.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
