### PR TITLE
fix(quickstart): Fixing manual mysql quickstart

### DIFF
--- a/docker/docker-compose-without-neo4j.yml
+++ b/docker/docker-compose-without-neo4j.yml
@@ -116,7 +116,7 @@ services:
         context: ../
         dockerfile: docker/datahub-gms/Dockerfile
     image: linkedin/datahub-gms:${DATAHUB_VERSION:-latest}
-    env_file: gms/env/docker-without-neo4j.env
+    env_file: datahub-gms/env/docker-without-neo4j.env
     hostname: datahub-gms
     container_name: datahub-gms
     ports:

--- a/docker/quickstart/generate_docker_quickstart.py
+++ b/docker/quickstart/generate_docker_quickstart.py
@@ -1,9 +1,9 @@
 import os
-from collections.abc import Mapping
-
 import click
 import yaml
+from collections.abc import Mapping
 from dotenv import dotenv_values
+from shutil import copyfile
 from yaml import Loader
 
 # Generates a merged docker-compose file with env variables inlined.
@@ -80,6 +80,10 @@ def modify_docker_config(base_path, docker_yaml_config):
 )
 @click.argument("output-file", type=click.Path())
 def generate(compose_files, output_file) -> None:
+
+    # Copy ../mysql/init.sql into the mysql directory
+    currDir = os.path.dirname(os.path.realpath(__file__))
+    copyfile(currDir + "/../mysql/init.sql", currDir + "/mysql/init.sql")
 
     # Resolve .env files to inlined vars
     modified_files = []

--- a/docker/quickstart/generate_docker_quickstart.py
+++ b/docker/quickstart/generate_docker_quickstart.py
@@ -81,10 +81,6 @@ def modify_docker_config(base_path, docker_yaml_config):
 @click.argument("output-file", type=click.Path())
 def generate(compose_files, output_file) -> None:
 
-    # Copy ../mysql/init.sql into the mysql directory
-    currDir = os.path.dirname(os.path.realpath(__file__))
-    copyfile(currDir + "/../mysql/init.sql", currDir + "/mysql/init.sql")
-
     # Resolve .env files to inlined vars
     modified_files = []
     for compose_file in compose_files:

--- a/docker/quickstart/generate_docker_quickstart.py
+++ b/docker/quickstart/generate_docker_quickstart.py
@@ -3,7 +3,6 @@ import click
 import yaml
 from collections.abc import Mapping
 from dotenv import dotenv_values
-from shutil import copyfile
 from yaml import Loader
 
 # Generates a merged docker-compose file with env variables inlined.

--- a/docker/quickstart/generate_docker_quickstart.sh
+++ b/docker/quickstart/generate_docker_quickstart.sh
@@ -8,6 +8,8 @@ set -euxo pipefail
 python3 -m venv venv
 source venv/bin/activate
 
+cp $(pwd)/../mysql/init.sql $(pwd)/mysql/init.sql
+
 pip install -r requirements.txt
 python generate_docker_quickstart.py ../docker-compose.yml ../docker-compose.override.yml docker-compose.quickstart.yml
 python generate_docker_quickstart.py ../docker-compose-without-neo4j.yml ../docker-compose-without-neo4j.override.yml docker-compose-without-neo4j.quickstart.yml

--- a/docker/quickstart/mysql/init.sql
+++ b/docker/quickstart/mysql/init.sql
@@ -1,0 +1,43 @@
+-- create metadata aspect table
+CREATE TABLE metadata_aspect_v2 (
+  urn                           VARCHAR(500) NOT NULL,
+  aspect                        VARCHAR(200) NOT NULL,
+  version                       bigint(20) NOT NULL,
+  metadata                      longtext NOT NULL,
+  systemmetadata                longtext,
+  createdon                     datetime(6) NOT NULL,
+  createdby                     VARCHAR(255) NOT NULL,
+  createdfor                    VARCHAR(255),
+  CONSTRAINT pk_metadata_aspect_v2 PRIMARY KEY (urn,aspect,version)
+);
+
+INSERT INTO metadata_aspect_v2 (urn, aspect, version, metadata, createdon, createdby) VALUES(
+  'urn:li:corpuser:datahub',
+  'corpUserInfo',
+  0,
+  '{"displayName":"Data Hub","active":true,"fullName":"Data Hub","email":"datahub@linkedin.com"}',
+  now(),
+  'urn:li:principal:datahub'
+), (
+  'urn:li:corpuser:datahub',
+  'corpUserEditableInfo',
+  0,
+  '{"skills":[],"teams":[],"pictureLink":"https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web/packages/data-portal/public/assets/images/default_avatar.png"}',
+  now(),
+  'urn:li:principal:datahub'
+);
+
+-- create metadata index table
+CREATE TABLE metadata_index (
+ `id` BIGINT NOT NULL AUTO_INCREMENT,
+ `urn` VARCHAR(200) NOT NULL,
+ `aspect` VARCHAR(150) NOT NULL,
+ `path` VARCHAR(150) NOT NULL,
+ `longVal` BIGINT,
+ `stringVal` VARCHAR(200),
+ `doubleVal` DOUBLE,
+ CONSTRAINT id_pk PRIMARY KEY (id),
+ INDEX longIndex (`urn`,`aspect`,`path`,`longVal`),
+ INDEX stringIndex (`urn`,`aspect`,`path`,`stringVal`),
+ INDEX doubleIndex (`urn`,`aspect`,`path`,`doubleVal`)
+);


### PR DESCRIPTION
When you manually run quickstart for mysql container (using quickstart.sh), the container will fail to spin up the first time you run "up" because the init.sql file cannot be found in the `docker/quickstart` directory. 

This fixes it by adding logic to copy the `init.sql` file from the mysql/init.sql file into the expected `docker/quickstart` location when `generate_docker_quickstart.sh` is executed. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
