### PR TITLE
fix(standalone mae consumer): support standalone mae consumer without neo4j

### DIFF
--- a/docker/datahub-gms/start.sh
+++ b/docker/datahub-gms/start.sh
@@ -26,27 +26,20 @@ else
     ELASTICSEARCH_PROTOCOL=http
 fi
 
+WAIT_FOR_NEO4J=""
+
 if [[ $GRAPH_SERVICE_IMPL != elasticsearch ]]; then
-    dockerize \
-      -wait tcp://$EBEAN_DATASOURCE_HOST \
-      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
-      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
-      -wait $NEO4J_HOST \
-      -timeout 240s \
-      java $JAVA_OPTS $JMX_OPTS \
-      -jar /jetty-runner.jar \
-      --jar jetty-util.jar \
-      --jar jetty-jmx.jar \
-      /datahub/datahub-gms/bin/war.war
-else
-    dockerize \
-      -wait tcp://$EBEAN_DATASOURCE_HOST \
-      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
-      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
-      -timeout 240s \
-      java $JAVA_OPTS $JMX_OPTS \
-      -jar /jetty-runner.jar \
-      --jar jetty-util.jar \
-      --jar jetty-jmx.jar \
-      /datahub/datahub-gms/bin/war.war
+  WAIT_FOR_NEO4J=" -wait $NEO4J_HOST "
 fi
+
+dockerize \
+  -wait tcp://$EBEAN_DATASOURCE_HOST \
+  -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
+  -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
+  $WAIT_FOR_NEO4J \
+  -timeout 240s \
+  java $JAVA_OPTS $JMX_OPTS \
+  -jar /jetty-runner.jar \
+  --jar jetty-util.jar \
+  --jar jetty-jmx.jar \
+  /datahub/datahub-gms/bin/war.war

--- a/docker/datahub-gms/start.sh
+++ b/docker/datahub-gms/start.sh
@@ -26,13 +26,27 @@ else
     ELASTICSEARCH_PROTOCOL=http
 fi
 
-dockerize \
-  -wait tcp://$EBEAN_DATASOURCE_HOST \
-  -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
-  -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
-  -timeout 240s \
-  java $JAVA_OPTS $JMX_OPTS \
-  -jar /jetty-runner.jar \
-  --jar jetty-util.jar \
-  --jar jetty-jmx.jar \
-  /datahub/datahub-gms/bin/war.war
+if [[ $GRAPH_SERVICE_IMPL != elasticsearch ]]; then
+    dockerize \
+      -wait tcp://$EBEAN_DATASOURCE_HOST \
+      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
+      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
+      -wait $NEO4J_HOST \
+      -timeout 240s \
+      java $JAVA_OPTS $JMX_OPTS \
+      -jar /jetty-runner.jar \
+      --jar jetty-util.jar \
+      --jar jetty-jmx.jar \
+      /datahub/datahub-gms/bin/war.war
+else
+    dockerize \
+      -wait tcp://$EBEAN_DATASOURCE_HOST \
+      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
+      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
+      -timeout 240s \
+      java $JAVA_OPTS $JMX_OPTS \
+      -jar /jetty-runner.jar \
+      --jar jetty-util.jar \
+      --jar jetty-jmx.jar \
+      /datahub/datahub-gms/bin/war.war
+fi

--- a/docker/datahub-mae-consumer/env/docker-without-neo4j.env
+++ b/docker/datahub-mae-consumer/env/docker-without-neo4j.env
@@ -3,13 +3,9 @@ KAFKA_BOOTSTRAP_SERVER=broker:29092
 KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
 ELASTICSEARCH_HOST=elasticsearch
 ELASTICSEARCH_PORT=9200
-NEO4J_HOST=http://neo4j:7474
-NEO4J_URI=bolt://neo4j
-NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=datahub
 GMS_HOST=datahub-gms
 GMS_PORT=8080
-GRAPH_SERVICE_IMPL=neo4j
+GRAPH_SERVICE_IMPL=elasticsearch
 
 # Uncomment to disable persistence of client-side analytics events
 # DATAHUB_ANALYTICS_ENABLED=false

--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -26,17 +26,15 @@ else
     ELASTICSEARCH_PROTOCOL=http
 fi
 
+WAIT_FOR_NEO4J=""
+
 if [[ $GRAPH_SERVICE_IMPL != elasticsearch ]]; then
-    dockerize \
-      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
-      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
-      -wait $NEO4J_HOST \
-      -timeout 240s \
-      java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
-else
-    dockerize \
-      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
-      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
-      -timeout 240s \
-      java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
+  WAIT_FOR_NEO4J=" -wait $NEO4J_HOST "
 fi
+
+    dockerize \
+      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
+      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
+      $WAIT_FOR_NEO4J \
+      -timeout 240s \
+      java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar

--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -26,9 +26,17 @@ else
     ELASTICSEARCH_PROTOCOL=http
 fi
 
-dockerize \
-  -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
-  -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
-  -wait $NEO4J_HOST \
-  -timeout 240s \
-  java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
+if [[ $GRAPH_SERVICE_IMPL != elasticsearch ]]; then
+    dockerize \
+      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
+      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
+      -wait $NEO4J_HOST \
+      -timeout 240s \
+      java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
+else
+    dockerize \
+      -wait tcp://$(echo $KAFKA_BOOTSTRAP_SERVER | sed 's/,/ -wait tcp:\/\//g') \
+      -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST_URL:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
+      -timeout 240s \
+      java $JAVA_OPTS $JMX_OPTS -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
+fi

--- a/docker/dev-without-neo4j.sh
+++ b/docker/dev-without-neo4j.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Launches dev instances of DataHub images. See documentation for more details.
+# YOU MUST BUILD VIA GRADLE BEFORE RUNNING THIS.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR && \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose \
+    -f docker-compose-without-neo4j.yml \
+    -f docker-compose-without-neo4j.override.yml \
+    -f docker-compose.dev.yml \
+    pull \
+&& \
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -p datahub \
+    -f docker-compose-without-neo4j.yml \
+    -f docker-compose-without-neo4j.override.yml \
+    -f docker-compose.dev.yml \
+    up --build $@

--- a/docker/docker-compose.consumers-without-neo4j.yml
+++ b/docker/docker-compose.consumers-without-neo4j.yml
@@ -1,0 +1,30 @@
+# Service definitions for standalone Kafka consumer containers.
+version: '3.8'
+services:
+  datahub-mae-consumer:
+    build:
+      context: ../
+      dockerfile: docker/datahub-mae-consumer/Dockerfile
+    image: linkedin/datahub-mae-consumer:${DATAHUB_VERSION:-head}
+    env_file: datahub-mae-consumer/env/docker-without-neo4j.env
+    hostname: datahub-mae-consumer
+    container_name: datahub-mae-consumer
+    ports:
+      - "9091:9091"
+    depends_on:
+      - kafka-setup
+      - elasticsearch-setup
+
+  datahub-mce-consumer:
+    build:
+      context: ../
+      dockerfile: docker/datahub-mce-consumer/Dockerfile
+    image: linkedin/datahub-mce-consumer:${DATAHUB_VERSION:-head}
+    env_file: datahub-mce-consumer/env/docker.env
+    hostname: datahub-mce-consumer
+    container_name: datahub-mce-consumer
+    ports:
+      - "9090:9090"
+    depends_on:
+      - kafka-setup
+      - datahub-gms


### PR DESCRIPTION
Extends mae consumer docker compose files to include one that supports an elastic-as-graph compose file. Also updates start.sh scripts to conditionally wait on neo if neo is the graph service.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
