### PR TITLE
feat (helm datahub-gms): add ingress template to datahub-gms helm chart

### DIFF
--- a/datahub-kubernetes/datahub/Chart.yaml
+++ b/datahub-kubernetes/datahub/Chart.yaml
@@ -4,13 +4,13 @@ description: A Helm chart for LinkedIn DataHub
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.3
+version: 0.2.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 0.8.5 #0.3.1
 dependencies:
   - name: datahub-gms
-    version: 0.2.1
+    version: 0.2.2
     repository: file://./charts/datahub-gms
     condition: datahub-gms.enabled
   - name: datahub-frontend

--- a/datahub-kubernetes/datahub/charts/datahub-gms/Chart.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-gms/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/datahub-kubernetes/datahub/charts/datahub-gms/templates/ingress.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-gms/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := printf "%s-%s" .Release.Name "datahub-gms"}}
+{{- $svcPort := .Values.global.datahub.gms.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName}}
+  labels:
+    {{- include "datahub-gms.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .redirectPaths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .name }}
+              servicePort: {{ .port }}
+        {{- end }}
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/datahub-kubernetes/datahub/charts/datahub-gms/values.yaml
+++ b/datahub-kubernetes/datahub/charts/datahub-gms/values.yaml
@@ -51,6 +51,7 @@ ingress:
   hosts:
     - host: chart-example.local
       paths: []
+      redirectPaths: []
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Add ingress template for helm chart to enable access from outside the cluster
Linked issue: https://github.com/linkedin/datahub/issues/2831

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
