### PR TITLE
fix(datahub-upgrade): Adding runtime dependency on logbackClassic

### DIFF
--- a/datahub-upgrade/build.gradle
+++ b/datahub-upgrade/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   compile externalDependency.springCore
   compile externalDependency.springKafka
 
+  runtime externalDependency.logbackClassic
   runtime externalDependency.mariadbConnector
   runtime externalDependency.mysqlConnector
   runtime externalDependency.postgresql


### PR DESCRIPTION
Adding logbackClassic dependency to datahub-upgrade so that logging is all captured. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
