### PR TITLE
fix(ingest): convert superset timestamps to micros

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/superset.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/superset.py
@@ -196,7 +196,7 @@ class SupersetSource(Source):
 
         modified_actor = f"urn:li:corpuser:{(dashboard_data.get('changed_by') or {}).get('username', 'unknown')}"
         modified_ts = int(
-            dp.parse(dashboard_data.get("changed_on_utc", "now")).timestamp()
+            dp.parse(dashboard_data.get("changed_on_utc", "now")).timestamp() * 1000
         )
         title = dashboard_data.get("dashboard_title", "")
         # note: the API does not currently supply created_by usernames due to a bug, but we are required to
@@ -263,7 +263,9 @@ class SupersetSource(Source):
         )
 
         modified_actor = f"urn:li:corpuser:{(chart_data.get('changed_by') or {}).get('username', 'unknown')}"
-        modified_ts = int(dp.parse(chart_data.get("changed_on_utc", "now")).timestamp())
+        modified_ts = int(
+            dp.parse(chart_data.get("changed_on_utc", "now")).timestamp() * 1000
+        )
         title = chart_data.get("slice_name", "")
 
         # note: the API does not currently supply created_by usernames due to a bug, but we are required to


### PR DESCRIPTION
Previous values were in seconds, which rendered incorrectly in the UI:

![image](https://user-images.githubusercontent.com/12566801/124336632-998f3580-db53-11eb-8e43-370cd04115dc.png)

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
