### PR TITLE
fix(ingest): avoid setting timestamps unless source system provides it

### DIFF
--- a/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
@@ -56,7 +56,7 @@ export default function ChartHeader({
                 urn={urn}
             />
             <AvatarsGroup owners={ownership?.owners} entityRegistry={entityRegistry} size="large" />
-            {info?.lastModified && (
+            {info?.lastModified?.time && (
                 <Typography.Text type="secondary">
                     Last modified at {new Date(info?.lastModified.time).toLocaleDateString('en-US')}
                 </Typography.Text>

--- a/datahub-web-react/src/app/entity/shared/Ownership.tsx
+++ b/datahub-web-react/src/app/entity/shared/Ownership.tsx
@@ -315,9 +315,11 @@ export const Ownership: React.FC<Props> = ({ owners, lastModifiedAt, updateOwner
 
     return (
         <>
-            <UpdatedText>
-                Last updated <b>{new Date(lastModifiedAt).toLocaleDateString('en-US')}</b>
-            </UpdatedText>
+            {lastModified && (
+                <UpdatedText>
+                    Last updated <b>{new Date(lastModifiedAt).toLocaleDateString('en-US')}</b>
+                </UpdatedText>
+            )}
             <Space direction="vertical" style={{ width: '100%' }} size="middle">
                 <Typography.Title level={3}>Ownership</Typography.Title>
                 <Typography.Paragraph>

--- a/datahub-web-react/src/app/entity/shared/Ownership.tsx
+++ b/datahub-web-react/src/app/entity/shared/Ownership.tsx
@@ -315,7 +315,7 @@ export const Ownership: React.FC<Props> = ({ owners, lastModifiedAt, updateOwner
 
     return (
         <>
-            {lastModified && (
+            {lastModifiedAt && (
                 <UpdatedText>
                     Last updated <b>{new Date(lastModifiedAt).toLocaleDateString('en-US')}</b>
                 </UpdatedText>

--- a/gms/api/src/main/snapshot/com.linkedin.chart.charts.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.chart.charts.snapshot.json
@@ -133,11 +133,19 @@
               "optional" : true
             } ]
           },
-          "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+          "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+          "default" : {
+            "actor" : "urn:li:corpuser:unknown",
+            "time" : 0
+          }
         }, {
           "name" : "lastModified",
           "type" : "AuditStamp",
-          "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+          "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+          "default" : {
+            "actor" : "urn:li:corpuser:unknown",
+            "time" : 0
+          }
         }, {
           "name" : "deleted",
           "type" : "AuditStamp",
@@ -459,7 +467,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.dashboard.dashboards.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dashboard.dashboards.snapshot.json
@@ -70,11 +70,19 @@
     "fields" : [ {
       "name" : "created",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "deleted",
       "type" : "AuditStamp",
@@ -322,7 +330,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.dataflow.dataFlows.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataflow.dataFlows.snapshot.json
@@ -60,11 +60,19 @@
     "fields" : [ {
       "name" : "created",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "deleted",
       "type" : "AuditStamp",
@@ -284,7 +292,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.datajob.dataJobs.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.datajob.dataJobs.snapshot.json
@@ -60,11 +60,19 @@
     "fields" : [ {
       "name" : "created",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "deleted",
       "type" : "AuditStamp",
@@ -352,7 +360,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.dataprocess.dataProcesses.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataprocess.dataProcesses.snapshot.json
@@ -200,7 +200,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
@@ -1143,7 +1143,12 @@
               "fields" : [ {
                 "name" : "auditStamp",
                 "type" : "com.linkedin.common.AuditStamp",
-                "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
+                "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+                "default" : {
+                  "actor" : "urn:li:corpuser:unknown",
+                  "time" : 0
+                },
+                "deprecated" : "we no longer associate a timestamp per upstream edge"
               }, {
                 "name" : "dataset",
                 "type" : "com.linkedin.common.DatasetUrn",

--- a/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.dataset.datasets.snapshot.json
@@ -94,11 +94,19 @@
     "fields" : [ {
       "name" : "created",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "deleted",
       "type" : "AuditStamp",
@@ -477,7 +485,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"
@@ -1131,7 +1143,7 @@
               "fields" : [ {
                 "name" : "auditStamp",
                 "type" : "com.linkedin.common.AuditStamp",
-                "doc" : "Audit stamp containing who reported the lineage and when"
+                "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
               }, {
                 "name" : "dataset",
                 "type" : "com.linkedin.common.DatasetUrn",

--- a/gms/api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -133,11 +133,19 @@
               "optional" : true
             } ]
           },
-          "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+          "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+          "default" : {
+            "actor" : "urn:li:corpuser:unknown",
+            "time" : 0
+          }
         }, {
           "name" : "lastModified",
           "type" : "AuditStamp",
-          "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+          "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+          "default" : {
+            "actor" : "urn:li:corpuser:unknown",
+            "time" : 0
+          }
         }, {
           "name" : "deleted",
           "type" : "AuditStamp",
@@ -784,7 +792,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"
@@ -1136,7 +1148,7 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when"
+      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",

--- a/gms/api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1148,7 +1148,12 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
+      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      },
+      "deprecated" : "we no longer associate a timestamp per upstream edge"
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",

--- a/gms/api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -1624,7 +1624,12 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
+      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      },
+      "deprecated" : "we no longer associate a timestamp per upstream edge"
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",

--- a/gms/api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -133,11 +133,19 @@
               "optional" : true
             } ]
           },
-          "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+          "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+          "default" : {
+            "actor" : "urn:li:corpuser:unknown",
+            "time" : 0
+          }
         }, {
           "name" : "lastModified",
           "type" : "AuditStamp",
-          "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+          "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+          "default" : {
+            "actor" : "urn:li:corpuser:unknown",
+            "time" : 0
+          }
         }, {
           "name" : "deleted",
           "type" : "AuditStamp",
@@ -1040,7 +1048,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"
@@ -1612,7 +1624,7 @@
     "fields" : [ {
       "name" : "auditStamp",
       "type" : "com.linkedin.common.AuditStamp",
-      "doc" : "Audit stamp containing who reported the lineage and when"
+      "doc" : "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
     }, {
       "name" : "dataset",
       "type" : "com.linkedin.common.DatasetUrn",

--- a/gms/api/src/main/snapshot/com.linkedin.glossary.glossaryNodes.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.glossary.glossaryNodes.snapshot.json
@@ -142,7 +142,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.glossary.glossaryTerms.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.glossary.glossaryTerms.snapshot.json
@@ -169,7 +169,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.ml.mlModels.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.ml.mlModels.snapshot.json
@@ -60,11 +60,19 @@
     "fields" : [ {
       "name" : "created",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "deleted",
       "type" : "AuditStamp",
@@ -434,7 +442,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/gms/api/src/main/snapshot/com.linkedin.tag.tags.snapshot.json
+++ b/gms/api/src/main/snapshot/com.linkedin.tag.tags.snapshot.json
@@ -38,11 +38,19 @@
     "fields" : [ {
       "name" : "created",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+      "doc" : "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+      "doc" : "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     }, {
       "name" : "deleted",
       "type" : "AuditStamp",
@@ -134,7 +142,11 @@
     }, {
       "name" : "lastModified",
       "type" : "AuditStamp",
-      "doc" : "Audit stamp containing who last modified the record and when."
+      "doc" : "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+      "default" : {
+        "actor" : "urn:li:corpuser:unknown",
+        "time" : 0
+      }
     } ],
     "Aspect" : {
       "name" : "ownership"

--- a/li-utils/src/main/pegasus/com/linkedin/common/ChangeAuditStamps.pdl
+++ b/li-utils/src/main/pegasus/com/linkedin/common/ChangeAuditStamps.pdl
@@ -6,14 +6,20 @@ namespace com.linkedin.common
 record ChangeAuditStamps {
 
   /**
-   * An AuditStamp corresponding to the creation of this resource/association/sub-resource
+   * An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.
    */
-  created: AuditStamp
+  created: AuditStamp = {
+    "time": 0,
+    "actor": "urn:li:corpuser:unknown"
+  }
 
   /**
-   * An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created
+   * An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.
    */
-  lastModified: AuditStamp
+  lastModified: AuditStamp = {
+    "time": 0,
+    "actor": "urn:li:corpuser:unknown"
+  }
 
   /**
    * An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics.

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -37,7 +37,7 @@ framework_common = {
     "entrypoints",
     "docker",
     "expandvars>=0.6.5",
-    "avro-gen3==0.5.1",
+    "avro-gen3==0.5.2",
     "avro-python3>=1.8.2",
     "python-dateutil",
 }

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -37,7 +37,7 @@ framework_common = {
     "entrypoints",
     "docker",
     "expandvars>=0.6.5",
-    "avro-gen3==0.5.2",
+    "avro-gen3==0.5.3",
     "avro-python3>=1.8.2",
     "python-dateutil",
 }

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -37,7 +37,7 @@ framework_common = {
     "entrypoints",
     "docker",
     "expandvars>=0.6.5",
-    "avro-gen3==0.5.0",
+    "avro-gen3==0.5.1",
     "avro-python3>=1.8.2",
     "python-dateutil",
 }

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -4,7 +4,6 @@ import time
 from typing import List, Optional, Type, TypeVar
 
 from datahub.metadata.schema_classes import (
-    AuditStampClass,
     DatasetLineageTypeClass,
     DatasetSnapshotClass,
     MetadataChangeEventClass,
@@ -20,6 +19,7 @@ T = TypeVar("T")
 
 
 def get_sys_time() -> int:
+    # TODO deprecate this
     return int(time.time() * 1000)
 
 
@@ -76,11 +76,8 @@ def make_ml_feature_table_urn(platform: str, feature_table_name: str) -> str:
 def make_lineage_mce(
     upstream_urns: List[str],
     downstream_urn: str,
-    actor: str = make_user_urn("datahub"),
     lineage_type: str = DatasetLineageTypeClass.TRANSFORMED,
 ) -> MetadataChangeEventClass:
-    sys_time = get_sys_time()
-
     mce = MetadataChangeEventClass(
         proposedSnapshot=DatasetSnapshotClass(
             urn=downstream_urn,
@@ -88,10 +85,6 @@ def make_lineage_mce(
                 UpstreamLineageClass(
                     upstreams=[
                         UpstreamClass(
-                            auditStamp=AuditStampClass(
-                                time=sys_time,
-                                actor=actor,
-                            ),
                             dataset=upstream_urn,
                             type=lineage_type,
                         )

--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -6,7 +6,7 @@ import dateutil.parser
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import AllowDenyPattern
-from datahub.emitter.mce_builder import DEFAULT_ENV, get_sys_time
+from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -260,13 +260,9 @@ def get_upstreams(
 def get_upstream_lineage(upstream_urns: List[str]) -> UpstreamLineage:
     ucl: List[UpstreamClass] = []
 
-    actor = "urn:li:corpuser:dbt_executor"
-    sys_time = get_sys_time()
-
     for dep in upstream_urns:
         uc = UpstreamClass(
             dataset=dep,
-            auditStamp=AuditStamp(actor=actor, time=sys_time),
             type=DatasetLineageTypeClass.TRANSFORMED,
         )
         ucl.append(uc)
@@ -330,14 +326,12 @@ def get_schema_metadata(
 
         canonical_schema.append(field)
 
-    actor = "urn:li:corpuser:dbt_executor"
-    sys_time = get_sys_time()
-
-    last_modified = sys_time
-
+    last_modified = None
     if node.max_loaded_at is not None:
-        last_modified = int(
-            dateutil.parser.parse(node.max_loaded_at).timestamp() * 1000
+        actor = "urn:li:corpuser:dbt_executor"
+        last_modified = AuditStamp(
+            time=int(dateutil.parser.parse(node.max_loaded_at).timestamp() * 1000),
+            actor=actor,
         )
 
     return SchemaMetadata(
@@ -346,8 +340,7 @@ def get_schema_metadata(
         version=0,
         hash="",
         platformSchema=MySqlDDL(tableSchema=""),
-        created=AuditStamp(time=sys_time, actor=actor),
-        lastModified=AuditStamp(time=last_modified, actor=actor),
+        lastModified=last_modified,
         fields=canonical_schema,
     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -9,11 +9,11 @@ import datahub.ingestion.extractor.schema_util as schema_util
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import AllowDenyPattern
 from datahub.configuration.kafka import KafkaConsumerConnectionConfig
-from datahub.emitter.mce_builder import DEFAULT_ENV, get_sys_time
+from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.com.linkedin.pegasus2avro.common import AuditStamp, Status
+from datahub.metadata.com.linkedin.pegasus2avro.common import Status
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
@@ -87,8 +87,6 @@ class KafkaSource(Source):
         logger.debug(f"topic = {topic}")
         platform = "kafka"
         dataset_name = topic
-        actor = "urn:li:corpuser:etl"
-        sys_time = get_sys_time()
 
         dataset_snapshot = DatasetSnapshot(
             urn=f"urn:li:dataset:(urn:li:dataPlatform:{platform},{dataset_name},{self.source_config.env})",
@@ -124,8 +122,6 @@ class KafkaSource(Source):
                 platform=f"urn:li:dataPlatform:{platform}",
                 platformSchema=KafkaSchema(documentSchema=schema.schema_str),
                 fields=fields,
-                created=AuditStamp(time=sys_time, actor=actor),
-                lastModified=AuditStamp(time=sys_time, actor=actor),
             )
             dataset_snapshot.aspects.append(schema_metadata)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -345,10 +345,6 @@ class KafkaConnectSource(Source):
                                             self.config.env,
                                         ),
                                         type=models.DatasetLineageTypeClass.TRANSFORMED,
-                                        auditStamp=models.AuditStampClass(
-                                            time=builder.get_sys_time(),
-                                            actor="urn:li:corpuser:datahub",
-                                        ),
                                     )
                                 ]
                             )

--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -17,22 +17,17 @@ from looker_sdk.sdk.api31.models import (
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import AllowDenyPattern
-from datahub.emitter.mce_builder import DEFAULT_ENV, get_sys_time
+from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.com.linkedin.pegasus2avro.common import (
-    AuditStamp,
-    ChangeAuditStamps,
-    Status,
-)
+from datahub.metadata.com.linkedin.pegasus2avro.common import ChangeAuditStamps, Status
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import (
     ChartSnapshot,
     DashboardSnapshot,
 )
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.schema_classes import (
-    AuditStampClass,
     ChartInfoClass,
     ChartTypeClass,
     DashboardInfoClass,
@@ -303,30 +298,19 @@ class LookerDashboardSource(Source):
     def _make_chart_mce(
         self, dashboard_element: LookerDashboardElement
     ) -> MetadataChangeEvent:
-        actor = self.source_config.actor
-        sys_time = get_sys_time()
         chart_urn = f"urn:li:chart:({self.source_config.platform_name},{dashboard_element.get_urn_element_id()})"
         chart_snapshot = ChartSnapshot(
             urn=chart_urn,
             aspects=[],
         )
 
-        last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=sys_time, actor=actor),
-            lastModified=AuditStamp(time=sys_time, actor=actor),
-        )
-
         chart_type = self._get_chart_type(dashboard_element)
 
         chart_info = ChartInfoClass(
             type=chart_type,
-            description=dashboard_element.description
-            if dashboard_element.description is not None
-            else "",
-            title=dashboard_element.title
-            if dashboard_element.title is not None
-            else "",
-            lastModified=last_modified,
+            description=dashboard_element.description or "",
+            title=dashboard_element.title or "",
+            lastModified=ChangeAuditStamps(),
             chartUrl=dashboard_element.url(self.source_config.base_url),
             inputs=dashboard_element.get_view_urns(self.source_config.platform_name),
         )
@@ -338,7 +322,6 @@ class LookerDashboardSource(Source):
         self, looker_dashboard: LookerDashboard
     ) -> List[MetadataChangeEvent]:
         actor = self.source_config.actor
-        sys_time = get_sys_time()
 
         chart_mces = [
             self._make_chart_mce(element)
@@ -351,18 +334,11 @@ class LookerDashboardSource(Source):
             aspects=[],
         )
 
-        last_modified = ChangeAuditStamps(
-            created=AuditStamp(time=sys_time, actor=actor),
-            lastModified=AuditStamp(time=sys_time, actor=actor),
-        )
-
         dashboard_info = DashboardInfoClass(
-            description=looker_dashboard.description
-            if looker_dashboard.description is not None
-            else "",
+            description=looker_dashboard.description or "",
             title=looker_dashboard.title,
             charts=[mce.proposedSnapshot.urn for mce in chart_mces],
-            lastModified=last_modified,
+            lastModified=ChangeAuditStamps(),
             dashboardUrl=looker_dashboard.url(self.source_config.base_url),
         )
 
@@ -371,9 +347,6 @@ class LookerDashboardSource(Source):
         dashboard_snapshot.aspects.append(
             OwnershipClass(
                 owners=owners,
-                lastModified=AuditStampClass(
-                    time=sys_time, actor=self.source_config.actor
-                ),
             )
         )
         dashboard_snapshot.aspects.append(Status(removed=looker_dashboard.is_deleted))

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -17,11 +17,11 @@ from sql_metadata import Parser as SQLParser
 
 from datahub.configuration import ConfigModel
 from datahub.configuration.common import AllowDenyPattern
-from datahub.emitter.mce_builder import DEFAULT_ENV, get_sys_time
+from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.com.linkedin.pegasus2avro.common import AuditStamp, Status
+from datahub.metadata.com.linkedin.pegasus2avro.common import Status
 from datahub.metadata.com.linkedin.pegasus2avro.dataset import (
     DatasetLineageTypeClass,
     UpstreamClass,
@@ -394,16 +394,13 @@ class LookMLSource(Source):  # pragma: no cover
                 f"Could not find a platform for looker view with connection: {connection}"
             )
 
-    def _get_upsteam_lineage(
-        self, looker_view: LookerView, actor: str, sys_time: int
-    ) -> UpstreamLineage:
+    def _get_upsteam_lineage(self, looker_view: LookerView) -> UpstreamLineage:
         upstreams = []
         for sql_table_name in looker_view.sql_table_names:
             upstream = UpstreamClass(
                 dataset=self._construct_datalineage_urn(
                     sql_table_name, looker_view.connection
                 ),
-                auditStamp=AuditStamp(actor=actor, time=sys_time),
                 type=DatasetLineageTypeClass.TRANSFORMED,
             )
             upstreams.append(upstream)
@@ -473,19 +470,14 @@ class LookMLSource(Source):  # pragma: no cover
                 primary_keys.append(schema_field.fieldPath)
         return fields, primary_keys
 
-    def _get_schema(
-        self, looker_view: LookerView, actor: str, sys_time: int
-    ) -> SchemaMetadataClass:
+    def _get_schema(self, looker_view: LookerView) -> SchemaMetadataClass:
         fields, primary_keys = self._get_fields_and_primary_keys(looker_view)
-        stamp = AuditStamp(time=sys_time, actor=actor)
         schema_metadata = SchemaMetadata(
             schemaName=looker_view.view_name,
             platform=f"urn:li:dataPlatform:{self.source_config.platform_name}",
             version=0,
             fields=fields,
             primaryKeys=primary_keys,
-            created=stamp,
-            lastModified=stamp,
             hash="",
             platformSchema=OtherSchema(rawSchema="looker-view"),
         )
@@ -496,20 +488,15 @@ class LookMLSource(Source):  # pragma: no cover
         Creates MetadataChangeEvent for the dataset, creating upstream lineage links
         """
         logger.debug(f"looker_view = {looker_view.view_name}")
-
         dataset_name = looker_view.view_name
-        actor = self.source_config.actor
-        sys_time = get_sys_time()
 
         dataset_snapshot = DatasetSnapshot(
             urn=f"urn:li:dataset:(urn:li:dataPlatform:{self.source_config.platform_name},{dataset_name},{self.source_config.env})",
             aspects=[],  # we append to this list later on
         )
         dataset_snapshot.aspects.append(Status(removed=False))
-        dataset_snapshot.aspects.append(
-            self._get_upsteam_lineage(looker_view, actor, sys_time)
-        )
-        dataset_snapshot.aspects.append(self._get_schema(looker_view, actor, sys_time))
+        dataset_snapshot.aspects.append(self._get_upsteam_lineage(looker_view))
+        dataset_snapshot.aspects.append(self._get_schema(looker_view))
 
         mce = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mongodb.py
@@ -11,11 +11,10 @@ from pydantic import PositiveInt
 from pymongo.mongo_client import MongoClient
 
 from datahub.configuration.common import AllowDenyPattern, ConfigModel
-from datahub.emitter.mce_builder import DEFAULT_ENV, get_sys_time
+from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.com.linkedin.pegasus2avro.common import AuditStamp
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
@@ -465,16 +464,12 @@ class MongoDBSource(Source):
                         canonical_schema.append(field)
 
                     # create schema metadata object for collection
-                    actor = "urn:li:corpuser:etl"
-                    sys_time = get_sys_time()
                     schema_metadata = SchemaMetadata(
                         schemaName=collection_name,
                         platform=f"urn:li:dataPlatform:{platform}",
                         version=0,
                         hash="",
                         platformSchema=SchemalessClass(),
-                        created=AuditStamp(time=sys_time, actor=actor),
-                        lastModified=AuditStamp(time=sys_time, actor=actor),
                         fields=canonical_schema,
                     )
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql_common.py
@@ -9,11 +9,10 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql import sqltypes as types
 
 from datahub.configuration.common import AllowDenyPattern, ConfigModel
-from datahub.emitter.mce_builder import DEFAULT_ENV, get_sys_time
+from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
-from datahub.metadata.com.linkedin.pegasus2avro.common import AuditStamp
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
@@ -214,16 +213,12 @@ def get_schema_metadata(
         )
         canonical_schema.append(field)
 
-    actor = "urn:li:corpuser:etl"
-    sys_time = get_sys_time()
     schema_metadata = SchemaMetadata(
         schemaName=dataset_name,
         platform=f"urn:li:dataPlatform:{platform}",
         version=0,
         hash="",
         platformSchema=MySqlDDL(tableSchema=""),
-        created=AuditStamp(time=sys_time, actor=actor),
-        lastModified=AuditStamp(time=sys_time, actor=actor),
         fields=canonical_schema,
     )
     return schema_metadata

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -5,7 +5,6 @@ from datahub.configuration.common import ConfigModel
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
 from datahub.ingestion.api.transform import Transformer
 from datahub.metadata.schema_classes import (
-    AuditStampClass,
     DatasetSnapshotClass,
     MetadataChangeEventClass,
     OwnerClass,

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -57,10 +57,6 @@ class AddDatasetOwnership(Transformer):
                 mce,
                 OwnershipClass(
                     owners=[],
-                    lastModified=AuditStampClass(
-                        time=builder.get_sys_time(),
-                        actor=self.config.default_actor,
-                    ),
                 ),
             )
             ownership.owners.extend(owners_to_add)

--- a/metadata-ingestion/src/datahub/metadata/schema.avsc
+++ b/metadata-ingestion/src/datahub/metadata/schema.avsc
@@ -230,12 +230,22 @@
                                   "doc": "Data captured on a resource/association/sub-resource level giving insight into when that resource/association/sub-resource moved into a particular lifecycle stage, and who acted to move it into that specific lifecycle stage."
                                 },
                                 "name": "created",
-                                "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                                "default": {
+                                  "actor": "urn:li:corpuser:unknown",
+                                  "impersonator": null,
+                                  "time": 0
+                                },
+                                "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                               },
                               {
                                 "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                                 "name": "lastModified",
-                                "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                                "default": {
+                                  "actor": "urn:li:corpuser:unknown",
+                                  "impersonator": null,
+                                  "time": 0
+                                },
+                                "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                               },
                               {
                                 "type": [
@@ -409,12 +419,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [
@@ -568,7 +588,12 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "Audit stamp containing who last modified the record and when."
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data."
                         }
                       ],
                       "doc": "Ownership information of an entity."
@@ -1199,12 +1224,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [
@@ -1380,12 +1415,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [
@@ -1678,12 +1723,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [
@@ -1881,12 +1936,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [
@@ -2062,7 +2127,7 @@
                                 {
                                   "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                                   "name": "auditStamp",
-                                  "doc": "Audit stamp containing who reported the lineage and when"
+                                  "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
                                 },
                                 {
                                   "Relationship": {
@@ -2195,12 +2260,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [
@@ -2751,12 +2826,22 @@
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "created",
-                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                           "name": "lastModified",
-                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                          "default": {
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null,
+                            "time": 0
+                          },
+                          "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."
                         },
                         {
                           "type": [

--- a/metadata-ingestion/src/datahub/metadata/schema.avsc
+++ b/metadata-ingestion/src/datahub/metadata/schema.avsc
@@ -2125,8 +2125,14 @@
                               "namespace": "com.linkedin.pegasus2avro.dataset",
                               "fields": [
                                 {
+                                  "deprecated": "we no longer associate a timestamp per upstream edge",
                                   "type": "com.linkedin.pegasus2avro.common.AuditStamp",
                                   "name": "auditStamp",
+                                  "default": {
+                                    "actor": "urn:li:corpuser:unknown",
+                                    "impersonator": null,
+                                    "time": 0
+                                  },
                                   "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
                                 },
                                 {

--- a/metadata-ingestion/src/datahub/metadata/schema_classes.py
+++ b/metadata-ingestion/src/datahub/metadata/schema_classes.py
@@ -198,7 +198,7 @@ class ChartInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
         self.externalUrl = externalUrl
@@ -453,11 +453,11 @@ class EditableChartPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -471,8 +471,8 @@ class EditableChartPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(EditableChartPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableChartPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(EditableChartPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableChartPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
@@ -650,11 +650,11 @@ class ChangeAuditStampsClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -667,8 +667,8 @@ class ChangeAuditStampsClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(ChangeAuditStampsClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=ChangeAuditStampsClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(ChangeAuditStampsClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=ChangeAuditStampsClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
     
     
@@ -1287,7 +1287,7 @@ class OwnershipClass(DictWrapper):
         
         self.owners = owners
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
     
@@ -1300,7 +1300,7 @@ class OwnershipClass(DictWrapper):
     
     def _restore_defaults(self) -> None:
         self.owners = list()
-        self.lastModified = _json_converter.from_json_object(OwnershipClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=OwnershipClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
     
     
     @property
@@ -1438,7 +1438,7 @@ class StatusClass(DictWrapper):
         super().__init__()
         
         if removed is None:
-            self.removed = False
+            self.removed = self.RECORD_SCHEMA.field_map["removed"].default
         else:
             self.removed = removed
     
@@ -1607,14 +1607,14 @@ class DashboardInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
         self.externalUrl = externalUrl
         self.title = title
         self.description = description
         if charts is None:
-            self.charts = []
+            self.charts = list()
         else:
             self.charts = charts
         self.lastModified = lastModified
@@ -1763,11 +1763,11 @@ class EditableDashboardPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -1781,8 +1781,8 @@ class EditableDashboardPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
@@ -1849,7 +1849,7 @@ class DataFlowInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
         self.externalUrl = externalUrl
@@ -1947,7 +1947,7 @@ class DataJobInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
         self.externalUrl = externalUrl
@@ -2122,11 +2122,11 @@ class EditableDataFlowPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -2140,8 +2140,8 @@ class EditableDataFlowPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
@@ -2208,11 +2208,11 @@ class EditableDataJobPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -2226,8 +2226,8 @@ class EditableDataJobPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
@@ -2670,14 +2670,14 @@ class DatasetPropertiesClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
         self.externalUrl = externalUrl
         self.description = description
         self.uri = uri
         if tags is None:
-            self.tags = []
+            self.tags = list()
         else:
             self.tags = tags
     
@@ -2804,11 +2804,11 @@ class EditableDatasetPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -2822,8 +2822,8 @@ class EditableDatasetPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
@@ -2881,13 +2881,16 @@ class UpstreamClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.dataset.Upstream")
     def __init__(self,
-        auditStamp: "AuditStampClass",
         dataset: str,
         type: Union[str, "DatasetLineageTypeClass"],
+        auditStamp: Optional["AuditStampClass"]=None,
     ):
         super().__init__()
         
-        self.auditStamp = auditStamp
+        if auditStamp is None:
+            self.auditStamp = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["auditStamp"].default, writers_schema=self.RECORD_SCHEMA.field_map["auditStamp"].type)
+        else:
+            self.auditStamp = auditStamp
         self.dataset = dataset
         self.type = type
     
@@ -2899,7 +2902,7 @@ class UpstreamClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.auditStamp = AuditStampClass.construct_with_defaults()
+        self.auditStamp = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["auditStamp"].default, writers_schema=self.RECORD_SCHEMA.field_map["auditStamp"].type)
         self.dataset = str()
         self.type = DatasetLineageTypeClass.COPY
     
@@ -3045,7 +3048,7 @@ class GlossaryTermInfoClass(DictWrapper):
         self.sourceRef = sourceRef
         self.sourceUrl = sourceUrl
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
     
@@ -3230,15 +3233,15 @@ class CorpUserEditableInfoClass(DictWrapper):
         
         self.aboutMe = aboutMe
         if teams is None:
-            self.teams = []
+            self.teams = list()
         else:
             self.teams = teams
         if skills is None:
-            self.skills = []
+            self.skills = list()
         else:
             self.skills = skills
         if pictureLink is None:
-            self.pictureLink = 'https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web/packages/data-portal/public/assets/images/default_avatar.png'
+            self.pictureLink = self.RECORD_SCHEMA.field_map["pictureLink"].default
         else:
             self.pictureLink = pictureLink
     
@@ -5514,7 +5517,7 @@ class MLFeatureTablePropertiesClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
-            self.customProperties = {}
+            self.customProperties = dict()
         else:
             self.customProperties = customProperties
         self.description = description
@@ -5724,7 +5727,7 @@ class MLModelPropertiesClass(DictWrapper):
         self.hyperParameters = hyperParameters
         self.mlFeatures = mlFeatures
         if tags is None:
-            self.tags = []
+            self.tags = list()
         else:
             self.tags = tags
     
@@ -6529,11 +6532,11 @@ class EditableSchemaMetadataClass(DictWrapper):
         super().__init__()
         
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -6547,8 +6550,8 @@ class EditableSchemaMetadataClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = _json_converter.from_json_object(EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.editableSchemaFieldInfo = list()
     
@@ -7106,14 +7109,14 @@ class SchemaFieldClass(DictWrapper):
         self.fieldPath = fieldPath
         self.jsonPath = jsonPath
         if nullable is None:
-            self.nullable = False
+            self.nullable = self.RECORD_SCHEMA.field_map["nullable"].default
         else:
             self.nullable = nullable
         self.description = description
         self.type = type
         self.nativeDataType = nativeDataType
         if recursive is None:
-            self.recursive = False
+            self.recursive = self.RECORD_SCHEMA.field_map["recursive"].default
         else:
             self.recursive = recursive
         self.globalTags = globalTags
@@ -7305,11 +7308,11 @@ class SchemaMetadataClass(DictWrapper):
         self.platform = platform
         self.version = version
         if created is None:
-            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
-            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+            self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
         self.deleted = deleted
@@ -7332,8 +7335,8 @@ class SchemaMetadataClass(DictWrapper):
         self.schemaName = str()
         self.platform = str()
         self.version = int()
-        self.created = _json_converter.from_json_object(SchemaMetadataClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=SchemaMetadataClass.RECORD_SCHEMA.field_map["created"].type)
-        self.lastModified = _json_converter.from_json_object(SchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=SchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].type)
+        self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.dataset = self.RECORD_SCHEMA.field_map["dataset"].default
         self.cluster = self.RECORD_SCHEMA.field_map["cluster"].default

--- a/metadata-ingestion/src/datahub/metadata/schema_classes.py
+++ b/metadata-ingestion/src/datahub/metadata/schema_classes.py
@@ -88,7 +88,6 @@ class KafkaAuditHeaderClass(DictWrapper):
         """Getter: The time at which the event was emitted into kafka."""
         return self._inner_dict.get('time')  # type: ignore
     
-    
     @time.setter
     def time(self, value: int) -> None:
         """Setter: The time at which the event was emitted into kafka."""
@@ -99,7 +98,6 @@ class KafkaAuditHeaderClass(DictWrapper):
     def server(self) -> str:
         """Getter: The fully qualified name of the host from which the event is being emitted."""
         return self._inner_dict.get('server')  # type: ignore
-    
     
     @server.setter
     def server(self, value: str) -> None:
@@ -112,7 +110,6 @@ class KafkaAuditHeaderClass(DictWrapper):
         """Getter: The instance on the server from which the event is being emitted. e.g. i001"""
         return self._inner_dict.get('instance')  # type: ignore
     
-    
     @instance.setter
     def instance(self, value: Union[None, str]) -> None:
         """Setter: The instance on the server from which the event is being emitted. e.g. i001"""
@@ -123,7 +120,6 @@ class KafkaAuditHeaderClass(DictWrapper):
     def appName(self) -> str:
         """Getter: The name of the application from which the event is being emitted. see go/appname"""
         return self._inner_dict.get('appName')  # type: ignore
-    
     
     @appName.setter
     def appName(self, value: str) -> None:
@@ -136,7 +132,6 @@ class KafkaAuditHeaderClass(DictWrapper):
         """Getter: A unique identifier for the message"""
         return self._inner_dict.get('messageId')  # type: ignore
     
-    
     @messageId.setter
     def messageId(self, value: bytes) -> None:
         """Setter: A unique identifier for the message"""
@@ -147,7 +142,6 @@ class KafkaAuditHeaderClass(DictWrapper):
     def auditVersion(self) -> Union[None, int]:
         """Getter: The version that is being used for auditing. In version 0, the audit trail buckets events into 10 minute audit windows based on the EventHeader timestamp. In version 1, the audit trail buckets events as follows: if the schema has an outer KafkaAuditHeader, use the outer audit header timestamp for bucketing; else if the EventHeader has an inner KafkaAuditHeader use that inner audit header's timestamp for bucketing"""
         return self._inner_dict.get('auditVersion')  # type: ignore
-    
     
     @auditVersion.setter
     def auditVersion(self, value: Union[None, int]) -> None:
@@ -160,7 +154,6 @@ class KafkaAuditHeaderClass(DictWrapper):
         """Getter: The fabricUrn of the host from which the event is being emitted. Fabric Urn in the format of urn:li:fabric:{fabric_name}. See go/fabric."""
         return self._inner_dict.get('fabricUrn')  # type: ignore
     
-    
     @fabricUrn.setter
     def fabricUrn(self, value: Union[None, str]) -> None:
         """Setter: The fabricUrn of the host from which the event is being emitted. Fabric Urn in the format of urn:li:fabric:{fabric_name}. See go/fabric."""
@@ -171,7 +164,6 @@ class KafkaAuditHeaderClass(DictWrapper):
     def clusterConnectionString(self) -> Union[None, str]:
         """Getter: This is a String that the client uses to establish some kind of connection with the Kafka cluster. The exact format of it depends on specific versions of clients and brokers. This information could potentially identify the fabric and cluster with which the client is producing to or consuming from."""
         return self._inner_dict.get('clusterConnectionString')  # type: ignore
-    
     
     @clusterConnectionString.setter
     def clusterConnectionString(self, value: Union[None, str]) -> None:
@@ -198,6 +190,7 @@ class ChartInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -236,7 +229,6 @@ class ChartInfoClass(DictWrapper):
         """Getter: Custom property bag."""
         return self._inner_dict.get('customProperties')  # type: ignore
     
-    
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
         """Setter: Custom property bag."""
@@ -247,7 +239,6 @@ class ChartInfoClass(DictWrapper):
     def externalUrl(self) -> Union[None, str]:
         """Getter: URL where the reference exist"""
         return self._inner_dict.get('externalUrl')  # type: ignore
-    
     
     @externalUrl.setter
     def externalUrl(self, value: Union[None, str]) -> None:
@@ -260,7 +251,6 @@ class ChartInfoClass(DictWrapper):
         """Getter: Title of the chart"""
         return self._inner_dict.get('title')  # type: ignore
     
-    
     @title.setter
     def title(self, value: str) -> None:
         """Setter: Title of the chart"""
@@ -271,7 +261,6 @@ class ChartInfoClass(DictWrapper):
     def description(self) -> str:
         """Getter: Detailed description about the chart"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: str) -> None:
@@ -284,7 +273,6 @@ class ChartInfoClass(DictWrapper):
         """Getter: Captures information about who created/last modified/deleted this chart and when"""
         return self._inner_dict.get('lastModified')  # type: ignore
     
-    
     @lastModified.setter
     def lastModified(self, value: "ChangeAuditStampsClass") -> None:
         """Setter: Captures information about who created/last modified/deleted this chart and when"""
@@ -295,7 +283,6 @@ class ChartInfoClass(DictWrapper):
     def chartUrl(self) -> Union[None, str]:
         """Getter: URL for the chart. This could be used as an external link on DataHub to allow users access/view the chart"""
         return self._inner_dict.get('chartUrl')  # type: ignore
-    
     
     @chartUrl.setter
     def chartUrl(self, value: Union[None, str]) -> None:
@@ -308,7 +295,6 @@ class ChartInfoClass(DictWrapper):
         """Getter: Data sources for the chart"""
         return self._inner_dict.get('inputs')  # type: ignore
     
-    
     @inputs.setter
     def inputs(self, value: Union[None, List[str]]) -> None:
         """Setter: Data sources for the chart"""
@@ -319,7 +305,6 @@ class ChartInfoClass(DictWrapper):
     def type(self) -> Union[None, Union[str, "ChartTypeClass"]]:
         """Getter: Type of the chart"""
         return self._inner_dict.get('type')  # type: ignore
-    
     
     @type.setter
     def type(self, value: Union[None, Union[str, "ChartTypeClass"]]) -> None:
@@ -332,7 +317,6 @@ class ChartInfoClass(DictWrapper):
         """Getter: Access level for the chart"""
         return self._inner_dict.get('access')  # type: ignore
     
-    
     @access.setter
     def access(self, value: Union[None, Union[str, "AccessLevelClass"]]) -> None:
         """Setter: Access level for the chart"""
@@ -343,7 +327,6 @@ class ChartInfoClass(DictWrapper):
     def lastRefreshed(self) -> Union[None, int]:
         """Getter: The time when this chart last refreshed"""
         return self._inner_dict.get('lastRefreshed')  # type: ignore
-    
     
     @lastRefreshed.setter
     def lastRefreshed(self, value: Union[None, int]) -> None:
@@ -381,7 +364,6 @@ class ChartQueryClass(DictWrapper):
         """Getter: Raw query to build a chart from input datasets"""
         return self._inner_dict.get('rawQuery')  # type: ignore
     
-    
     @rawQuery.setter
     def rawQuery(self, value: str) -> None:
         """Setter: Raw query to build a chart from input datasets"""
@@ -392,7 +374,6 @@ class ChartQueryClass(DictWrapper):
     def type(self) -> Union[str, "ChartQueryTypeClass"]:
         """Getter: Chart query type"""
         return self._inner_dict.get('type')  # type: ignore
-    
     
     @type.setter
     def type(self, value: Union[str, "ChartQueryTypeClass"]) -> None:
@@ -453,10 +434,12 @@ class EditableChartPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -482,7 +465,6 @@ class EditableChartPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -493,7 +475,6 @@ class EditableChartPropertiesClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -506,7 +487,6 @@ class EditableChartPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
     
-    
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
         """Setter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
@@ -517,7 +497,6 @@ class EditableChartPropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Edited documentation of the chart """
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -569,7 +548,6 @@ class AuditStampClass(DictWrapper):
         """Getter: When did the resource/association/sub-resource move into the specific lifecycle stage represented by this AuditEvent."""
         return self._inner_dict.get('time')  # type: ignore
     
-    
     @time.setter
     def time(self, value: int) -> None:
         """Setter: When did the resource/association/sub-resource move into the specific lifecycle stage represented by this AuditEvent."""
@@ -581,7 +559,6 @@ class AuditStampClass(DictWrapper):
         """Getter: The entity (e.g. a member URN) which will be credited for moving the resource/association/sub-resource into the specific lifecycle stage. It is also the one used to authorize the change."""
         return self._inner_dict.get('actor')  # type: ignore
     
-    
     @actor.setter
     def actor(self, value: str) -> None:
         """Setter: The entity (e.g. a member URN) which will be credited for moving the resource/association/sub-resource into the specific lifecycle stage. It is also the one used to authorize the change."""
@@ -592,7 +569,6 @@ class AuditStampClass(DictWrapper):
     def impersonator(self) -> Union[None, str]:
         """Getter: The entity (e.g. a service URN) which performs the change on behalf of the Actor and must be authorized to act as the Actor."""
         return self._inner_dict.get('impersonator')  # type: ignore
-    
     
     @impersonator.setter
     def impersonator(self, value: Union[None, str]) -> None:
@@ -629,7 +605,6 @@ class BrowsePathsClass(DictWrapper):
     Browse paths are expected to be backslash-separated strings. For example: 'prod/snowflake/datasetName'"""
         return self._inner_dict.get('paths')  # type: ignore
     
-    
     @paths.setter
     def paths(self, value: List[str]) -> None:
         """Setter: A list of valid browse paths for the entity.
@@ -650,10 +625,12 @@ class ChangeAuditStampsClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -677,7 +654,6 @@ class ChangeAuditStampsClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -689,7 +665,6 @@ class ChangeAuditStampsClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
-    
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
@@ -700,7 +675,6 @@ class ChangeAuditStampsClass(DictWrapper):
     def deleted(self) -> Union[None, "AuditStampClass"]:
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
-    
     
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
@@ -738,7 +712,6 @@ class CostClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('costType')  # type: ignore
     
-    
     @costType.setter
     def costType(self, value: Union[str, "CostTypeClass"]) -> None:
         # No docs available.
@@ -749,7 +722,6 @@ class CostClass(DictWrapper):
     def cost(self) -> "CostCostClass":
         # No docs available.
         return self._inner_dict.get('cost')  # type: ignore
-    
     
     @cost.setter
     def cost(self, value: "CostCostClass") -> None:
@@ -790,7 +762,6 @@ class CostCostClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('costId')  # type: ignore
     
-    
     @costId.setter
     def costId(self, value: Union[None, float]) -> None:
         # No docs available.
@@ -802,7 +773,6 @@ class CostCostClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('costCode')  # type: ignore
     
-    
     @costCode.setter
     def costCode(self, value: Union[None, str]) -> None:
         # No docs available.
@@ -813,7 +783,6 @@ class CostCostClass(DictWrapper):
     def fieldDiscriminator(self) -> Union[str, "CostCostDiscriminatorClass"]:
         """Getter: Contains the name of the field that has its value set."""
         return self._inner_dict.get('fieldDiscriminator')  # type: ignore
-    
     
     @fieldDiscriminator.setter
     def fieldDiscriminator(self, value: Union[str, "CostCostDiscriminatorClass"]) -> None:
@@ -872,7 +841,6 @@ class DeprecationClass(DictWrapper):
         """Getter: Whether the entity is deprecated."""
         return self._inner_dict.get('deprecated')  # type: ignore
     
-    
     @deprecated.setter
     def deprecated(self, value: bool) -> None:
         """Setter: Whether the entity is deprecated."""
@@ -883,7 +851,6 @@ class DeprecationClass(DictWrapper):
     def decommissionTime(self) -> Union[None, int]:
         """Getter: The time user plan to decommission this entity."""
         return self._inner_dict.get('decommissionTime')  # type: ignore
-    
     
     @decommissionTime.setter
     def decommissionTime(self, value: Union[None, int]) -> None:
@@ -896,7 +863,6 @@ class DeprecationClass(DictWrapper):
         """Getter: Additional information about the entity deprecation plan, such as the wiki, doc, RB."""
         return self._inner_dict.get('note')  # type: ignore
     
-    
     @note.setter
     def note(self, value: str) -> None:
         """Setter: Additional information about the entity deprecation plan, such as the wiki, doc, RB."""
@@ -907,7 +873,6 @@ class DeprecationClass(DictWrapper):
     def actor(self) -> str:
         """Getter: The corpuser URN which will be credited for modifying this deprecation content."""
         return self._inner_dict.get('actor')  # type: ignore
-    
     
     @actor.setter
     def actor(self, value: str) -> None:
@@ -959,7 +924,6 @@ class GlobalTagsClass(DictWrapper):
         """Getter: Tags associated with a given entity"""
         return self._inner_dict.get('tags')  # type: ignore
     
-    
     @tags.setter
     def tags(self, value: List["TagAssociationClass"]) -> None:
         """Setter: Tags associated with a given entity"""
@@ -992,7 +956,6 @@ class GlossaryTermAssociationClass(DictWrapper):
     def urn(self) -> str:
         """Getter: Urn of the applied glossary term"""
         return self._inner_dict.get('urn')  # type: ignore
-    
     
     @urn.setter
     def urn(self, value: str) -> None:
@@ -1030,7 +993,6 @@ class GlossaryTermsClass(DictWrapper):
         """Getter: The related business terms"""
         return self._inner_dict.get('terms')  # type: ignore
     
-    
     @terms.setter
     def terms(self, value: List["GlossaryTermAssociationClass"]) -> None:
         """Setter: The related business terms"""
@@ -1041,7 +1003,6 @@ class GlossaryTermsClass(DictWrapper):
     def auditStamp(self) -> "AuditStampClass":
         """Getter: Audit stamp containing who reported the related business term"""
         return self._inner_dict.get('auditStamp')  # type: ignore
-    
     
     @auditStamp.setter
     def auditStamp(self, value: "AuditStampClass") -> None:
@@ -1075,7 +1036,6 @@ class InstitutionalMemoryClass(DictWrapper):
     def elements(self) -> List["InstitutionalMemoryMetadataClass"]:
         """Getter: List of records that represent institutional memory of an entity. Each record consists of a link, description, creator and timestamps associated with that record."""
         return self._inner_dict.get('elements')  # type: ignore
-    
     
     @elements.setter
     def elements(self, value: List["InstitutionalMemoryMetadataClass"]) -> None:
@@ -1116,7 +1076,6 @@ class InstitutionalMemoryMetadataClass(DictWrapper):
         """Getter: Link to an engineering design document or a wiki page."""
         return self._inner_dict.get('url')  # type: ignore
     
-    
     @url.setter
     def url(self, value: str) -> None:
         """Setter: Link to an engineering design document or a wiki page."""
@@ -1128,7 +1087,6 @@ class InstitutionalMemoryMetadataClass(DictWrapper):
         """Getter: Description of the link."""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: str) -> None:
         """Setter: Description of the link."""
@@ -1139,7 +1097,6 @@ class InstitutionalMemoryMetadataClass(DictWrapper):
     def createStamp(self) -> "AuditStampClass":
         """Getter: Audit stamp associated with creation of this record"""
         return self._inner_dict.get('createStamp')  # type: ignore
-    
     
     @createStamp.setter
     def createStamp(self, value: "AuditStampClass") -> None:
@@ -1243,7 +1200,6 @@ class OwnerClass(DictWrapper):
     (Caveat: only corpuser is currently supported in the frontend.)"""
         return self._inner_dict.get('owner')  # type: ignore
     
-    
     @owner.setter
     def owner(self, value: str) -> None:
         """Setter: Owner URN, e.g. urn:li:corpuser:ldap, urn:li:corpGroup:group_name, and urn:li:multiProduct:mp_name
@@ -1256,7 +1212,6 @@ class OwnerClass(DictWrapper):
         """Getter: The type of the ownership"""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: Union[str, "OwnershipTypeClass"]) -> None:
         """Setter: The type of the ownership"""
@@ -1267,7 +1222,6 @@ class OwnerClass(DictWrapper):
     def source(self) -> Union[None, "OwnershipSourceClass"]:
         """Getter: Source information for the ownership"""
         return self._inner_dict.get('source')  # type: ignore
-    
     
     @source.setter
     def source(self, value: Union[None, "OwnershipSourceClass"]) -> None:
@@ -1287,6 +1241,7 @@ class OwnershipClass(DictWrapper):
         
         self.owners = owners
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -1308,7 +1263,6 @@ class OwnershipClass(DictWrapper):
         """Getter: List of owners of the entity."""
         return self._inner_dict.get('owners')  # type: ignore
     
-    
     @owners.setter
     def owners(self, value: List["OwnerClass"]) -> None:
         """Setter: List of owners of the entity."""
@@ -1319,7 +1273,6 @@ class OwnershipClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -1357,7 +1310,6 @@ class OwnershipSourceClass(DictWrapper):
         """Getter: The type of the source"""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: Union[str, "OwnershipSourceTypeClass"]) -> None:
         """Setter: The type of the source"""
@@ -1368,7 +1320,6 @@ class OwnershipSourceClass(DictWrapper):
     def url(self) -> Union[None, str]:
         """Getter: A reference URL for the source"""
         return self._inner_dict.get('url')  # type: ignore
-    
     
     @url.setter
     def url(self, value: Union[None, str]) -> None:
@@ -1438,6 +1389,7 @@ class StatusClass(DictWrapper):
         super().__init__()
         
         if removed is None:
+            # default: False
             self.removed = self.RECORD_SCHEMA.field_map["removed"].default
         else:
             self.removed = removed
@@ -1457,7 +1409,6 @@ class StatusClass(DictWrapper):
     def removed(self) -> bool:
         """Getter: whether the entity is removed or not"""
         return self._inner_dict.get('removed')  # type: ignore
-    
     
     @removed.setter
     def removed(self, value: bool) -> None:
@@ -1493,7 +1444,6 @@ class TagAssociationClass(DictWrapper):
         """Getter: Urn of the applied tag"""
         return self._inner_dict.get('tag')  # type: ignore
     
-    
     @tag.setter
     def tag(self, value: str) -> None:
         """Setter: Urn of the applied tag"""
@@ -1526,7 +1476,6 @@ class VersionTagClass(DictWrapper):
     def versionTag(self) -> Union[None, str]:
         # No docs available.
         return self._inner_dict.get('versionTag')  # type: ignore
-    
     
     @versionTag.setter
     def versionTag(self, value: Union[None, str]) -> None:
@@ -1582,7 +1531,6 @@ class UDFTransformerClass(DictWrapper):
         """Getter: A UDF mentioning how the source fields got transformed to destination field. This is the FQCN(Fully Qualified Class Name) of the udf."""
         return self._inner_dict.get('udf')  # type: ignore
     
-    
     @udf.setter
     def udf(self, value: str) -> None:
         """Setter: A UDF mentioning how the source fields got transformed to destination field. This is the FQCN(Fully Qualified Class Name) of the udf."""
@@ -1607,6 +1555,7 @@ class DashboardInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -1614,6 +1563,7 @@ class DashboardInfoClass(DictWrapper):
         self.title = title
         self.description = description
         if charts is None:
+            # default: []
             self.charts = list()
         else:
             self.charts = charts
@@ -1646,7 +1596,6 @@ class DashboardInfoClass(DictWrapper):
         """Getter: Custom property bag."""
         return self._inner_dict.get('customProperties')  # type: ignore
     
-    
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
         """Setter: Custom property bag."""
@@ -1657,7 +1606,6 @@ class DashboardInfoClass(DictWrapper):
     def externalUrl(self) -> Union[None, str]:
         """Getter: URL where the reference exist"""
         return self._inner_dict.get('externalUrl')  # type: ignore
-    
     
     @externalUrl.setter
     def externalUrl(self, value: Union[None, str]) -> None:
@@ -1670,7 +1618,6 @@ class DashboardInfoClass(DictWrapper):
         """Getter: Title of the dashboard"""
         return self._inner_dict.get('title')  # type: ignore
     
-    
     @title.setter
     def title(self, value: str) -> None:
         """Setter: Title of the dashboard"""
@@ -1681,7 +1628,6 @@ class DashboardInfoClass(DictWrapper):
     def description(self) -> str:
         """Getter: Detailed description about the dashboard"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: str) -> None:
@@ -1694,7 +1640,6 @@ class DashboardInfoClass(DictWrapper):
         """Getter: Charts in a dashboard"""
         return self._inner_dict.get('charts')  # type: ignore
     
-    
     @charts.setter
     def charts(self, value: List[str]) -> None:
         """Setter: Charts in a dashboard"""
@@ -1705,7 +1650,6 @@ class DashboardInfoClass(DictWrapper):
     def lastModified(self) -> "ChangeAuditStampsClass":
         """Getter: Captures information about who created/last modified/deleted this dashboard and when"""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "ChangeAuditStampsClass") -> None:
@@ -1718,7 +1662,6 @@ class DashboardInfoClass(DictWrapper):
         """Getter: URL for the dashboard. This could be used as an external link on DataHub to allow users access/view the dashboard"""
         return self._inner_dict.get('dashboardUrl')  # type: ignore
     
-    
     @dashboardUrl.setter
     def dashboardUrl(self, value: Union[None, str]) -> None:
         """Setter: URL for the dashboard. This could be used as an external link on DataHub to allow users access/view the dashboard"""
@@ -1730,7 +1673,6 @@ class DashboardInfoClass(DictWrapper):
         """Getter: Access level for the dashboard"""
         return self._inner_dict.get('access')  # type: ignore
     
-    
     @access.setter
     def access(self, value: Union[None, Union[str, "AccessLevelClass"]]) -> None:
         """Setter: Access level for the dashboard"""
@@ -1741,7 +1683,6 @@ class DashboardInfoClass(DictWrapper):
     def lastRefreshed(self) -> Union[None, int]:
         """Getter: The time when this dashboard last refreshed"""
         return self._inner_dict.get('lastRefreshed')  # type: ignore
-    
     
     @lastRefreshed.setter
     def lastRefreshed(self, value: Union[None, int]) -> None:
@@ -1763,10 +1704,12 @@ class EditableDashboardPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -1792,7 +1735,6 @@ class EditableDashboardPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -1803,7 +1745,6 @@ class EditableDashboardPropertiesClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -1816,7 +1757,6 @@ class EditableDashboardPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
     
-    
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
         """Setter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
@@ -1827,7 +1767,6 @@ class EditableDashboardPropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Edited documentation of the dashboard"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -1849,6 +1788,7 @@ class DataFlowInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -1877,7 +1817,6 @@ class DataFlowInfoClass(DictWrapper):
         """Getter: Custom property bag."""
         return self._inner_dict.get('customProperties')  # type: ignore
     
-    
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
         """Setter: Custom property bag."""
@@ -1888,7 +1827,6 @@ class DataFlowInfoClass(DictWrapper):
     def externalUrl(self) -> Union[None, str]:
         """Getter: URL where the reference exist"""
         return self._inner_dict.get('externalUrl')  # type: ignore
-    
     
     @externalUrl.setter
     def externalUrl(self, value: Union[None, str]) -> None:
@@ -1901,7 +1839,6 @@ class DataFlowInfoClass(DictWrapper):
         """Getter: Flow name"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Flow name"""
@@ -1913,7 +1850,6 @@ class DataFlowInfoClass(DictWrapper):
         """Getter: Flow description"""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: Union[None, str]) -> None:
         """Setter: Flow description"""
@@ -1924,7 +1860,6 @@ class DataFlowInfoClass(DictWrapper):
     def project(self) -> Union[None, str]:
         """Getter: Optional project/namespace associated with the flow"""
         return self._inner_dict.get('project')  # type: ignore
-    
     
     @project.setter
     def project(self, value: Union[None, str]) -> None:
@@ -1947,6 +1882,7 @@ class DataJobInfoClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -1977,7 +1913,6 @@ class DataJobInfoClass(DictWrapper):
         """Getter: Custom property bag."""
         return self._inner_dict.get('customProperties')  # type: ignore
     
-    
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
         """Setter: Custom property bag."""
@@ -1988,7 +1923,6 @@ class DataJobInfoClass(DictWrapper):
     def externalUrl(self) -> Union[None, str]:
         """Getter: URL where the reference exist"""
         return self._inner_dict.get('externalUrl')  # type: ignore
-    
     
     @externalUrl.setter
     def externalUrl(self, value: Union[None, str]) -> None:
@@ -2001,7 +1935,6 @@ class DataJobInfoClass(DictWrapper):
         """Getter: Job name"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Job name"""
@@ -2012,7 +1945,6 @@ class DataJobInfoClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Job description"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -2025,7 +1957,6 @@ class DataJobInfoClass(DictWrapper):
         """Getter: Datajob type"""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: Union[str, "AzkabanJobTypeClass"]) -> None:
         """Setter: Datajob type"""
@@ -2036,7 +1967,6 @@ class DataJobInfoClass(DictWrapper):
     def flowUrn(self) -> Union[None, str]:
         """Getter: DataFlow urn that this job is part of"""
         return self._inner_dict.get('flowUrn')  # type: ignore
-    
     
     @flowUrn.setter
     def flowUrn(self, value: Union[None, str]) -> None:
@@ -2077,7 +2007,6 @@ class DataJobInputOutputClass(DictWrapper):
         """Getter: Input datasets consumed by the data job during processing"""
         return self._inner_dict.get('inputDatasets')  # type: ignore
     
-    
     @inputDatasets.setter
     def inputDatasets(self, value: List[str]) -> None:
         """Setter: Input datasets consumed by the data job during processing"""
@@ -2089,7 +2018,6 @@ class DataJobInputOutputClass(DictWrapper):
         """Getter: Output datasets produced by the data job during processing"""
         return self._inner_dict.get('outputDatasets')  # type: ignore
     
-    
     @outputDatasets.setter
     def outputDatasets(self, value: List[str]) -> None:
         """Setter: Output datasets produced by the data job during processing"""
@@ -2100,7 +2028,6 @@ class DataJobInputOutputClass(DictWrapper):
     def inputDatajobs(self) -> Union[None, List[str]]:
         """Getter: Input datajobs that this data job depends on"""
         return self._inner_dict.get('inputDatajobs')  # type: ignore
-    
     
     @inputDatajobs.setter
     def inputDatajobs(self, value: Union[None, List[str]]) -> None:
@@ -2122,10 +2049,12 @@ class EditableDataFlowPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -2151,7 +2080,6 @@ class EditableDataFlowPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -2162,7 +2090,6 @@ class EditableDataFlowPropertiesClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -2175,7 +2102,6 @@ class EditableDataFlowPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
     
-    
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
         """Setter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
@@ -2186,7 +2112,6 @@ class EditableDataFlowPropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Edited documentation of the data flow"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -2208,10 +2133,12 @@ class EditableDataJobPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -2237,7 +2164,6 @@ class EditableDataJobPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -2248,7 +2174,6 @@ class EditableDataJobPropertiesClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -2261,7 +2186,6 @@ class EditableDataJobPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
     
-    
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
         """Setter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
@@ -2272,7 +2196,6 @@ class EditableDataJobPropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Edited documentation of the data job """
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -2348,7 +2271,6 @@ class DataPlatformInfoClass(DictWrapper):
         """Getter: Name of the data platform"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Name of the data platform"""
@@ -2359,7 +2281,6 @@ class DataPlatformInfoClass(DictWrapper):
     def displayName(self) -> Union[None, str]:
         """Getter: The name that will be used for displaying a platform type."""
         return self._inner_dict.get('displayName')  # type: ignore
-    
     
     @displayName.setter
     def displayName(self, value: Union[None, str]) -> None:
@@ -2372,7 +2293,6 @@ class DataPlatformInfoClass(DictWrapper):
         """Getter: Platform type this data platform describes"""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: Union[str, "PlatformTypeClass"]) -> None:
         """Setter: Platform type this data platform describes"""
@@ -2384,7 +2304,6 @@ class DataPlatformInfoClass(DictWrapper):
         """Getter: The delimiter in the dataset names on the data platform, e.g. '/' for HDFS and '.' for Oracle"""
         return self._inner_dict.get('datasetNameDelimiter')  # type: ignore
     
-    
     @datasetNameDelimiter.setter
     def datasetNameDelimiter(self, value: str) -> None:
         """Setter: The delimiter in the dataset names on the data platform, e.g. '/' for HDFS and '.' for Oracle"""
@@ -2395,7 +2314,6 @@ class DataPlatformInfoClass(DictWrapper):
     def logoUrl(self) -> Union[None, str]:
         """Getter: The URL for a logo associated with the platform"""
         return self._inner_dict.get('logoUrl')  # type: ignore
-    
     
     @logoUrl.setter
     def logoUrl(self, value: Union[None, str]) -> None:
@@ -2465,7 +2383,6 @@ class DataProcessInfoClass(DictWrapper):
         """Getter: the inputs of the data process"""
         return self._inner_dict.get('inputs')  # type: ignore
     
-    
     @inputs.setter
     def inputs(self, value: Union[None, List[str]]) -> None:
         """Setter: the inputs of the data process"""
@@ -2476,7 +2393,6 @@ class DataProcessInfoClass(DictWrapper):
     def outputs(self) -> Union[None, List[str]]:
         """Getter: the outputs of the data process"""
         return self._inner_dict.get('outputs')  # type: ignore
-    
     
     @outputs.setter
     def outputs(self, value: Union[None, List[str]]) -> None:
@@ -2520,7 +2436,6 @@ class DatasetDeprecationClass(DictWrapper):
         """Getter: Whether the dataset is deprecated by owner."""
         return self._inner_dict.get('deprecated')  # type: ignore
     
-    
     @deprecated.setter
     def deprecated(self, value: bool) -> None:
         """Setter: Whether the dataset is deprecated by owner."""
@@ -2531,7 +2446,6 @@ class DatasetDeprecationClass(DictWrapper):
     def decommissionTime(self) -> Union[None, int]:
         """Getter: The time user plan to decommission this dataset."""
         return self._inner_dict.get('decommissionTime')  # type: ignore
-    
     
     @decommissionTime.setter
     def decommissionTime(self, value: Union[None, int]) -> None:
@@ -2544,7 +2458,6 @@ class DatasetDeprecationClass(DictWrapper):
         """Getter: Additional information about the dataset deprecation plan, such as the wiki, doc, RB."""
         return self._inner_dict.get('note')  # type: ignore
     
-    
     @note.setter
     def note(self, value: str) -> None:
         """Setter: Additional information about the dataset deprecation plan, such as the wiki, doc, RB."""
@@ -2555,7 +2468,6 @@ class DatasetDeprecationClass(DictWrapper):
     def actor(self) -> Union[None, str]:
         """Getter: The corpuser URN which will be credited for modifying this deprecation content."""
         return self._inner_dict.get('actor')  # type: ignore
-    
     
     @actor.setter
     def actor(self, value: Union[None, str]) -> None:
@@ -2599,7 +2511,6 @@ class DatasetFieldMappingClass(DictWrapper):
         """Getter: Audit stamp containing who reported the field mapping and when"""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: Audit stamp containing who reported the field mapping and when"""
@@ -2610,7 +2521,6 @@ class DatasetFieldMappingClass(DictWrapper):
     def transformation(self) -> Union[Union[str, "TransformationTypeClass"], "UDFTransformerClass"]:
         """Getter: Transfomration function between the fields involved"""
         return self._inner_dict.get('transformation')  # type: ignore
-    
     
     @transformation.setter
     def transformation(self, value: Union[Union[str, "TransformationTypeClass"], "UDFTransformerClass"]) -> None:
@@ -2623,7 +2533,6 @@ class DatasetFieldMappingClass(DictWrapper):
         """Getter: Source fields from which the fine grained lineage is derived"""
         return self._inner_dict.get('sourceFields')  # type: ignore
     
-    
     @sourceFields.setter
     def sourceFields(self, value: List[str]) -> None:
         """Setter: Source fields from which the fine grained lineage is derived"""
@@ -2634,7 +2543,6 @@ class DatasetFieldMappingClass(DictWrapper):
     def destinationField(self) -> str:
         """Getter: Destination field which is derived from source fields"""
         return self._inner_dict.get('destinationField')  # type: ignore
-    
     
     @destinationField.setter
     def destinationField(self, value: str) -> None:
@@ -2670,6 +2578,7 @@ class DatasetPropertiesClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -2677,6 +2586,7 @@ class DatasetPropertiesClass(DictWrapper):
         self.description = description
         self.uri = uri
         if tags is None:
+            # default: []
             self.tags = list()
         else:
             self.tags = tags
@@ -2701,7 +2611,6 @@ class DatasetPropertiesClass(DictWrapper):
         """Getter: Custom property bag."""
         return self._inner_dict.get('customProperties')  # type: ignore
     
-    
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
         """Setter: Custom property bag."""
@@ -2712,7 +2621,6 @@ class DatasetPropertiesClass(DictWrapper):
     def externalUrl(self) -> Union[None, str]:
         """Getter: URL where the reference exist"""
         return self._inner_dict.get('externalUrl')  # type: ignore
-    
     
     @externalUrl.setter
     def externalUrl(self, value: Union[None, str]) -> None:
@@ -2725,7 +2633,6 @@ class DatasetPropertiesClass(DictWrapper):
         """Getter: Documentation of the dataset"""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: Union[None, str]) -> None:
         """Setter: Documentation of the dataset"""
@@ -2737,7 +2644,6 @@ class DatasetPropertiesClass(DictWrapper):
         """Getter: The abstracted URI such as hdfs:///data/tracking/PageViewEvent, file:///dir/file_name. Uri should not include any environment specific properties. Some datasets might not have a standardized uri, which makes this field optional (i.e. kafka topic)."""
         return self._inner_dict.get('uri')  # type: ignore
     
-    
     @uri.setter
     def uri(self, value: Union[None, str]) -> None:
         """Setter: The abstracted URI such as hdfs:///data/tracking/PageViewEvent, file:///dir/file_name. Uri should not include any environment specific properties. Some datasets might not have a standardized uri, which makes this field optional (i.e. kafka topic)."""
@@ -2748,7 +2654,6 @@ class DatasetPropertiesClass(DictWrapper):
     def tags(self) -> List[str]:
         """Getter: [Legacy] Unstructured tags for the dataset. Structured tags can be applied via the `GlobalTags` aspect."""
         return self._inner_dict.get('tags')  # type: ignore
-    
     
     @tags.setter
     def tags(self, value: List[str]) -> None:
@@ -2783,7 +2688,6 @@ class DatasetUpstreamLineageClass(DictWrapper):
         """Getter: Upstream to downstream field level lineage mappings"""
         return self._inner_dict.get('fieldMappings')  # type: ignore
     
-    
     @fieldMappings.setter
     def fieldMappings(self, value: List["DatasetFieldMappingClass"]) -> None:
         """Setter: Upstream to downstream field level lineage mappings"""
@@ -2804,10 +2708,12 @@ class EditableDatasetPropertiesClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -2833,7 +2739,6 @@ class EditableDatasetPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -2844,7 +2749,6 @@ class EditableDatasetPropertiesClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -2857,7 +2761,6 @@ class EditableDatasetPropertiesClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
     
-    
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
         """Setter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
@@ -2868,7 +2771,6 @@ class EditableDatasetPropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Documentation of the dataset"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -2888,6 +2790,7 @@ class UpstreamClass(DictWrapper):
         super().__init__()
         
         if auditStamp is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.auditStamp = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["auditStamp"].default, writers_schema=self.RECORD_SCHEMA.field_map["auditStamp"].type)
         else:
             self.auditStamp = auditStamp
@@ -2913,7 +2816,6 @@ class UpstreamClass(DictWrapper):
     WARNING: this field is deprecated and may be removed in a future release."""
         return self._inner_dict.get('auditStamp')  # type: ignore
     
-    
     @auditStamp.setter
     def auditStamp(self, value: "AuditStampClass") -> None:
         """Setter: Audit stamp containing who reported the lineage and when.
@@ -2926,7 +2828,6 @@ class UpstreamClass(DictWrapper):
         """Getter: The upstream dataset the lineage points to"""
         return self._inner_dict.get('dataset')  # type: ignore
     
-    
     @dataset.setter
     def dataset(self, value: str) -> None:
         """Setter: The upstream dataset the lineage points to"""
@@ -2937,7 +2838,6 @@ class UpstreamClass(DictWrapper):
     def type(self) -> Union[str, "DatasetLineageTypeClass"]:
         """Getter: The type of the lineage"""
         return self._inner_dict.get('type')  # type: ignore
-    
     
     @type.setter
     def type(self, value: Union[str, "DatasetLineageTypeClass"]) -> None:
@@ -2971,7 +2871,6 @@ class UpstreamLineageClass(DictWrapper):
     def upstreams(self) -> List["UpstreamClass"]:
         """Getter: List of upstream dataset lineage information"""
         return self._inner_dict.get('upstreams')  # type: ignore
-    
     
     @upstreams.setter
     def upstreams(self, value: List["UpstreamClass"]) -> None:
@@ -3009,7 +2908,6 @@ class GlossaryNodeInfoClass(DictWrapper):
         """Getter: Definition of business node"""
         return self._inner_dict.get('definition')  # type: ignore
     
-    
     @definition.setter
     def definition(self, value: str) -> None:
         """Setter: Definition of business node"""
@@ -3020,7 +2918,6 @@ class GlossaryNodeInfoClass(DictWrapper):
     def parentNode(self) -> Union[None, str]:
         """Getter: Parent node of the glossary term"""
         return self._inner_dict.get('parentNode')  # type: ignore
-    
     
     @parentNode.setter
     def parentNode(self, value: Union[None, str]) -> None:
@@ -3048,6 +2945,7 @@ class GlossaryTermInfoClass(DictWrapper):
         self.sourceRef = sourceRef
         self.sourceUrl = sourceUrl
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -3073,7 +2971,6 @@ class GlossaryTermInfoClass(DictWrapper):
         """Getter: Definition of business term"""
         return self._inner_dict.get('definition')  # type: ignore
     
-    
     @definition.setter
     def definition(self, value: str) -> None:
         """Setter: Definition of business term"""
@@ -3084,7 +2981,6 @@ class GlossaryTermInfoClass(DictWrapper):
     def parentNode(self) -> Union[None, str]:
         """Getter: Parent node of the glossary term"""
         return self._inner_dict.get('parentNode')  # type: ignore
-    
     
     @parentNode.setter
     def parentNode(self, value: Union[None, str]) -> None:
@@ -3097,7 +2993,6 @@ class GlossaryTermInfoClass(DictWrapper):
         """Getter: Source of the Business Term (INTERNAL or EXTERNAL) with default value as INTERNAL"""
         return self._inner_dict.get('termSource')  # type: ignore
     
-    
     @termSource.setter
     def termSource(self, value: str) -> None:
         """Setter: Source of the Business Term (INTERNAL or EXTERNAL) with default value as INTERNAL"""
@@ -3108,7 +3003,6 @@ class GlossaryTermInfoClass(DictWrapper):
     def sourceRef(self) -> Union[None, str]:
         """Getter: External Reference to the business-term"""
         return self._inner_dict.get('sourceRef')  # type: ignore
-    
     
     @sourceRef.setter
     def sourceRef(self, value: Union[None, str]) -> None:
@@ -3121,7 +3015,6 @@ class GlossaryTermInfoClass(DictWrapper):
         """Getter: The abstracted URL such as https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/CashInstrument."""
         return self._inner_dict.get('sourceUrl')  # type: ignore
     
-    
     @sourceUrl.setter
     def sourceUrl(self, value: Union[None, str]) -> None:
         """Setter: The abstracted URL such as https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/CashInstrument."""
@@ -3132,7 +3025,6 @@ class GlossaryTermInfoClass(DictWrapper):
     def customProperties(self) -> Dict[str, str]:
         """Getter: A key-value map to capture any other non-standardized properties for the glossary term"""
         return self._inner_dict.get('customProperties')  # type: ignore
-    
     
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
@@ -3176,7 +3068,6 @@ class CorpGroupInfoClass(DictWrapper):
         """Getter: email of this group"""
         return self._inner_dict.get('email')  # type: ignore
     
-    
     @email.setter
     def email(self, value: str) -> None:
         """Setter: email of this group"""
@@ -3187,7 +3078,6 @@ class CorpGroupInfoClass(DictWrapper):
     def admins(self) -> List[str]:
         """Getter: owners of this group"""
         return self._inner_dict.get('admins')  # type: ignore
-    
     
     @admins.setter
     def admins(self, value: List[str]) -> None:
@@ -3200,7 +3090,6 @@ class CorpGroupInfoClass(DictWrapper):
         """Getter: List of ldap urn in this group."""
         return self._inner_dict.get('members')  # type: ignore
     
-    
     @members.setter
     def members(self, value: List[str]) -> None:
         """Setter: List of ldap urn in this group."""
@@ -3211,7 +3100,6 @@ class CorpGroupInfoClass(DictWrapper):
     def groups(self) -> List[str]:
         """Getter: List of groups in this group."""
         return self._inner_dict.get('groups')  # type: ignore
-    
     
     @groups.setter
     def groups(self, value: List[str]) -> None:
@@ -3233,14 +3121,17 @@ class CorpUserEditableInfoClass(DictWrapper):
         
         self.aboutMe = aboutMe
         if teams is None:
+            # default: []
             self.teams = list()
         else:
             self.teams = teams
         if skills is None:
+            # default: []
             self.skills = list()
         else:
             self.skills = skills
         if pictureLink is None:
+            # default: 'https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web/packages/data-portal/public/assets/images/default_avatar.png'
             self.pictureLink = self.RECORD_SCHEMA.field_map["pictureLink"].default
         else:
             self.pictureLink = pictureLink
@@ -3264,7 +3155,6 @@ class CorpUserEditableInfoClass(DictWrapper):
         """Getter: About me section of the user"""
         return self._inner_dict.get('aboutMe')  # type: ignore
     
-    
     @aboutMe.setter
     def aboutMe(self, value: Union[None, str]) -> None:
         """Setter: About me section of the user"""
@@ -3275,7 +3165,6 @@ class CorpUserEditableInfoClass(DictWrapper):
     def teams(self) -> List[str]:
         """Getter: Teams that the user belongs to e.g. Metadata"""
         return self._inner_dict.get('teams')  # type: ignore
-    
     
     @teams.setter
     def teams(self, value: List[str]) -> None:
@@ -3288,7 +3177,6 @@ class CorpUserEditableInfoClass(DictWrapper):
         """Getter: Skills that the user possesses e.g. Machine Learning"""
         return self._inner_dict.get('skills')  # type: ignore
     
-    
     @skills.setter
     def skills(self, value: List[str]) -> None:
         """Setter: Skills that the user possesses e.g. Machine Learning"""
@@ -3299,7 +3187,6 @@ class CorpUserEditableInfoClass(DictWrapper):
     def pictureLink(self) -> str:
         """Getter: A URL which points to a picture which user wants to set as a profile photo"""
         return self._inner_dict.get('pictureLink')  # type: ignore
-    
     
     @pictureLink.setter
     def pictureLink(self, value: str) -> None:
@@ -3364,7 +3251,6 @@ class CorpUserInfoClass(DictWrapper):
         """Getter: Whether the corpUser is active, ref: https://iwww.corp.linkedin.com/wiki/cf/display/GTSD/Accessing+Active+Directory+via+LDAP+tools"""
         return self._inner_dict.get('active')  # type: ignore
     
-    
     @active.setter
     def active(self, value: bool) -> None:
         """Setter: Whether the corpUser is active, ref: https://iwww.corp.linkedin.com/wiki/cf/display/GTSD/Accessing+Active+Directory+via+LDAP+tools"""
@@ -3375,7 +3261,6 @@ class CorpUserInfoClass(DictWrapper):
     def displayName(self) -> Union[None, str]:
         """Getter: displayName of this user ,  e.g.  Hang Zhang(DataHQ)"""
         return self._inner_dict.get('displayName')  # type: ignore
-    
     
     @displayName.setter
     def displayName(self, value: Union[None, str]) -> None:
@@ -3388,7 +3273,6 @@ class CorpUserInfoClass(DictWrapper):
         """Getter: email address of this user"""
         return self._inner_dict.get('email')  # type: ignore
     
-    
     @email.setter
     def email(self, value: str) -> None:
         """Setter: email address of this user"""
@@ -3399,7 +3283,6 @@ class CorpUserInfoClass(DictWrapper):
     def title(self) -> Union[None, str]:
         """Getter: title of this user"""
         return self._inner_dict.get('title')  # type: ignore
-    
     
     @title.setter
     def title(self, value: Union[None, str]) -> None:
@@ -3412,7 +3295,6 @@ class CorpUserInfoClass(DictWrapper):
         """Getter: direct manager of this user"""
         return self._inner_dict.get('managerUrn')  # type: ignore
     
-    
     @managerUrn.setter
     def managerUrn(self, value: Union[None, str]) -> None:
         """Setter: direct manager of this user"""
@@ -3423,7 +3305,6 @@ class CorpUserInfoClass(DictWrapper):
     def departmentId(self) -> Union[None, int]:
         """Getter: department id this user belong to"""
         return self._inner_dict.get('departmentId')  # type: ignore
-    
     
     @departmentId.setter
     def departmentId(self, value: Union[None, int]) -> None:
@@ -3436,7 +3317,6 @@ class CorpUserInfoClass(DictWrapper):
         """Getter: department name this user belong to"""
         return self._inner_dict.get('departmentName')  # type: ignore
     
-    
     @departmentName.setter
     def departmentName(self, value: Union[None, str]) -> None:
         """Setter: department name this user belong to"""
@@ -3447,7 +3327,6 @@ class CorpUserInfoClass(DictWrapper):
     def firstName(self) -> Union[None, str]:
         """Getter: first name of this user"""
         return self._inner_dict.get('firstName')  # type: ignore
-    
     
     @firstName.setter
     def firstName(self, value: Union[None, str]) -> None:
@@ -3460,7 +3339,6 @@ class CorpUserInfoClass(DictWrapper):
         """Getter: last name of this user"""
         return self._inner_dict.get('lastName')  # type: ignore
     
-    
     @lastName.setter
     def lastName(self, value: Union[None, str]) -> None:
         """Setter: last name of this user"""
@@ -3472,7 +3350,6 @@ class CorpUserInfoClass(DictWrapper):
         """Getter: Common name of this user, format is firstName + lastName (split by a whitespace)"""
         return self._inner_dict.get('fullName')  # type: ignore
     
-    
     @fullName.setter
     def fullName(self, value: Union[None, str]) -> None:
         """Setter: Common name of this user, format is firstName + lastName (split by a whitespace)"""
@@ -3483,7 +3360,6 @@ class CorpUserInfoClass(DictWrapper):
     def countryCode(self) -> Union[None, str]:
         """Getter: two uppercase letters country code. e.g.  US"""
         return self._inner_dict.get('countryCode')  # type: ignore
-    
     
     @countryCode.setter
     def countryCode(self, value: Union[None, str]) -> None:
@@ -3521,7 +3397,6 @@ class ChartKeyClass(DictWrapper):
         """Getter: The name of the dashboard tool such as looker, redash etc."""
         return self._inner_dict.get('dashboardTool')  # type: ignore
     
-    
     @dashboardTool.setter
     def dashboardTool(self, value: str) -> None:
         """Setter: The name of the dashboard tool such as looker, redash etc."""
@@ -3532,7 +3407,6 @@ class ChartKeyClass(DictWrapper):
     def chartId(self) -> str:
         """Getter: Unique id for the chart. This id should be globally unique for a dashboarding tool even when there are multiple deployments of it. As an example, chart URL could be used here for Looker such as 'looker.linkedin.com/looks/1234'"""
         return self._inner_dict.get('chartId')  # type: ignore
-    
     
     @chartId.setter
     def chartId(self, value: str) -> None:
@@ -3567,7 +3441,6 @@ class CorpGroupKeyClass(DictWrapper):
         """Getter: The name of the AD/LDAP group."""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: The name of the AD/LDAP group."""
@@ -3600,7 +3473,6 @@ class CorpUserKeyClass(DictWrapper):
     def username(self) -> str:
         """Getter: The name of the AD/LDAP user."""
         return self._inner_dict.get('username')  # type: ignore
-    
     
     @username.setter
     def username(self, value: str) -> None:
@@ -3638,7 +3510,6 @@ class DashboardKeyClass(DictWrapper):
         """Getter: The name of the dashboard tool such as looker, redash etc."""
         return self._inner_dict.get('dashboardTool')  # type: ignore
     
-    
     @dashboardTool.setter
     def dashboardTool(self, value: str) -> None:
         """Setter: The name of the dashboard tool such as looker, redash etc."""
@@ -3649,7 +3520,6 @@ class DashboardKeyClass(DictWrapper):
     def dashboardId(self) -> str:
         """Getter: Unique id for the dashboard. This id should be globally unique for a dashboarding tool even when there are multiple deployments of it. As an example, dashboard URL could be used here for Looker such as 'looker.linkedin.com/dashboards/1234'"""
         return self._inner_dict.get('dashboardId')  # type: ignore
-    
     
     @dashboardId.setter
     def dashboardId(self, value: str) -> None:
@@ -3690,7 +3560,6 @@ class DataFlowKeyClass(DictWrapper):
         """Getter: Workflow manager like azkaban, airflow which orchestrates the flow"""
         return self._inner_dict.get('orchestrator')  # type: ignore
     
-    
     @orchestrator.setter
     def orchestrator(self, value: str) -> None:
         """Setter: Workflow manager like azkaban, airflow which orchestrates the flow"""
@@ -3702,7 +3571,6 @@ class DataFlowKeyClass(DictWrapper):
         """Getter: Unique Identifier of the data flow"""
         return self._inner_dict.get('flowId')  # type: ignore
     
-    
     @flowId.setter
     def flowId(self, value: str) -> None:
         """Setter: Unique Identifier of the data flow"""
@@ -3713,7 +3581,6 @@ class DataFlowKeyClass(DictWrapper):
     def cluster(self) -> str:
         """Getter: Cluster where the flow is executed"""
         return self._inner_dict.get('cluster')  # type: ignore
-    
     
     @cluster.setter
     def cluster(self, value: str) -> None:
@@ -3751,7 +3618,6 @@ class DataJobKeyClass(DictWrapper):
         """Getter: Standardized data processing flow urn representing the flow for the job"""
         return self._inner_dict.get('flow')  # type: ignore
     
-    
     @flow.setter
     def flow(self, value: str) -> None:
         """Setter: Standardized data processing flow urn representing the flow for the job"""
@@ -3762,7 +3628,6 @@ class DataJobKeyClass(DictWrapper):
     def jobId(self) -> str:
         """Getter: Unique Identifier of the data job"""
         return self._inner_dict.get('jobId')  # type: ignore
-    
     
     @jobId.setter
     def jobId(self, value: str) -> None:
@@ -3796,7 +3661,6 @@ class DataPlatformKeyClass(DictWrapper):
     def platformName(self) -> str:
         """Getter: Data platform name i.e. hdfs, oracle, espresso"""
         return self._inner_dict.get('platformName')  # type: ignore
-    
     
     @platformName.setter
     def platformName(self, value: str) -> None:
@@ -3837,7 +3701,6 @@ class DataProcessKeyClass(DictWrapper):
         """Getter: Process name i.e. an ETL job name"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Process name i.e. an ETL job name"""
@@ -3850,7 +3713,6 @@ class DataProcessKeyClass(DictWrapper):
     TODO: Migrate towards something that can be validated like DataPlatform urn"""
         return self._inner_dict.get('orchestrator')  # type: ignore
     
-    
     @orchestrator.setter
     def orchestrator(self, value: str) -> None:
         """Setter: Standardized Orchestrator where data process is defined.
@@ -3862,7 +3724,6 @@ class DataProcessKeyClass(DictWrapper):
     def origin(self) -> Union[str, "FabricTypeClass"]:
         """Getter: Fabric type where dataset belongs to or where it was generated."""
         return self._inner_dict.get('origin')  # type: ignore
-    
     
     @origin.setter
     def origin(self, value: Union[str, "FabricTypeClass"]) -> None:
@@ -3903,7 +3764,6 @@ class DatasetKeyClass(DictWrapper):
         """Getter: Data platform urn associated with the dataset"""
         return self._inner_dict.get('platform')  # type: ignore
     
-    
     @platform.setter
     def platform(self, value: str) -> None:
         """Setter: Data platform urn associated with the dataset"""
@@ -3915,7 +3775,6 @@ class DatasetKeyClass(DictWrapper):
         """Getter: Dataset native name e.g. <db>.<table>, /dir/subdir/<name>, or <name>"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Dataset native name e.g. <db>.<table>, /dir/subdir/<name>, or <name>"""
@@ -3926,7 +3785,6 @@ class DatasetKeyClass(DictWrapper):
     def origin(self) -> Union[str, "FabricTypeClass"]:
         """Getter: Fabric type where dataset belongs to or where it was generated."""
         return self._inner_dict.get('origin')  # type: ignore
-    
     
     @origin.setter
     def origin(self, value: Union[str, "FabricTypeClass"]) -> None:
@@ -3961,7 +3819,6 @@ class GlossaryNodeKeyClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         # No docs available.
@@ -3994,7 +3851,6 @@ class GlossaryTermKeyClass(DictWrapper):
     def name(self) -> str:
         # No docs available.
         return self._inner_dict.get('name')  # type: ignore
-    
     
     @name.setter
     def name(self, value: str) -> None:
@@ -4032,7 +3888,6 @@ class MLFeatureKeyClass(DictWrapper):
         """Getter: Namespace for the feature"""
         return self._inner_dict.get('featureNamespace')  # type: ignore
     
-    
     @featureNamespace.setter
     def featureNamespace(self, value: str) -> None:
         """Setter: Namespace for the feature"""
@@ -4043,7 +3898,6 @@ class MLFeatureKeyClass(DictWrapper):
     def name(self) -> str:
         """Getter: Name of the feature"""
         return self._inner_dict.get('name')  # type: ignore
-    
     
     @name.setter
     def name(self, value: str) -> None:
@@ -4081,7 +3935,6 @@ class MLFeatureTableKeyClass(DictWrapper):
         """Getter: Data platform urn associated with the feature table"""
         return self._inner_dict.get('platform')  # type: ignore
     
-    
     @platform.setter
     def platform(self, value: str) -> None:
         """Setter: Data platform urn associated with the feature table"""
@@ -4092,7 +3945,6 @@ class MLFeatureTableKeyClass(DictWrapper):
     def name(self) -> str:
         """Getter: Name of the feature table"""
         return self._inner_dict.get('name')  # type: ignore
-    
     
     @name.setter
     def name(self, value: str) -> None:
@@ -4133,7 +3985,6 @@ class MLModelKeyClass(DictWrapper):
         """Getter: Standardized platform urn for the model"""
         return self._inner_dict.get('platform')  # type: ignore
     
-    
     @platform.setter
     def platform(self, value: str) -> None:
         """Setter: Standardized platform urn for the model"""
@@ -4145,7 +3996,6 @@ class MLModelKeyClass(DictWrapper):
         """Getter: Name of the MLModel"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Name of the MLModel"""
@@ -4156,7 +4006,6 @@ class MLModelKeyClass(DictWrapper):
     def origin(self) -> Union[str, "FabricTypeClass"]:
         """Getter: Fabric type where model belongs to or where it was generated"""
         return self._inner_dict.get('origin')  # type: ignore
-    
     
     @origin.setter
     def origin(self, value: Union[str, "FabricTypeClass"]) -> None:
@@ -4194,7 +4043,6 @@ class MLPrimaryKeyKeyClass(DictWrapper):
         """Getter: Namespace for the primary key"""
         return self._inner_dict.get('featureNamespace')  # type: ignore
     
-    
     @featureNamespace.setter
     def featureNamespace(self, value: str) -> None:
         """Setter: Namespace for the primary key"""
@@ -4205,7 +4053,6 @@ class MLPrimaryKeyKeyClass(DictWrapper):
     def name(self) -> str:
         """Getter: Name of the primary key"""
         return self._inner_dict.get('name')  # type: ignore
-    
     
     @name.setter
     def name(self, value: str) -> None:
@@ -4239,7 +4086,6 @@ class TagKeyClass(DictWrapper):
     def name(self) -> str:
         """Getter: The unique tag name"""
         return self._inner_dict.get('name')  # type: ignore
-    
     
     @name.setter
     def name(self, value: str) -> None:
@@ -4277,7 +4123,6 @@ class ChartSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4288,7 +4133,6 @@ class ChartSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["ChartKeyClass", "ChartInfoClass", "ChartQueryClass", "EditableChartPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the chart. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["ChartKeyClass", "ChartInfoClass", "ChartQueryClass", "EditableChartPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]) -> None:
@@ -4326,7 +4170,6 @@ class CorpGroupSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4337,7 +4180,6 @@ class CorpGroupSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["CorpGroupKeyClass", "CorpGroupInfoClass", "GlobalTagsClass", "StatusClass"]]:
         """Getter: The list of metadata aspects associated with the LdapUser. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["CorpGroupKeyClass", "CorpGroupInfoClass", "GlobalTagsClass", "StatusClass"]]) -> None:
@@ -4375,7 +4217,6 @@ class CorpUserSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4386,7 +4227,6 @@ class CorpUserSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["CorpUserKeyClass", "CorpUserInfoClass", "CorpUserEditableInfoClass", "GlobalTagsClass", "StatusClass"]]:
         """Getter: The list of metadata aspects associated with the CorpUser. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["CorpUserKeyClass", "CorpUserInfoClass", "CorpUserEditableInfoClass", "GlobalTagsClass", "StatusClass"]]) -> None:
@@ -4424,7 +4264,6 @@ class DashboardSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4435,7 +4274,6 @@ class DashboardSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["DashboardKeyClass", "DashboardInfoClass", "EditableDashboardPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the dashboard. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["DashboardKeyClass", "DashboardInfoClass", "EditableDashboardPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]) -> None:
@@ -4473,7 +4311,6 @@ class DataFlowSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4484,7 +4321,6 @@ class DataFlowSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["DataFlowKeyClass", "DataFlowInfoClass", "EditableDataFlowPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the data flow. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["DataFlowKeyClass", "DataFlowInfoClass", "EditableDataFlowPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]) -> None:
@@ -4522,7 +4358,6 @@ class DataJobSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4533,7 +4368,6 @@ class DataJobSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["DataJobKeyClass", "DataJobInfoClass", "DataJobInputOutputClass", "EditableDataJobPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the data job. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["DataJobKeyClass", "DataJobInfoClass", "DataJobInputOutputClass", "EditableDataJobPropertiesClass", "OwnershipClass", "StatusClass", "GlobalTagsClass", "BrowsePathsClass"]]) -> None:
@@ -4571,7 +4405,6 @@ class DataPlatformSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4582,7 +4415,6 @@ class DataPlatformSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["DataPlatformKeyClass", "DataPlatformInfoClass"]]:
         """Getter: The list of metadata aspects associated with the data platform. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["DataPlatformKeyClass", "DataPlatformInfoClass"]]) -> None:
@@ -4620,7 +4452,6 @@ class DataProcessSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4631,7 +4462,6 @@ class DataProcessSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["DataProcessKeyClass", "OwnershipClass", "DataProcessInfoClass", "StatusClass"]]:
         """Getter: The list of metadata aspects associated with the data process. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["DataProcessKeyClass", "OwnershipClass", "DataProcessInfoClass", "StatusClass"]]) -> None:
@@ -4669,7 +4499,6 @@ class DatasetSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4680,7 +4509,6 @@ class DatasetSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["DatasetKeyClass", "DatasetPropertiesClass", "EditableDatasetPropertiesClass", "DatasetDeprecationClass", "DatasetUpstreamLineageClass", "UpstreamLineageClass", "InstitutionalMemoryClass", "OwnershipClass", "StatusClass", "SchemaMetadataClass", "EditableSchemaMetadataClass", "GlobalTagsClass", "GlossaryTermsClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the dataset. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["DatasetKeyClass", "DatasetPropertiesClass", "EditableDatasetPropertiesClass", "DatasetDeprecationClass", "DatasetUpstreamLineageClass", "UpstreamLineageClass", "InstitutionalMemoryClass", "OwnershipClass", "StatusClass", "SchemaMetadataClass", "EditableSchemaMetadataClass", "GlobalTagsClass", "GlossaryTermsClass", "BrowsePathsClass"]]) -> None:
@@ -4718,7 +4546,6 @@ class GlossaryNodeSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4729,7 +4556,6 @@ class GlossaryNodeSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["GlossaryNodeKeyClass", "GlossaryNodeInfoClass", "OwnershipClass", "StatusClass"]]:
         """Getter: The list of metadata aspects associated with the GlossaryNode. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["GlossaryNodeKeyClass", "GlossaryNodeInfoClass", "OwnershipClass", "StatusClass"]]) -> None:
@@ -4767,7 +4593,6 @@ class GlossaryTermSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4778,7 +4603,6 @@ class GlossaryTermSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["GlossaryTermKeyClass", "GlossaryTermInfoClass", "OwnershipClass", "StatusClass"]]:
         """Getter: The list of metadata aspects associated with the GlossaryTerm. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["GlossaryTermKeyClass", "GlossaryTermInfoClass", "OwnershipClass", "StatusClass"]]) -> None:
@@ -4816,7 +4640,6 @@ class MLFeatureSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4827,7 +4650,6 @@ class MLFeatureSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["MLFeatureKeyClass", "MLFeaturePropertiesClass", "OwnershipClass", "InstitutionalMemoryClass", "StatusClass", "DeprecationClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the MLFeature. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["MLFeatureKeyClass", "MLFeaturePropertiesClass", "OwnershipClass", "InstitutionalMemoryClass", "StatusClass", "DeprecationClass", "BrowsePathsClass"]]) -> None:
@@ -4865,7 +4687,6 @@ class MLFeatureTableSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4876,7 +4697,6 @@ class MLFeatureTableSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["MLFeatureTableKeyClass", "MLFeatureTablePropertiesClass", "OwnershipClass", "InstitutionalMemoryClass", "StatusClass", "DeprecationClass"]]:
         """Getter: The list of metadata aspects associated with the MLFeatureTable. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["MLFeatureTableKeyClass", "MLFeatureTablePropertiesClass", "OwnershipClass", "InstitutionalMemoryClass", "StatusClass", "DeprecationClass"]]) -> None:
@@ -4914,7 +4734,6 @@ class MLModelSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4925,7 +4744,6 @@ class MLModelSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["MLModelKeyClass", "OwnershipClass", "MLModelPropertiesClass", "IntendedUseClass", "MLModelFactorPromptsClass", "MetricsClass", "EvaluationDataClass", "TrainingDataClass", "QuantitativeAnalysesClass", "EthicalConsiderationsClass", "CaveatsAndRecommendationsClass", "InstitutionalMemoryClass", "SourceCodeClass", "StatusClass", "CostClass", "DeprecationClass", "BrowsePathsClass"]]:
         """Getter: The list of metadata aspects associated with the MLModel. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["MLModelKeyClass", "OwnershipClass", "MLModelPropertiesClass", "IntendedUseClass", "MLModelFactorPromptsClass", "MetricsClass", "EvaluationDataClass", "TrainingDataClass", "QuantitativeAnalysesClass", "EthicalConsiderationsClass", "CaveatsAndRecommendationsClass", "InstitutionalMemoryClass", "SourceCodeClass", "StatusClass", "CostClass", "DeprecationClass", "BrowsePathsClass"]]) -> None:
@@ -4963,7 +4781,6 @@ class MLPrimaryKeySnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -4974,7 +4791,6 @@ class MLPrimaryKeySnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["MLPrimaryKeyKeyClass", "MLPrimaryKeyPropertiesClass", "OwnershipClass", "InstitutionalMemoryClass", "StatusClass", "DeprecationClass"]]:
         """Getter: The list of metadata aspects associated with the MLPrimaryKey. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["MLPrimaryKeyKeyClass", "MLPrimaryKeyPropertiesClass", "OwnershipClass", "InstitutionalMemoryClass", "StatusClass", "DeprecationClass"]]) -> None:
@@ -5012,7 +4828,6 @@ class TagSnapshotClass(DictWrapper):
         """Getter: URN for the entity the metadata snapshot is associated with."""
         return self._inner_dict.get('urn')  # type: ignore
     
-    
     @urn.setter
     def urn(self, value: str) -> None:
         """Setter: URN for the entity the metadata snapshot is associated with."""
@@ -5023,7 +4838,6 @@ class TagSnapshotClass(DictWrapper):
     def aspects(self) -> List[Union["TagKeyClass", "OwnershipClass", "TagPropertiesClass", "StatusClass"]]:
         """Getter: The list of metadata aspects associated with the dataset. Depending on the use case, this can either be all, or a selection, of supported aspects."""
         return self._inner_dict.get('aspects')  # type: ignore
-    
     
     @aspects.setter
     def aspects(self, value: List[Union["TagKeyClass", "OwnershipClass", "TagPropertiesClass", "StatusClass"]]) -> None:
@@ -5064,7 +4878,6 @@ class BaseDataClass(DictWrapper):
         """Getter: What dataset were used in the MLModel?"""
         return self._inner_dict.get('dataset')  # type: ignore
     
-    
     @dataset.setter
     def dataset(self, value: str) -> None:
         """Setter: What dataset were used in the MLModel?"""
@@ -5076,7 +4889,6 @@ class BaseDataClass(DictWrapper):
         """Getter: Why was this dataset chosen?"""
         return self._inner_dict.get('motivation')  # type: ignore
     
-    
     @motivation.setter
     def motivation(self, value: Union[None, str]) -> None:
         """Setter: Why was this dataset chosen?"""
@@ -5087,7 +4899,6 @@ class BaseDataClass(DictWrapper):
     def preProcessing(self) -> Union[None, List[str]]:
         """Getter: How was the data preprocessed (e.g., tokenization of sentences, cropping of images, any filtering such as dropping images without faces)?"""
         return self._inner_dict.get('preProcessing')  # type: ignore
-    
     
     @preProcessing.setter
     def preProcessing(self, value: Union[None, List[str]]) -> None:
@@ -5128,7 +4939,6 @@ class CaveatDetailsClass(DictWrapper):
         """Getter: Did the results suggest any further testing?"""
         return self._inner_dict.get('needsFurtherTesting')  # type: ignore
     
-    
     @needsFurtherTesting.setter
     def needsFurtherTesting(self, value: Union[None, bool]) -> None:
         """Setter: Did the results suggest any further testing?"""
@@ -5141,7 +4951,6 @@ class CaveatDetailsClass(DictWrapper):
     For ex: Given gender classes are binary (male/not male), which we include as male/female. Further work needed to evaluate across a spectrum of genders."""
         return self._inner_dict.get('caveatDescription')  # type: ignore
     
-    
     @caveatDescription.setter
     def caveatDescription(self, value: Union[None, str]) -> None:
         """Setter: Caveat Description
@@ -5153,7 +4962,6 @@ class CaveatDetailsClass(DictWrapper):
     def groupsNotRepresented(self) -> Union[None, List[str]]:
         """Getter: Relevant groups that were not represented in the evaluation dataset?"""
         return self._inner_dict.get('groupsNotRepresented')  # type: ignore
-    
     
     @groupsNotRepresented.setter
     def groupsNotRepresented(self, value: Union[None, List[str]]) -> None:
@@ -5194,7 +5002,6 @@ class CaveatsAndRecommendationsClass(DictWrapper):
         """Getter: This section should list additional concerns that were not covered in the previous sections. For example, did the results suggest any further testing? Were there any relevant groups that were not represented in the evaluation dataset?"""
         return self._inner_dict.get('caveats')  # type: ignore
     
-    
     @caveats.setter
     def caveats(self, value: Union[None, "CaveatDetailsClass"]) -> None:
         """Setter: This section should list additional concerns that were not covered in the previous sections. For example, did the results suggest any further testing? Were there any relevant groups that were not represented in the evaluation dataset?"""
@@ -5206,7 +5013,6 @@ class CaveatsAndRecommendationsClass(DictWrapper):
         """Getter: Recommendations on where this MLModel should be used."""
         return self._inner_dict.get('recommendations')  # type: ignore
     
-    
     @recommendations.setter
     def recommendations(self, value: Union[None, str]) -> None:
         """Setter: Recommendations on where this MLModel should be used."""
@@ -5217,7 +5023,6 @@ class CaveatsAndRecommendationsClass(DictWrapper):
     def idealDatasetCharacteristics(self) -> Union[None, List[str]]:
         """Getter: Ideal characteristics of an evaluation dataset for this MLModel"""
         return self._inner_dict.get('idealDatasetCharacteristics')  # type: ignore
-    
     
     @idealDatasetCharacteristics.setter
     def idealDatasetCharacteristics(self, value: Union[None, List[str]]) -> None:
@@ -5264,7 +5069,6 @@ class EthicalConsiderationsClass(DictWrapper):
         """Getter: Does the MLModel use any sensitive data (e.g., protected classes)?"""
         return self._inner_dict.get('data')  # type: ignore
     
-    
     @data.setter
     def data(self, value: Union[None, List[str]]) -> None:
         """Setter: Does the MLModel use any sensitive data (e.g., protected classes)?"""
@@ -5275,7 +5079,6 @@ class EthicalConsiderationsClass(DictWrapper):
     def humanLife(self) -> Union[None, List[str]]:
         """Getter:  Is the MLModel intended to inform decisions about matters central to human life or flourishing – e.g., health or safety? Or could it be used in such a way?"""
         return self._inner_dict.get('humanLife')  # type: ignore
-    
     
     @humanLife.setter
     def humanLife(self, value: Union[None, List[str]]) -> None:
@@ -5288,7 +5091,6 @@ class EthicalConsiderationsClass(DictWrapper):
         """Getter: What risk mitigation strategies were used during MLModel development?"""
         return self._inner_dict.get('mitigations')  # type: ignore
     
-    
     @mitigations.setter
     def mitigations(self, value: Union[None, List[str]]) -> None:
         """Setter: What risk mitigation strategies were used during MLModel development?"""
@@ -5300,7 +5102,6 @@ class EthicalConsiderationsClass(DictWrapper):
         """Getter: What risks may be present in MLModel usage? Try to identify the potential recipients, likelihood, and magnitude of harms. If these cannot be determined, note that they were considered but remain unknown."""
         return self._inner_dict.get('risksAndHarms')  # type: ignore
     
-    
     @risksAndHarms.setter
     def risksAndHarms(self, value: Union[None, List[str]]) -> None:
         """Setter: What risks may be present in MLModel usage? Try to identify the potential recipients, likelihood, and magnitude of harms. If these cannot be determined, note that they were considered but remain unknown."""
@@ -5311,7 +5112,6 @@ class EthicalConsiderationsClass(DictWrapper):
     def useCases(self) -> Union[None, List[str]]:
         """Getter: Are there any known MLModel use cases that are especially fraught? This may connect directly to the intended use section"""
         return self._inner_dict.get('useCases')  # type: ignore
-    
     
     @useCases.setter
     def useCases(self, value: Union[None, List[str]]) -> None:
@@ -5345,7 +5145,6 @@ class EvaluationDataClass(DictWrapper):
     def evaluationData(self) -> List["BaseDataClass"]:
         """Getter: Details on the dataset(s) used for the quantitative analyses in the MLModel"""
         return self._inner_dict.get('evaluationData')  # type: ignore
-    
     
     @evaluationData.setter
     def evaluationData(self, value: List["BaseDataClass"]) -> None:
@@ -5386,7 +5185,6 @@ class IntendedUseClass(DictWrapper):
         """Getter: Primary Use cases for the MLModel."""
         return self._inner_dict.get('primaryUses')  # type: ignore
     
-    
     @primaryUses.setter
     def primaryUses(self, value: Union[None, List[str]]) -> None:
         """Setter: Primary Use cases for the MLModel."""
@@ -5398,7 +5196,6 @@ class IntendedUseClass(DictWrapper):
         """Getter: Primary Intended Users - For example, was the MLModel developed for entertainment purposes, for hobbyists, or enterprise solutions?"""
         return self._inner_dict.get('primaryUsers')  # type: ignore
     
-    
     @primaryUsers.setter
     def primaryUsers(self, value: Union[None, List[Union[str, "IntendedUserTypeClass"]]]) -> None:
         """Setter: Primary Intended Users - For example, was the MLModel developed for entertainment purposes, for hobbyists, or enterprise solutions?"""
@@ -5409,7 +5206,6 @@ class IntendedUseClass(DictWrapper):
     def outOfScopeUses(self) -> Union[None, List[str]]:
         """Getter: Highlight technology that the MLModel might easily be confused with, or related contexts that users could try to apply the MLModel to."""
         return self._inner_dict.get('outOfScopeUses')  # type: ignore
-    
     
     @outOfScopeUses.setter
     def outOfScopeUses(self, value: Union[None, List[str]]) -> None:
@@ -5461,7 +5257,6 @@ class MLFeaturePropertiesClass(DictWrapper):
         """Getter: Documentation of the MLFeature"""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: Union[None, str]) -> None:
         """Setter: Documentation of the MLFeature"""
@@ -5472,7 +5267,6 @@ class MLFeaturePropertiesClass(DictWrapper):
     def dataType(self) -> Union[None, Union[str, "MLFeatureDataTypeClass"]]:
         """Getter: Data Type of the MLFeature"""
         return self._inner_dict.get('dataType')  # type: ignore
-    
     
     @dataType.setter
     def dataType(self, value: Union[None, Union[str, "MLFeatureDataTypeClass"]]) -> None:
@@ -5485,7 +5279,6 @@ class MLFeaturePropertiesClass(DictWrapper):
         """Getter: Version of the MLFeature"""
         return self._inner_dict.get('version')  # type: ignore
     
-    
     @version.setter
     def version(self, value: Union[None, "VersionTagClass"]) -> None:
         """Setter: Version of the MLFeature"""
@@ -5496,7 +5289,6 @@ class MLFeaturePropertiesClass(DictWrapper):
     def sources(self) -> Union[None, List[str]]:
         """Getter: Source of the MLFeature"""
         return self._inner_dict.get('sources')  # type: ignore
-    
     
     @sources.setter
     def sources(self, value: Union[None, List[str]]) -> None:
@@ -5517,6 +5309,7 @@ class MLFeatureTablePropertiesClass(DictWrapper):
         super().__init__()
         
         if customProperties is None:
+            # default: {}
             self.customProperties = dict()
         else:
             self.customProperties = customProperties
@@ -5543,7 +5336,6 @@ class MLFeatureTablePropertiesClass(DictWrapper):
         """Getter: Custom property bag."""
         return self._inner_dict.get('customProperties')  # type: ignore
     
-    
     @customProperties.setter
     def customProperties(self, value: Dict[str, str]) -> None:
         """Setter: Custom property bag."""
@@ -5554,7 +5346,6 @@ class MLFeatureTablePropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Documentation of the MLFeatureTable"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -5567,7 +5358,6 @@ class MLFeatureTablePropertiesClass(DictWrapper):
         """Getter: List of features contained in the feature table"""
         return self._inner_dict.get('mlFeatures')  # type: ignore
     
-    
     @mlFeatures.setter
     def mlFeatures(self, value: Union[None, List[str]]) -> None:
         """Setter: List of features contained in the feature table"""
@@ -5578,7 +5368,6 @@ class MLFeatureTablePropertiesClass(DictWrapper):
     def mlPrimaryKeys(self) -> Union[None, List[str]]:
         """Getter: List of primary keys in the feature table (if multiple, assumed to act as a composite key)"""
         return self._inner_dict.get('mlPrimaryKeys')  # type: ignore
-    
     
     @mlPrimaryKeys.setter
     def mlPrimaryKeys(self, value: Union[None, List[str]]) -> None:
@@ -5616,7 +5405,6 @@ class MLModelFactorPromptsClass(DictWrapper):
         """Getter: What are foreseeable salient factors for which MLModel performance may vary, and how were these determined?"""
         return self._inner_dict.get('relevantFactors')  # type: ignore
     
-    
     @relevantFactors.setter
     def relevantFactors(self, value: Union[None, List["MLModelFactorsClass"]]) -> None:
         """Setter: What are foreseeable salient factors for which MLModel performance may vary, and how were these determined?"""
@@ -5627,7 +5415,6 @@ class MLModelFactorPromptsClass(DictWrapper):
     def evaluationFactors(self) -> Union[None, List["MLModelFactorsClass"]]:
         """Getter: Which factors are being reported, and why were these chosen?"""
         return self._inner_dict.get('evaluationFactors')  # type: ignore
-    
     
     @evaluationFactors.setter
     def evaluationFactors(self, value: Union[None, List["MLModelFactorsClass"]]) -> None:
@@ -5669,7 +5456,6 @@ class MLModelFactorsClass(DictWrapper):
     For human-centric machine learning MLModels, groups are people who share one or multiple characteristics."""
         return self._inner_dict.get('groups')  # type: ignore
     
-    
     @groups.setter
     def groups(self, value: Union[None, List[str]]) -> None:
         """Setter: Groups refers to distinct categories with similar characteristics that are present in the evaluation data instances.
@@ -5684,7 +5470,6 @@ class MLModelFactorsClass(DictWrapper):
     including lens, image stabilization, high dynamic range techniques, and background blurring for portrait mode."""
         return self._inner_dict.get('instrumentation')  # type: ignore
     
-    
     @instrumentation.setter
     def instrumentation(self, value: Union[None, List[str]]) -> None:
         """Setter: The performance of a MLModel can vary depending on what instruments were used to capture the input to the MLModel.
@@ -5697,7 +5482,6 @@ class MLModelFactorsClass(DictWrapper):
     def environment(self) -> Union[None, List[str]]:
         """Getter: A further factor affecting MLModel performance is the environment in which it is deployed."""
         return self._inner_dict.get('environment')  # type: ignore
-    
     
     @environment.setter
     def environment(self, value: Union[None, List[str]]) -> None:
@@ -5727,6 +5511,7 @@ class MLModelPropertiesClass(DictWrapper):
         self.hyperParameters = hyperParameters
         self.mlFeatures = mlFeatures
         if tags is None:
+            # default: []
             self.tags = list()
         else:
             self.tags = tags
@@ -5753,7 +5538,6 @@ class MLModelPropertiesClass(DictWrapper):
         """Getter: Documentation of the MLModel"""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: Union[None, str]) -> None:
         """Setter: Documentation of the MLModel"""
@@ -5764,7 +5548,6 @@ class MLModelPropertiesClass(DictWrapper):
     def date(self) -> Union[None, int]:
         """Getter: Date when the MLModel was developed"""
         return self._inner_dict.get('date')  # type: ignore
-    
     
     @date.setter
     def date(self, value: Union[None, int]) -> None:
@@ -5777,7 +5560,6 @@ class MLModelPropertiesClass(DictWrapper):
         """Getter: Version of the MLModel"""
         return self._inner_dict.get('version')  # type: ignore
     
-    
     @version.setter
     def version(self, value: Union[None, "VersionTagClass"]) -> None:
         """Setter: Version of the MLModel"""
@@ -5788,7 +5570,6 @@ class MLModelPropertiesClass(DictWrapper):
     def type(self) -> Union[None, str]:
         """Getter: Type of Algorithm or MLModel such as whether it is a Naive Bayes classifier, Convolutional Neural Network, etc"""
         return self._inner_dict.get('type')  # type: ignore
-    
     
     @type.setter
     def type(self, value: Union[None, str]) -> None:
@@ -5801,7 +5582,6 @@ class MLModelPropertiesClass(DictWrapper):
         """Getter: Hyper Parameters of the MLModel"""
         return self._inner_dict.get('hyperParameters')  # type: ignore
     
-    
     @hyperParameters.setter
     def hyperParameters(self, value: Union[None, Dict[str, Union[str, int, float, float, bool]]]) -> None:
         """Setter: Hyper Parameters of the MLModel"""
@@ -5813,7 +5593,6 @@ class MLModelPropertiesClass(DictWrapper):
         """Getter: List of features used for MLModel training"""
         return self._inner_dict.get('mlFeatures')  # type: ignore
     
-    
     @mlFeatures.setter
     def mlFeatures(self, value: Union[None, List[str]]) -> None:
         """Setter: List of features used for MLModel training"""
@@ -5824,7 +5603,6 @@ class MLModelPropertiesClass(DictWrapper):
     def tags(self) -> List[str]:
         """Getter: Tags for the MLModel"""
         return self._inner_dict.get('tags')  # type: ignore
-    
     
     @tags.setter
     def tags(self, value: List[str]) -> None:
@@ -5868,7 +5646,6 @@ class MLPrimaryKeyPropertiesClass(DictWrapper):
         """Getter: Documentation of the MLPrimaryKey"""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: Union[None, str]) -> None:
         """Setter: Documentation of the MLPrimaryKey"""
@@ -5879,7 +5656,6 @@ class MLPrimaryKeyPropertiesClass(DictWrapper):
     def dataType(self) -> Union[None, Union[str, "MLFeatureDataTypeClass"]]:
         """Getter: Data Type of the MLPrimaryKey"""
         return self._inner_dict.get('dataType')  # type: ignore
-    
     
     @dataType.setter
     def dataType(self, value: Union[None, Union[str, "MLFeatureDataTypeClass"]]) -> None:
@@ -5892,7 +5668,6 @@ class MLPrimaryKeyPropertiesClass(DictWrapper):
         """Getter: Version of the MLPrimaryKey"""
         return self._inner_dict.get('version')  # type: ignore
     
-    
     @version.setter
     def version(self, value: Union[None, "VersionTagClass"]) -> None:
         """Setter: Version of the MLPrimaryKey"""
@@ -5903,7 +5678,6 @@ class MLPrimaryKeyPropertiesClass(DictWrapper):
     def sources(self) -> List[str]:
         """Getter: Source of the MLPrimaryKey"""
         return self._inner_dict.get('sources')  # type: ignore
-    
     
     @sources.setter
     def sources(self, value: List[str]) -> None:
@@ -5941,7 +5715,6 @@ class MetricsClass(DictWrapper):
         """Getter: Measures of MLModel performance"""
         return self._inner_dict.get('performanceMeasures')  # type: ignore
     
-    
     @performanceMeasures.setter
     def performanceMeasures(self, value: Union[None, List[str]]) -> None:
         """Setter: Measures of MLModel performance"""
@@ -5952,7 +5725,6 @@ class MetricsClass(DictWrapper):
     def decisionThreshold(self) -> Union[None, List[str]]:
         """Getter: Decision Thresholds used (if any)?"""
         return self._inner_dict.get('decisionThreshold')  # type: ignore
-    
     
     @decisionThreshold.setter
     def decisionThreshold(self, value: Union[None, List[str]]) -> None:
@@ -5990,7 +5762,6 @@ class QuantitativeAnalysesClass(DictWrapper):
         """Getter: Link to a dashboard with results showing how the MLModel performed with respect to each factor"""
         return self._inner_dict.get('unitaryResults')  # type: ignore
     
-    
     @unitaryResults.setter
     def unitaryResults(self, value: Union[None, str]) -> None:
         """Setter: Link to a dashboard with results showing how the MLModel performed with respect to each factor"""
@@ -6001,7 +5772,6 @@ class QuantitativeAnalysesClass(DictWrapper):
     def intersectionalResults(self) -> Union[None, str]:
         """Getter: Link to a dashboard with results showing how the MLModel performed with respect to the intersection of evaluated factors?"""
         return self._inner_dict.get('intersectionalResults')  # type: ignore
-    
     
     @intersectionalResults.setter
     def intersectionalResults(self, value: Union[None, str]) -> None:
@@ -6035,7 +5805,6 @@ class SourceCodeClass(DictWrapper):
     def sourceCode(self) -> List["SourceCodeUrlClass"]:
         """Getter: Source Code along with types"""
         return self._inner_dict.get('sourceCode')  # type: ignore
-    
     
     @sourceCode.setter
     def sourceCode(self, value: List["SourceCodeUrlClass"]) -> None:
@@ -6073,7 +5842,6 @@ class SourceCodeUrlClass(DictWrapper):
         """Getter: Source Code Url Types"""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: Union[str, "SourceCodeUrlTypeClass"]) -> None:
         """Setter: Source Code Url Types"""
@@ -6084,7 +5852,6 @@ class SourceCodeUrlClass(DictWrapper):
     def sourceCodeUrl(self) -> str:
         """Getter: Source Code Url"""
         return self._inner_dict.get('sourceCodeUrl')  # type: ignore
-    
     
     @sourceCodeUrl.setter
     def sourceCodeUrl(self, value: str) -> None:
@@ -6127,7 +5894,6 @@ class TrainingDataClass(DictWrapper):
         """Getter: Details on the dataset(s) used for training the MLModel"""
         return self._inner_dict.get('trainingData')  # type: ignore
     
-    
     @trainingData.setter
     def trainingData(self, value: List["BaseDataClass"]) -> None:
         """Setter: Details on the dataset(s) used for training the MLModel"""
@@ -6167,7 +5933,6 @@ class MetadataAuditEventClass(DictWrapper):
         """Getter: Kafka audit header. See go/kafkaauditheader for more info."""
         return self._inner_dict.get('auditHeader')  # type: ignore
     
-    
     @auditHeader.setter
     def auditHeader(self, value: Union[None, "KafkaAuditHeaderClass"]) -> None:
         """Setter: Kafka audit header. See go/kafkaauditheader for more info."""
@@ -6179,7 +5944,6 @@ class MetadataAuditEventClass(DictWrapper):
         """Getter: Snapshot of the metadata before the update. Set to null for newly created metadata. Only the metadata aspects affected by the update are included in the snapshot."""
         return self._inner_dict.get('oldSnapshot')  # type: ignore
     
-    
     @oldSnapshot.setter
     def oldSnapshot(self, value: Union[None, "ChartSnapshotClass", "CorpGroupSnapshotClass", "CorpUserSnapshotClass", "DashboardSnapshotClass", "DataFlowSnapshotClass", "DataJobSnapshotClass", "DatasetSnapshotClass", "DataProcessSnapshotClass", "DataPlatformSnapshotClass", "MLModelSnapshotClass", "MLPrimaryKeySnapshotClass", "MLFeatureSnapshotClass", "MLFeatureTableSnapshotClass", "TagSnapshotClass", "GlossaryTermSnapshotClass", "GlossaryNodeSnapshotClass"]) -> None:
         """Setter: Snapshot of the metadata before the update. Set to null for newly created metadata. Only the metadata aspects affected by the update are included in the snapshot."""
@@ -6190,7 +5954,6 @@ class MetadataAuditEventClass(DictWrapper):
     def newSnapshot(self) -> Union["ChartSnapshotClass", "CorpGroupSnapshotClass", "CorpUserSnapshotClass", "DashboardSnapshotClass", "DataFlowSnapshotClass", "DataJobSnapshotClass", "DatasetSnapshotClass", "DataProcessSnapshotClass", "DataPlatformSnapshotClass", "MLModelSnapshotClass", "MLPrimaryKeySnapshotClass", "MLFeatureSnapshotClass", "MLFeatureTableSnapshotClass", "TagSnapshotClass", "GlossaryTermSnapshotClass", "GlossaryNodeSnapshotClass"]:
         """Getter: Snapshot of the metadata after the update. Only the metadata aspects affected by the update are included in the snapshot."""
         return self._inner_dict.get('newSnapshot')  # type: ignore
-    
     
     @newSnapshot.setter
     def newSnapshot(self, value: Union["ChartSnapshotClass", "CorpGroupSnapshotClass", "CorpUserSnapshotClass", "DashboardSnapshotClass", "DataFlowSnapshotClass", "DataJobSnapshotClass", "DatasetSnapshotClass", "DataProcessSnapshotClass", "DataPlatformSnapshotClass", "MLModelSnapshotClass", "MLPrimaryKeySnapshotClass", "MLFeatureSnapshotClass", "MLFeatureTableSnapshotClass", "TagSnapshotClass", "GlossaryTermSnapshotClass", "GlossaryNodeSnapshotClass"]) -> None:
@@ -6231,7 +5994,6 @@ class MetadataChangeEventClass(DictWrapper):
         """Getter: Kafka audit header. See go/kafkaauditheader for more info."""
         return self._inner_dict.get('auditHeader')  # type: ignore
     
-    
     @auditHeader.setter
     def auditHeader(self, value: Union[None, "KafkaAuditHeaderClass"]) -> None:
         """Setter: Kafka audit header. See go/kafkaauditheader for more info."""
@@ -6243,7 +6005,6 @@ class MetadataChangeEventClass(DictWrapper):
         """Getter: Snapshot of the proposed metadata change. Include only the aspects affected by the change in the snapshot."""
         return self._inner_dict.get('proposedSnapshot')  # type: ignore
     
-    
     @proposedSnapshot.setter
     def proposedSnapshot(self, value: Union["ChartSnapshotClass", "CorpGroupSnapshotClass", "CorpUserSnapshotClass", "DashboardSnapshotClass", "DataFlowSnapshotClass", "DataJobSnapshotClass", "DatasetSnapshotClass", "DataProcessSnapshotClass", "DataPlatformSnapshotClass", "MLModelSnapshotClass", "MLPrimaryKeySnapshotClass", "MLFeatureSnapshotClass", "MLFeatureTableSnapshotClass", "TagSnapshotClass", "GlossaryTermSnapshotClass", "GlossaryNodeSnapshotClass"]) -> None:
         """Setter: Snapshot of the proposed metadata change. Include only the aspects affected by the change in the snapshot."""
@@ -6254,7 +6015,6 @@ class MetadataChangeEventClass(DictWrapper):
     def proposedDelta(self) -> None:
         """Getter: Delta of the proposed metadata partial update."""
         return self._inner_dict.get('proposedDelta')  # type: ignore
-    
     
     @proposedDelta.setter
     def proposedDelta(self, value: None) -> None:
@@ -6289,7 +6049,6 @@ class ArrayTypeClass(DictWrapper):
         """Getter: List of types this array holds."""
         return self._inner_dict.get('nestedType')  # type: ignore
     
-    
     @nestedType.setter
     def nestedType(self, value: Union[None, List[str]]) -> None:
         """Setter: List of types this array holds."""
@@ -6322,7 +6081,6 @@ class BinaryJsonSchemaClass(DictWrapper):
     def schema(self) -> str:
         """Getter: The native schema text for binary JSON file format."""
         return self._inner_dict.get('schema')  # type: ignore
-    
     
     @schema.setter
     def schema(self, value: str) -> None:
@@ -6403,7 +6161,6 @@ class DatasetFieldForeignKeyClass(DictWrapper):
         """Getter: dataset that stores the resource."""
         return self._inner_dict.get('parentDataset')  # type: ignore
     
-    
     @parentDataset.setter
     def parentDataset(self, value: str) -> None:
         """Setter: dataset that stores the resource."""
@@ -6415,7 +6172,6 @@ class DatasetFieldForeignKeyClass(DictWrapper):
         """Getter: List of fields in hosting(current) SchemaMetadata that conform a foreign key. List can contain a single entry or multiple entries if several entries in hosting schema conform a foreign key in a single parent dataset."""
         return self._inner_dict.get('currentFieldPaths')  # type: ignore
     
-    
     @currentFieldPaths.setter
     def currentFieldPaths(self, value: List[str]) -> None:
         """Setter: List of fields in hosting(current) SchemaMetadata that conform a foreign key. List can contain a single entry or multiple entries if several entries in hosting schema conform a foreign key in a single parent dataset."""
@@ -6426,7 +6182,6 @@ class DatasetFieldForeignKeyClass(DictWrapper):
     def parentField(self) -> str:
         """Getter: SchemaField@fieldPath that uniquely identify field in parent dataset that this field references."""
         return self._inner_dict.get('parentField')  # type: ignore
-    
     
     @parentField.setter
     def parentField(self, value: str) -> None:
@@ -6487,7 +6242,6 @@ class EditableSchemaFieldInfoClass(DictWrapper):
         """Getter: FieldPath uniquely identifying the SchemaField this metadata is associated with"""
         return self._inner_dict.get('fieldPath')  # type: ignore
     
-    
     @fieldPath.setter
     def fieldPath(self, value: str) -> None:
         """Setter: FieldPath uniquely identifying the SchemaField this metadata is associated with"""
@@ -6499,7 +6253,6 @@ class EditableSchemaFieldInfoClass(DictWrapper):
         """Getter: Description"""
         return self._inner_dict.get('description')  # type: ignore
     
-    
     @description.setter
     def description(self, value: Union[None, str]) -> None:
         """Setter: Description"""
@@ -6510,7 +6263,6 @@ class EditableSchemaFieldInfoClass(DictWrapper):
     def globalTags(self) -> Union[None, "GlobalTagsClass"]:
         """Getter: Tags associated with the field"""
         return self._inner_dict.get('globalTags')  # type: ignore
-    
     
     @globalTags.setter
     def globalTags(self, value: Union[None, "GlobalTagsClass"]) -> None:
@@ -6532,10 +6284,12 @@ class EditableSchemaMetadataClass(DictWrapper):
         super().__init__()
         
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -6561,7 +6315,6 @@ class EditableSchemaMetadataClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
-    
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
@@ -6572,7 +6325,6 @@ class EditableSchemaMetadataClass(DictWrapper):
     def lastModified(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
-    
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
@@ -6585,7 +6337,6 @@ class EditableSchemaMetadataClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
     
-    
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
         """Setter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
@@ -6596,7 +6347,6 @@ class EditableSchemaMetadataClass(DictWrapper):
     def editableSchemaFieldInfo(self) -> List["EditableSchemaFieldInfoClass"]:
         """Getter: Client provided a list of fields from document schema."""
         return self._inner_dict.get('editableSchemaFieldInfo')  # type: ignore
-    
     
     @editableSchemaFieldInfo.setter
     def editableSchemaFieldInfo(self, value: List["EditableSchemaFieldInfoClass"]) -> None:
@@ -6654,7 +6404,6 @@ class EspressoSchemaClass(DictWrapper):
         """Getter: The native espresso document schema."""
         return self._inner_dict.get('documentSchema')  # type: ignore
     
-    
     @documentSchema.setter
     def documentSchema(self, value: str) -> None:
         """Setter: The native espresso document schema."""
@@ -6665,7 +6414,6 @@ class EspressoSchemaClass(DictWrapper):
     def tableSchema(self) -> str:
         """Getter: The espresso table schema definition."""
         return self._inner_dict.get('tableSchema')  # type: ignore
-    
     
     @tableSchema.setter
     def tableSchema(self, value: str) -> None:
@@ -6720,7 +6468,6 @@ class ForeignKeySpecClass(DictWrapper):
         """Getter: Foreign key definition in metadata schema."""
         return self._inner_dict.get('foreignKey')  # type: ignore
     
-    
     @foreignKey.setter
     def foreignKey(self, value: Union["DatasetFieldForeignKeyClass", "UrnForeignKeyClass"]) -> None:
         """Setter: Foreign key definition in metadata schema."""
@@ -6753,7 +6500,6 @@ class KafkaSchemaClass(DictWrapper):
     def documentSchema(self) -> str:
         """Getter: The native kafka document schema. This is a human readable avro document schema."""
         return self._inner_dict.get('documentSchema')  # type: ignore
-    
     
     @documentSchema.setter
     def documentSchema(self, value: str) -> None:
@@ -6791,7 +6537,6 @@ class KeyValueSchemaClass(DictWrapper):
         """Getter: The raw schema for the key in the key-value store."""
         return self._inner_dict.get('keySchema')  # type: ignore
     
-    
     @keySchema.setter
     def keySchema(self, value: str) -> None:
         """Setter: The raw schema for the key in the key-value store."""
@@ -6802,7 +6547,6 @@ class KeyValueSchemaClass(DictWrapper):
     def valueSchema(self) -> str:
         """Getter: The raw schema for the value in the key-value store."""
         return self._inner_dict.get('valueSchema')  # type: ignore
-    
     
     @valueSchema.setter
     def valueSchema(self, value: str) -> None:
@@ -6840,7 +6584,6 @@ class MapTypeClass(DictWrapper):
         """Getter: Key type in a map"""
         return self._inner_dict.get('keyType')  # type: ignore
     
-    
     @keyType.setter
     def keyType(self, value: Union[None, str]) -> None:
         """Setter: Key type in a map"""
@@ -6851,7 +6594,6 @@ class MapTypeClass(DictWrapper):
     def valueType(self) -> Union[None, str]:
         """Getter: Type of the value in a map"""
         return self._inner_dict.get('valueType')  # type: ignore
-    
     
     @valueType.setter
     def valueType(self, value: Union[None, str]) -> None:
@@ -6885,7 +6627,6 @@ class MySqlDDLClass(DictWrapper):
     def tableSchema(self) -> str:
         """Getter: The native schema in the dataset's platform. This is a human readable (json blob) table schema."""
         return self._inner_dict.get('tableSchema')  # type: ignore
-    
     
     @tableSchema.setter
     def tableSchema(self, value: str) -> None:
@@ -6960,7 +6701,6 @@ class OracleDDLClass(DictWrapper):
         """Getter: The native schema in the dataset's platform. This is a human readable (json blob) table schema."""
         return self._inner_dict.get('tableSchema')  # type: ignore
     
-    
     @tableSchema.setter
     def tableSchema(self, value: str) -> None:
         """Setter: The native schema in the dataset's platform. This is a human readable (json blob) table schema."""
@@ -6993,7 +6733,6 @@ class OrcSchemaClass(DictWrapper):
     def schema(self) -> str:
         """Getter: The native schema for ORC file format."""
         return self._inner_dict.get('schema')  # type: ignore
-    
     
     @schema.setter
     def schema(self, value: str) -> None:
@@ -7028,7 +6767,6 @@ class OtherSchemaClass(DictWrapper):
         """Getter: The native schema in the dataset's platform."""
         return self._inner_dict.get('rawSchema')  # type: ignore
     
-    
     @rawSchema.setter
     def rawSchema(self, value: str) -> None:
         """Setter: The native schema in the dataset's platform."""
@@ -7061,7 +6799,6 @@ class PrestoDDLClass(DictWrapper):
     def rawSchema(self) -> str:
         """Getter: The raw schema in the dataset's platform. This includes the DDL and the columns extracted from DDL."""
         return self._inner_dict.get('rawSchema')  # type: ignore
-    
     
     @rawSchema.setter
     def rawSchema(self, value: str) -> None:
@@ -7109,6 +6846,7 @@ class SchemaFieldClass(DictWrapper):
         self.fieldPath = fieldPath
         self.jsonPath = jsonPath
         if nullable is None:
+            # default: False
             self.nullable = self.RECORD_SCHEMA.field_map["nullable"].default
         else:
             self.nullable = nullable
@@ -7116,6 +6854,7 @@ class SchemaFieldClass(DictWrapper):
         self.type = type
         self.nativeDataType = nativeDataType
         if recursive is None:
+            # default: False
             self.recursive = self.RECORD_SCHEMA.field_map["recursive"].default
         else:
             self.recursive = recursive
@@ -7146,7 +6885,6 @@ class SchemaFieldClass(DictWrapper):
         """Getter: Flattened name of the field. Field is computed from jsonPath field. For data translation rules refer to wiki page above."""
         return self._inner_dict.get('fieldPath')  # type: ignore
     
-    
     @fieldPath.setter
     def fieldPath(self, value: str) -> None:
         """Setter: Flattened name of the field. Field is computed from jsonPath field. For data translation rules refer to wiki page above."""
@@ -7157,7 +6895,6 @@ class SchemaFieldClass(DictWrapper):
     def jsonPath(self) -> Union[None, str]:
         """Getter: Flattened name of a field in JSON Path notation."""
         return self._inner_dict.get('jsonPath')  # type: ignore
-    
     
     @jsonPath.setter
     def jsonPath(self, value: Union[None, str]) -> None:
@@ -7170,7 +6907,6 @@ class SchemaFieldClass(DictWrapper):
         """Getter: Indicates if this field is optional or nullable"""
         return self._inner_dict.get('nullable')  # type: ignore
     
-    
     @nullable.setter
     def nullable(self, value: bool) -> None:
         """Setter: Indicates if this field is optional or nullable"""
@@ -7181,7 +6917,6 @@ class SchemaFieldClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Description"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -7194,7 +6929,6 @@ class SchemaFieldClass(DictWrapper):
         """Getter: Platform independent field type of the field."""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: "SchemaFieldDataTypeClass") -> None:
         """Setter: Platform independent field type of the field."""
@@ -7205,7 +6939,6 @@ class SchemaFieldClass(DictWrapper):
     def nativeDataType(self) -> str:
         """Getter: The native type of the field in the dataset's platform as declared by platform schema."""
         return self._inner_dict.get('nativeDataType')  # type: ignore
-    
     
     @nativeDataType.setter
     def nativeDataType(self, value: str) -> None:
@@ -7218,7 +6951,6 @@ class SchemaFieldClass(DictWrapper):
         """Getter: There are use cases when a field in type B references type A. A field in A references field of type B. In such cases, we will mark the first field as recursive."""
         return self._inner_dict.get('recursive')  # type: ignore
     
-    
     @recursive.setter
     def recursive(self, value: bool) -> None:
         """Setter: There are use cases when a field in type B references type A. A field in A references field of type B. In such cases, we will mark the first field as recursive."""
@@ -7230,7 +6962,6 @@ class SchemaFieldClass(DictWrapper):
         """Getter: Tags associated with the field"""
         return self._inner_dict.get('globalTags')  # type: ignore
     
-    
     @globalTags.setter
     def globalTags(self, value: Union[None, "GlobalTagsClass"]) -> None:
         """Setter: Tags associated with the field"""
@@ -7241,7 +6972,6 @@ class SchemaFieldClass(DictWrapper):
     def glossaryTerms(self) -> Union[None, "GlossaryTermsClass"]:
         """Getter: Glossary terms associated with the field"""
         return self._inner_dict.get('glossaryTerms')  # type: ignore
-    
     
     @glossaryTerms.setter
     def glossaryTerms(self, value: Union[None, "GlossaryTermsClass"]) -> None:
@@ -7276,7 +7006,6 @@ class SchemaFieldDataTypeClass(DictWrapper):
         """Getter: Data platform specific types"""
         return self._inner_dict.get('type')  # type: ignore
     
-    
     @type.setter
     def type(self, value: Union["BooleanTypeClass", "FixedTypeClass", "StringTypeClass", "BytesTypeClass", "NumberTypeClass", "DateTypeClass", "TimeTypeClass", "EnumTypeClass", "NullTypeClass", "MapTypeClass", "ArrayTypeClass", "UnionTypeClass", "RecordTypeClass"]) -> None:
         """Setter: Data platform specific types"""
@@ -7308,10 +7037,12 @@ class SchemaMetadataClass(DictWrapper):
         self.platform = platform
         self.version = version
         if created is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.created = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["created"].default, writers_schema=self.RECORD_SCHEMA.field_map["created"].type)
         else:
             self.created = created
         if lastModified is None:
+            # default: {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
             self.lastModified = _json_converter.from_json_object(self.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=self.RECORD_SCHEMA.field_map["lastModified"].type)
         else:
             self.lastModified = lastModified
@@ -7352,7 +7083,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: Schema name e.g. PageViewEvent, identity.Profile, ams.account_management_tracking"""
         return self._inner_dict.get('schemaName')  # type: ignore
     
-    
     @schemaName.setter
     def schemaName(self, value: str) -> None:
         """Setter: Schema name e.g. PageViewEvent, identity.Profile, ams.account_management_tracking"""
@@ -7363,7 +7093,6 @@ class SchemaMetadataClass(DictWrapper):
     def platform(self) -> str:
         """Getter: Standardized platform urn where schema is defined. The data platform Urn (urn:li:platform:{platform_name})"""
         return self._inner_dict.get('platform')  # type: ignore
-    
     
     @platform.setter
     def platform(self, value: str) -> None:
@@ -7376,7 +7105,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: Every change to SchemaMetadata in the resource results in a new version. Version is server assigned. This version is differ from platform native schema version."""
         return self._inner_dict.get('version')  # type: ignore
     
-    
     @version.setter
     def version(self, value: int) -> None:
         """Setter: Every change to SchemaMetadata in the resource results in a new version. Version is server assigned. This version is differ from platform native schema version."""
@@ -7387,7 +7115,6 @@ class SchemaMetadataClass(DictWrapper):
     def created(self) -> "AuditStampClass":
         """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
-    
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
@@ -7400,7 +7127,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
-    
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
         """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
@@ -7411,7 +7137,6 @@ class SchemaMetadataClass(DictWrapper):
     def deleted(self) -> Union[None, "AuditStampClass"]:
         """Getter: An AuditStamp corresponding to the deletion of this resource/association/sub-resource. Logically, deleted MUST have a later timestamp than creation. It may or may not have the same time as lastModified depending upon the resource/association/sub-resource semantics."""
         return self._inner_dict.get('deleted')  # type: ignore
-    
     
     @deleted.setter
     def deleted(self, value: Union[None, "AuditStampClass"]) -> None:
@@ -7424,7 +7149,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: Dataset this schema metadata is associated with."""
         return self._inner_dict.get('dataset')  # type: ignore
     
-    
     @dataset.setter
     def dataset(self, value: Union[None, str]) -> None:
         """Setter: Dataset this schema metadata is associated with."""
@@ -7435,7 +7159,6 @@ class SchemaMetadataClass(DictWrapper):
     def cluster(self) -> Union[None, str]:
         """Getter: The cluster this schema metadata resides from"""
         return self._inner_dict.get('cluster')  # type: ignore
-    
     
     @cluster.setter
     def cluster(self, value: Union[None, str]) -> None:
@@ -7448,7 +7171,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: the SHA1 hash of the schema content"""
         return self._inner_dict.get('hash')  # type: ignore
     
-    
     @hash.setter
     def hash(self, value: str) -> None:
         """Setter: the SHA1 hash of the schema content"""
@@ -7459,7 +7181,6 @@ class SchemaMetadataClass(DictWrapper):
     def platformSchema(self) -> Union["EspressoSchemaClass", "OracleDDLClass", "MySqlDDLClass", "PrestoDDLClass", "KafkaSchemaClass", "BinaryJsonSchemaClass", "OrcSchemaClass", "SchemalessClass", "KeyValueSchemaClass", "OtherSchemaClass"]:
         """Getter: The native schema in the dataset's platform."""
         return self._inner_dict.get('platformSchema')  # type: ignore
-    
     
     @platformSchema.setter
     def platformSchema(self, value: Union["EspressoSchemaClass", "OracleDDLClass", "MySqlDDLClass", "PrestoDDLClass", "KafkaSchemaClass", "BinaryJsonSchemaClass", "OrcSchemaClass", "SchemalessClass", "KeyValueSchemaClass", "OtherSchemaClass"]) -> None:
@@ -7472,7 +7193,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: Client provided a list of fields from document schema."""
         return self._inner_dict.get('fields')  # type: ignore
     
-    
     @fields.setter
     def fields(self, value: List["SchemaFieldClass"]) -> None:
         """Setter: Client provided a list of fields from document schema."""
@@ -7484,7 +7204,6 @@ class SchemaMetadataClass(DictWrapper):
         """Getter: Client provided list of fields that define primary keys to access record. Field order defines hierarchical espresso keys. Empty lists indicates absence of primary key access patter. Value is a SchemaField@fieldPath."""
         return self._inner_dict.get('primaryKeys')  # type: ignore
     
-    
     @primaryKeys.setter
     def primaryKeys(self, value: Union[None, List[str]]) -> None:
         """Setter: Client provided list of fields that define primary keys to access record. Field order defines hierarchical espresso keys. Empty lists indicates absence of primary key access patter. Value is a SchemaField@fieldPath."""
@@ -7495,7 +7214,6 @@ class SchemaMetadataClass(DictWrapper):
     def foreignKeysSpecs(self) -> Union[None, Dict[str, "ForeignKeySpecClass"]]:
         """Getter: Map captures all the references schema makes to external datasets. Map key is ForeignKeySpecName typeref."""
         return self._inner_dict.get('foreignKeysSpecs')  # type: ignore
-    
     
     @foreignKeysSpecs.setter
     def foreignKeysSpecs(self, value: Union[None, Dict[str, "ForeignKeySpecClass"]]) -> None:
@@ -7590,7 +7308,6 @@ class UnionTypeClass(DictWrapper):
         """Getter: List of types in union type."""
         return self._inner_dict.get('nestedTypes')  # type: ignore
     
-    
     @nestedTypes.setter
     def nestedTypes(self, value: Union[None, List[str]]) -> None:
         """Setter: List of types in union type."""
@@ -7623,7 +7340,6 @@ class UrnForeignKeyClass(DictWrapper):
     def currentFieldPath(self) -> str:
         """Getter: Field in hosting(current) SchemaMetadata."""
         return self._inner_dict.get('currentFieldPath')  # type: ignore
-    
     
     @currentFieldPath.setter
     def currentFieldPath(self, value: str) -> None:
@@ -7661,7 +7377,6 @@ class TagPropertiesClass(DictWrapper):
         """Getter: Name of the tag"""
         return self._inner_dict.get('name')  # type: ignore
     
-    
     @name.setter
     def name(self, value: str) -> None:
         """Setter: Name of the tag"""
@@ -7672,7 +7387,6 @@ class TagPropertiesClass(DictWrapper):
     def description(self) -> Union[None, str]:
         """Getter: Documentation of the tag"""
         return self._inner_dict.get('description')  # type: ignore
-    
     
     @description.setter
     def description(self, value: Union[None, str]) -> None:
@@ -7710,7 +7424,6 @@ class FieldUsageCountsClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('fieldName')  # type: ignore
     
-    
     @fieldName.setter
     def fieldName(self, value: str) -> None:
         # No docs available.
@@ -7721,7 +7434,6 @@ class FieldUsageCountsClass(DictWrapper):
     def count(self) -> int:
         # No docs available.
         return self._inner_dict.get('count')  # type: ignore
-    
     
     @count.setter
     def count(self, value: int) -> None:
@@ -7765,7 +7477,6 @@ class UsageAggregationClass(DictWrapper):
         """Getter:  Bucket start time in milliseconds """
         return self._inner_dict.get('bucket')  # type: ignore
     
-    
     @bucket.setter
     def bucket(self, value: int) -> None:
         """Setter:  Bucket start time in milliseconds """
@@ -7776,7 +7487,6 @@ class UsageAggregationClass(DictWrapper):
     def duration(self) -> Union[str, "WindowDurationClass"]:
         """Getter:  Bucket duration """
         return self._inner_dict.get('duration')  # type: ignore
-    
     
     @duration.setter
     def duration(self, value: Union[str, "WindowDurationClass"]) -> None:
@@ -7789,7 +7499,6 @@ class UsageAggregationClass(DictWrapper):
         """Getter:  Resource associated with these usage stats """
         return self._inner_dict.get('resource')  # type: ignore
     
-    
     @resource.setter
     def resource(self, value: str) -> None:
         """Setter:  Resource associated with these usage stats """
@@ -7800,7 +7509,6 @@ class UsageAggregationClass(DictWrapper):
     def metrics(self) -> "UsageAggregationMetricsClass":
         """Getter:  Metrics associated with this bucket """
         return self._inner_dict.get('metrics')  # type: ignore
-    
     
     @metrics.setter
     def metrics(self, value: "UsageAggregationMetricsClass") -> None:
@@ -7848,7 +7556,6 @@ class UsageAggregationMetricsClass(DictWrapper):
         """Getter:  Unique user count """
         return self._inner_dict.get('uniqueUserCount')  # type: ignore
     
-    
     @uniqueUserCount.setter
     def uniqueUserCount(self, value: Union[None, int]) -> None:
         """Setter:  Unique user count """
@@ -7859,7 +7566,6 @@ class UsageAggregationMetricsClass(DictWrapper):
     def users(self) -> Union[None, List["UserUsageCountsClass"]]:
         """Getter:  Users within this bucket, with frequency counts """
         return self._inner_dict.get('users')  # type: ignore
-    
     
     @users.setter
     def users(self, value: Union[None, List["UserUsageCountsClass"]]) -> None:
@@ -7872,7 +7578,6 @@ class UsageAggregationMetricsClass(DictWrapper):
         """Getter:  Total SQL query count """
         return self._inner_dict.get('totalSqlQueries')  # type: ignore
     
-    
     @totalSqlQueries.setter
     def totalSqlQueries(self, value: Union[None, int]) -> None:
         """Setter:  Total SQL query count """
@@ -7884,7 +7589,6 @@ class UsageAggregationMetricsClass(DictWrapper):
         """Getter:  Frequent SQL queries; mostly makes sense for datasets in SQL databases """
         return self._inner_dict.get('topSqlQueries')  # type: ignore
     
-    
     @topSqlQueries.setter
     def topSqlQueries(self, value: Union[None, List[str]]) -> None:
         """Setter:  Frequent SQL queries; mostly makes sense for datasets in SQL databases """
@@ -7895,7 +7599,6 @@ class UsageAggregationMetricsClass(DictWrapper):
     def fields(self) -> Union[None, List["FieldUsageCountsClass"]]:
         """Getter:  Field-level usage stats """
         return self._inner_dict.get('fields')  # type: ignore
-    
     
     @fields.setter
     def fields(self, value: Union[None, List["FieldUsageCountsClass"]]) -> None:
@@ -7936,7 +7639,6 @@ class UserUsageCountsClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('user')  # type: ignore
     
-    
     @user.setter
     def user(self, value: Union[None, str]) -> None:
         # No docs available.
@@ -7948,7 +7650,6 @@ class UserUsageCountsClass(DictWrapper):
         # No docs available.
         return self._inner_dict.get('count')  # type: ignore
     
-    
     @count.setter
     def count(self, value: int) -> None:
         # No docs available.
@@ -7959,7 +7660,6 @@ class UserUsageCountsClass(DictWrapper):
     def userEmail(self) -> Union[None, str]:
         """Getter:  If user_email is set, we attempt to resolve the user's urn upon ingest """
         return self._inner_dict.get('userEmail')  # type: ignore
-    
     
     @userEmail.setter
     def userEmail(self, value: Union[None, str]) -> None:

--- a/metadata-ingestion/src/datahub/metadata/schema_classes.py
+++ b/metadata-ingestion/src/datahub/metadata/schema_classes.py
@@ -445,15 +445,21 @@ class EditableChartPropertiesClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.chart.EditableChartProperties")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
         description: Union[None, str]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.description = description
     
@@ -465,33 +471,33 @@ class EditableChartPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(EditableChartPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableChartPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(EditableChartPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableChartPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -637,14 +643,20 @@ class ChangeAuditStampsClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.common.ChangeAuditStamps")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
     
     @classmethod
@@ -655,32 +667,32 @@ class ChangeAuditStampsClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(ChangeAuditStampsClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=ChangeAuditStampsClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(ChangeAuditStampsClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=ChangeAuditStampsClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -1269,12 +1281,15 @@ class OwnershipClass(DictWrapper):
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.common.Ownership")
     def __init__(self,
         owners: List["OwnerClass"],
-        lastModified: "AuditStampClass",
+        lastModified: Optional["AuditStampClass"]=None,
     ):
         super().__init__()
         
         self.owners = owners
-        self.lastModified = lastModified
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
     
     @classmethod
     def construct_with_defaults(cls) -> "OwnershipClass":
@@ -1285,7 +1300,7 @@ class OwnershipClass(DictWrapper):
     
     def _restore_defaults(self) -> None:
         self.owners = list()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.lastModified = _json_converter.from_json_object(OwnershipClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=OwnershipClass.RECORD_SCHEMA.field_map["lastModified"].type)
     
     
     @property
@@ -1302,13 +1317,13 @@ class OwnershipClass(DictWrapper):
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: Audit stamp containing who last modified the record and when."""
+        """Getter: Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: Audit stamp containing who last modified the record and when."""
+        """Setter: Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -1740,15 +1755,21 @@ class EditableDashboardPropertiesClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.dashboard.EditableDashboardProperties")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
         description: Union[None, str]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.description = description
     
@@ -1760,33 +1781,33 @@ class EditableDashboardPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDashboardPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -2093,15 +2114,21 @@ class EditableDataFlowPropertiesClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.datajob.EditableDataFlowProperties")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
         description: Union[None, str]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.description = description
     
@@ -2113,33 +2140,33 @@ class EditableDataFlowPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDataFlowPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -2173,15 +2200,21 @@ class EditableDataJobPropertiesClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.datajob.EditableDataJobProperties")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
         description: Union[None, str]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.description = description
     
@@ -2193,33 +2226,33 @@ class EditableDataJobPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDataJobPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -2763,15 +2796,21 @@ class EditableDatasetPropertiesClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.dataset.EditableDatasetProperties")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
         description: Union[None, str]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.description = description
     
@@ -2783,33 +2822,33 @@ class EditableDatasetPropertiesClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableDatasetPropertiesClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.description = self.RECORD_SCHEMA.field_map["description"].default
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -2867,13 +2906,15 @@ class UpstreamClass(DictWrapper):
     
     @property
     def auditStamp(self) -> "AuditStampClass":
-        """Getter: Audit stamp containing who reported the lineage and when"""
+        """Getter: Audit stamp containing who reported the lineage and when.
+    WARNING: this field is deprecated and may be removed in a future release."""
         return self._inner_dict.get('auditStamp')  # type: ignore
     
     
     @auditStamp.setter
     def auditStamp(self, value: "AuditStampClass") -> None:
-        """Setter: Audit stamp containing who reported the lineage and when"""
+        """Setter: Audit stamp containing who reported the lineage and when.
+    WARNING: this field is deprecated and may be removed in a future release."""
         self._inner_dict['auditStamp'] = value
     
     
@@ -6480,15 +6521,21 @@ class EditableSchemaMetadataClass(DictWrapper):
     
     RECORD_SCHEMA = get_schema_type("com.linkedin.pegasus2avro.schema.EditableSchemaMetadata")
     def __init__(self,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
         editableSchemaFieldInfo: List["EditableSchemaFieldInfoClass"],
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
     ):
         super().__init__()
         
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.editableSchemaFieldInfo = editableSchemaFieldInfo
     
@@ -6500,33 +6547,33 @@ class EditableSchemaMetadataClass(DictWrapper):
         return self
     
     def _restore_defaults(self) -> None:
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=EditableSchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.editableSchemaFieldInfo = list()
     
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     
@@ -7241,11 +7288,11 @@ class SchemaMetadataClass(DictWrapper):
         schemaName: str,
         platform: str,
         version: int,
-        created: "AuditStampClass",
-        lastModified: "AuditStampClass",
         hash: str,
         platformSchema: Union["EspressoSchemaClass", "OracleDDLClass", "MySqlDDLClass", "PrestoDDLClass", "KafkaSchemaClass", "BinaryJsonSchemaClass", "OrcSchemaClass", "SchemalessClass", "KeyValueSchemaClass", "OtherSchemaClass"],
         fields: List["SchemaFieldClass"],
+        created: Optional["AuditStampClass"]=None,
+        lastModified: Optional["AuditStampClass"]=None,
         deleted: Union[None, "AuditStampClass"]=None,
         dataset: Union[None, str]=None,
         cluster: Union[None, str]=None,
@@ -7257,8 +7304,14 @@ class SchemaMetadataClass(DictWrapper):
         self.schemaName = schemaName
         self.platform = platform
         self.version = version
-        self.created = created
-        self.lastModified = lastModified
+        if created is None:
+            self.created = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.created = created
+        if lastModified is None:
+            self.lastModified = {'actor': 'urn:li:corpuser:unknown', 'impersonator': None, 'time': 0}
+        else:
+            self.lastModified = lastModified
         self.deleted = deleted
         self.dataset = dataset
         self.cluster = cluster
@@ -7279,8 +7332,8 @@ class SchemaMetadataClass(DictWrapper):
         self.schemaName = str()
         self.platform = str()
         self.version = int()
-        self.created = AuditStampClass.construct_with_defaults()
-        self.lastModified = AuditStampClass.construct_with_defaults()
+        self.created = _json_converter.from_json_object(SchemaMetadataClass.RECORD_SCHEMA.field_map["created"].default, writers_schema=SchemaMetadataClass.RECORD_SCHEMA.field_map["created"].type)
+        self.lastModified = _json_converter.from_json_object(SchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].default, writers_schema=SchemaMetadataClass.RECORD_SCHEMA.field_map["lastModified"].type)
         self.deleted = self.RECORD_SCHEMA.field_map["deleted"].default
         self.dataset = self.RECORD_SCHEMA.field_map["dataset"].default
         self.cluster = self.RECORD_SCHEMA.field_map["cluster"].default
@@ -7329,25 +7382,25 @@ class SchemaMetadataClass(DictWrapper):
     
     @property
     def created(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Getter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('created')  # type: ignore
     
     
     @created.setter
     def created(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource"""
+        """Setter: An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data."""
         self._inner_dict['created'] = value
     
     
     @property
     def lastModified(self) -> "AuditStampClass":
-        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Getter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         return self._inner_dict.get('lastModified')  # type: ignore
     
     
     @lastModified.setter
     def lastModified(self, value: "AuditStampClass") -> None:
-        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"""
+        """Setter: An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data."""
         self._inner_dict['lastModified'] = value
     
     

--- a/metadata-ingestion/src/datahub/metadata/schemas/MetadataAuditEvent.avsc
+++ b/metadata-ingestion/src/datahub/metadata/schemas/MetadataAuditEvent.avsc
@@ -2114,7 +2114,13 @@
                               {
                                 "name": "auditStamp",
                                 "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                                "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
+                                "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+                                "default": {
+                                  "actor": "urn:li:corpuser:unknown",
+                                  "impersonator": null,
+                                  "time": 0
+                                },
+                                "deprecated": "we no longer associate a timestamp per upstream edge"
                               },
                               {
                                 "name": "dataset",

--- a/metadata-ingestion/src/datahub/metadata/schemas/MetadataAuditEvent.avsc
+++ b/metadata-ingestion/src/datahub/metadata/schemas/MetadataAuditEvent.avsc
@@ -227,12 +227,22 @@
                                   }
                                 ]
                               },
-                              "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                              "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                              "default": {
+                                "actor": "urn:li:corpuser:unknown",
+                                "impersonator": null,
+                                "time": 0
+                              }
                             },
                             {
                               "name": "lastModified",
                               "type": "AuditStamp",
-                              "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                              "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                              "default": {
+                                "actor": "urn:li:corpuser:unknown",
+                                "impersonator": null,
+                                "time": 0
+                              }
                             },
                             {
                               "name": "deleted",
@@ -402,12 +412,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -557,7 +577,12 @@
                       {
                         "name": "lastModified",
                         "type": "AuditStamp",
-                        "doc": "Audit stamp containing who last modified the record and when."
+                        "doc": "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       }
                     ],
                     "Aspect": {
@@ -1187,12 +1212,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -1368,12 +1403,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -1666,12 +1711,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -1868,12 +1923,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -2049,7 +2114,7 @@
                               {
                                 "name": "auditStamp",
                                 "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                                "doc": "Audit stamp containing who reported the lineage and when"
+                                "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
                               },
                               {
                                 "name": "dataset",
@@ -2178,12 +2243,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -2705,12 +2780,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",

--- a/metadata-ingestion/src/datahub/metadata/schemas/MetadataChangeEvent.avsc
+++ b/metadata-ingestion/src/datahub/metadata/schemas/MetadataChangeEvent.avsc
@@ -226,12 +226,22 @@
                                   }
                                 ]
                               },
-                              "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                              "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                              "default": {
+                                "actor": "urn:li:corpuser:unknown",
+                                "impersonator": null,
+                                "time": 0
+                              }
                             },
                             {
                               "name": "lastModified",
                               "type": "AuditStamp",
-                              "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                              "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                              "default": {
+                                "actor": "urn:li:corpuser:unknown",
+                                "impersonator": null,
+                                "time": 0
+                              }
                             },
                             {
                               "name": "deleted",
@@ -401,12 +411,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -556,7 +576,12 @@
                       {
                         "name": "lastModified",
                         "type": "AuditStamp",
-                        "doc": "Audit stamp containing who last modified the record and when."
+                        "doc": "Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       }
                     ],
                     "Aspect": {
@@ -1186,12 +1211,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -1367,12 +1402,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -1665,12 +1710,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -1867,12 +1922,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -2048,7 +2113,7 @@
                               {
                                 "name": "auditStamp",
                                 "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                                "doc": "Audit stamp containing who reported the lineage and when"
+                                "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
                               },
                               {
                                 "name": "dataset",
@@ -2177,12 +2242,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",
@@ -2704,12 +2779,22 @@
                       {
                         "name": "created",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource"
+                        "doc": "An AuditStamp corresponding to the creation of this resource/association/sub-resource. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "lastModified",
                         "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created"
+                        "doc": "An AuditStamp corresponding to the last modification of this resource/association/sub-resource. If no modification has happened since creation, lastModified should be the same as created. A value of 0 for time indicates missing data.",
+                        "default": {
+                          "actor": "urn:li:corpuser:unknown",
+                          "impersonator": null,
+                          "time": 0
+                        }
                       },
                       {
                         "name": "deleted",

--- a/metadata-ingestion/src/datahub/metadata/schemas/MetadataChangeEvent.avsc
+++ b/metadata-ingestion/src/datahub/metadata/schemas/MetadataChangeEvent.avsc
@@ -2113,7 +2113,13 @@
                               {
                                 "name": "auditStamp",
                                 "type": "com.linkedin.pegasus2avro.common.AuditStamp",
-                                "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release."
+                                "doc": "Audit stamp containing who reported the lineage and when.\nWARNING: this field is deprecated and may be removed in a future release.",
+                                "default": {
+                                  "actor": "urn:li:corpuser:unknown",
+                                  "impersonator": null,
+                                  "time": 0
+                                },
+                                "deprecated": "we no longer associate a timestamp per upstream edge"
                               },
                               {
                                 "name": "dataset",

--- a/metadata-ingestion/tests/integration/dbt/dbt_mces_golden.json
+++ b/metadata-ingestion/tests/integration/dbt/dbt_mces_golden.json
@@ -23,8 +23,8 @@
                         "upstreams": [
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.customer,PROD)",
@@ -32,8 +32,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.address,PROD)",
@@ -41,8 +41,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.city,PROD)",
@@ -57,13 +57,13 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -109,8 +109,8 @@
                         "upstreams": [
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_by_customer_by_month,PROD)",
@@ -118,8 +118,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.customer_details,PROD)",
@@ -134,13 +134,13 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -247,8 +247,8 @@
                         "upstreams": [
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_01,PROD)",
@@ -256,8 +256,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
@@ -265,8 +265,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_02,PROD)",
@@ -274,8 +274,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_03,PROD)",
@@ -283,8 +283,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_04,PROD)",
@@ -292,8 +292,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_05,PROD)",
@@ -301,8 +301,8 @@
                             },
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.public.payment_p2020_06,PROD)",
@@ -317,13 +317,13 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -460,8 +460,8 @@
                         "upstreams": [
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:dbt_executor",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,pagila.dbt_postgres.payments_base,PROD)",
@@ -476,13 +476,13 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -580,8 +580,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -699,8 +699,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -878,8 +878,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -982,8 +982,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -1101,8 +1101,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -1205,8 +1205,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -1414,8 +1414,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -1563,8 +1563,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -1712,8 +1712,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -1861,8 +1861,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -2010,8 +2010,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
@@ -2159,8 +2159,8 @@
                         "platform": "urn:li:dataPlatform:dbt",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:dbt_executor",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {

--- a/metadata-ingestion/tests/integration/hive/hive_mces_golden.json
+++ b/metadata-ingestion/tests/integration/hive/hive_mces_golden.json
@@ -1,409 +1,409 @@
 [
 {
-  "auditHeader": null,
-  "proposedSnapshot": {
-    "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-      "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default._test_table_underscore,PROD)",
-      "aspects": [
-        {
-          "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-            "customProperties": {
-              "Database:": "default",
-              "Owner:": "root",
-              "CreateTime:": "Wed Jun 30 00:48:37 UTC 2021",
-              "LastAccessTime:": "UNKNOWN",
-              "Retention:": "0",
-              "Location:": "hdfs://namenode:8020/user/hive/warehouse/_test_table_underscore",
-              "Table Type:": "MANAGED_TABLE",
-              "Table Parameters: COLUMN_STATS_ACCURATE": "{\\\"BASIC_STATS\\\":\\\"true\\\"}",
-              "Table Parameters: numFiles": "0",
-              "Table Parameters: numRows": "0",
-              "Table Parameters: rawDataSize": "0",
-              "Table Parameters: totalSize": "0",
-              "Table Parameters: transient_lastDdlTime": "1625014117",
-              "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-              "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
-              "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-              "Compressed:": "No",
-              "Num Buckets:": "-1",
-              "Bucket Columns:": "[]",
-              "Sort Columns:": "[]",
-              "Storage Desc Params: serialization.format": "1"
-            },
-            "externalUrl": null,
-            "description": null,
-            "uri": null,
-            "tags": []
-          }
-        },
-        {
-          "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-            "schemaName": "default._test_table_underscore",
-            "platform": "urn:li:dataPlatform:hive",
-            "version": 0,
-            "created": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "lastModified": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "deleted": null,
-            "dataset": null,
-            "cluster": null,
-            "hash": "",
-            "platformSchema": {
-              "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                "tableSchema": ""
-              }
-            },
-            "fields": [
-              {
-                "fieldPath": "foo",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.NumberType": {}
-                  }
+    "auditHeader": null,
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default._test_table_underscore,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "Database:": "default",
+                            "Owner:": "root",
+                            "CreateTime:": "Fri Jul 02 22:51:46 UTC 2021",
+                            "LastAccessTime:": "UNKNOWN",
+                            "Retention:": "0",
+                            "Location:": "hdfs://namenode:8020/user/hive/warehouse/_test_table_underscore",
+                            "Table Type:": "MANAGED_TABLE",
+                            "Table Parameters: COLUMN_STATS_ACCURATE": "{\\\"BASIC_STATS\\\":\\\"true\\\"}",
+                            "Table Parameters: numFiles": "0",
+                            "Table Parameters: numRows": "0",
+                            "Table Parameters: rawDataSize": "0",
+                            "Table Parameters: totalSize": "0",
+                            "Table Parameters: transient_lastDdlTime": "1625266306",
+                            "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                            "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
+                            "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                            "Compressed:": "No",
+                            "Num Buckets:": "-1",
+                            "Bucket Columns:": "[]",
+                            "Sort Columns:": "[]",
+                            "Storage Desc Params: serialization.format": "1"
+                        },
+                        "externalUrl": null,
+                        "description": null,
+                        "uri": null,
+                        "tags": []
+                    }
                 },
-                "nativeDataType": "int",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              },
-              {
-                "fieldPath": "bar",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.StringType": {}
-                  }
-                },
-                "nativeDataType": "string",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              }
-            ],
-            "primaryKeys": null,
-            "foreignKeysSpecs": null
-          }
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "default._test_table_underscore",
+                        "platform": "urn:li:dataPlatform:hive",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "deleted": null,
+                        "dataset": null,
+                        "cluster": null,
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "foo",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            },
+                            {
+                                "fieldPath": "bar",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            }
+                        ],
+                        "primaryKeys": null,
+                        "foreignKeysSpecs": null
+                    }
+                }
+            ]
         }
-      ]
-    }
-  },
-  "proposedDelta": null
+    },
+    "proposedDelta": null
 },
 {
-  "auditHeader": null,
-  "proposedSnapshot": {
-    "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-      "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default.array_struct_test,PROD)",
-      "aspects": [
-        {
-          "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-            "customProperties": {
-              "Database:": "default",
-              "Owner:": "root",
-              "CreateTime:": "Wed Jun 30 00:48:37 UTC 2021",
-              "LastAccessTime:": "UNKNOWN",
-              "Retention:": "0",
-              "Location:": "hdfs://namenode:8020/user/hive/warehouse/array_struct_test",
-              "Table Type:": "MANAGED_TABLE",
-              "Table Parameters: COLUMN_STATS_ACCURATE": "{\\\"BASIC_STATS\\\":\\\"true\\\"}",
-              "Table Parameters: numFiles": "1",
-              "Table Parameters: numRows": "1",
-              "Table Parameters: rawDataSize": "32",
-              "Table Parameters: totalSize": "33",
-              "Table Parameters: transient_lastDdlTime": "1625014122",
-              "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-              "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
-              "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-              "Compressed:": "No",
-              "Num Buckets:": "-1",
-              "Bucket Columns:": "[]",
-              "Sort Columns:": "[]",
-              "Storage Desc Params: serialization.format": "1"
-            },
-            "externalUrl": null,
-            "description": null,
-            "uri": null,
-            "tags": []
-          }
-        },
-        {
-          "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-            "schemaName": "default.array_struct_test",
-            "platform": "urn:li:dataPlatform:hive",
-            "version": 0,
-            "created": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "lastModified": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "deleted": null,
-            "dataset": null,
-            "cluster": null,
-            "hash": "",
-            "platformSchema": {
-              "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                "tableSchema": ""
-              }
-            },
-            "fields": [
-              {
-                "fieldPath": "property_id",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.NumberType": {}
-                  }
+    "auditHeader": null,
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default.array_struct_test,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "Database:": "default",
+                            "Owner:": "root",
+                            "CreateTime:": "Fri Jul 02 22:51:47 UTC 2021",
+                            "LastAccessTime:": "UNKNOWN",
+                            "Retention:": "0",
+                            "Location:": "hdfs://namenode:8020/user/hive/warehouse/array_struct_test",
+                            "Table Type:": "MANAGED_TABLE",
+                            "Table Parameters: COLUMN_STATS_ACCURATE": "{\\\"BASIC_STATS\\\":\\\"true\\\"}",
+                            "Table Parameters: numFiles": "1",
+                            "Table Parameters: numRows": "1",
+                            "Table Parameters: rawDataSize": "32",
+                            "Table Parameters: totalSize": "33",
+                            "Table Parameters: transient_lastDdlTime": "1625266310",
+                            "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                            "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
+                            "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                            "Compressed:": "No",
+                            "Num Buckets:": "-1",
+                            "Bucket Columns:": "[]",
+                            "Sort Columns:": "[]",
+                            "Storage Desc Params: serialization.format": "1"
+                        },
+                        "externalUrl": null,
+                        "description": null,
+                        "uri": null,
+                        "tags": []
+                    }
                 },
-                "nativeDataType": "int",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              },
-              {
-                "fieldPath": "service",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.NullType": {}
-                  }
-                },
-                "nativeDataType": "array<struct<type:string,provider:array<int>>>",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              }
-            ],
-            "primaryKeys": null,
-            "foreignKeysSpecs": null
-          }
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "default.array_struct_test",
+                        "platform": "urn:li:dataPlatform:hive",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "deleted": null,
+                        "dataset": null,
+                        "cluster": null,
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "property_id",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            },
+                            {
+                                "fieldPath": "service",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NullType": {}
+                                    }
+                                },
+                                "nativeDataType": "array<struct<type:string,provider:array<int>>>",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            }
+                        ],
+                        "primaryKeys": null,
+                        "foreignKeysSpecs": null
+                    }
+                }
+            ]
         }
-      ]
-    }
-  },
-  "proposedDelta": null
+    },
+    "proposedDelta": null
 },
 {
-  "auditHeader": null,
-  "proposedSnapshot": {
-    "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-      "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default.pokes,PROD)",
-      "aspects": [
-        {
-          "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-            "customProperties": {
-              "Database:": "default",
-              "Owner:": "root",
-              "CreateTime:": "Wed Jun 30 00:48:35 UTC 2021",
-              "LastAccessTime:": "UNKNOWN",
-              "Retention:": "0",
-              "Location:": "hdfs://namenode:8020/user/hive/warehouse/pokes",
-              "Table Type:": "MANAGED_TABLE",
-              "Table Parameters: numFiles": "1",
-              "Table Parameters: numRows": "0",
-              "Table Parameters: rawDataSize": "0",
-              "Table Parameters: totalSize": "5812",
-              "Table Parameters: transient_lastDdlTime": "1625014117",
-              "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-              "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
-              "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-              "Compressed:": "No",
-              "Num Buckets:": "-1",
-              "Bucket Columns:": "[]",
-              "Sort Columns:": "[]",
-              "Storage Desc Params: serialization.format": "1"
-            },
-            "externalUrl": null,
-            "description": null,
-            "uri": null,
-            "tags": []
-          }
-        },
-        {
-          "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-            "schemaName": "default.pokes",
-            "platform": "urn:li:dataPlatform:hive",
-            "version": 0,
-            "created": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "lastModified": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "deleted": null,
-            "dataset": null,
-            "cluster": null,
-            "hash": "",
-            "platformSchema": {
-              "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                "tableSchema": ""
-              }
-            },
-            "fields": [
-              {
-                "fieldPath": "foo",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.NumberType": {}
-                  }
+    "auditHeader": null,
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default.pokes,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "Database:": "default",
+                            "Owner:": "root",
+                            "CreateTime:": "Fri Jul 02 22:51:45 UTC 2021",
+                            "LastAccessTime:": "UNKNOWN",
+                            "Retention:": "0",
+                            "Location:": "hdfs://namenode:8020/user/hive/warehouse/pokes",
+                            "Table Type:": "MANAGED_TABLE",
+                            "Table Parameters: numFiles": "1",
+                            "Table Parameters: numRows": "0",
+                            "Table Parameters: rawDataSize": "0",
+                            "Table Parameters: totalSize": "5812",
+                            "Table Parameters: transient_lastDdlTime": "1625266306",
+                            "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                            "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
+                            "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                            "Compressed:": "No",
+                            "Num Buckets:": "-1",
+                            "Bucket Columns:": "[]",
+                            "Sort Columns:": "[]",
+                            "Storage Desc Params: serialization.format": "1"
+                        },
+                        "externalUrl": null,
+                        "description": null,
+                        "uri": null,
+                        "tags": []
+                    }
                 },
-                "nativeDataType": "int",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              },
-              {
-                "fieldPath": "bar",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.StringType": {}
-                  }
-                },
-                "nativeDataType": "string",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              }
-            ],
-            "primaryKeys": null,
-            "foreignKeysSpecs": null
-          }
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "default.pokes",
+                        "platform": "urn:li:dataPlatform:hive",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "deleted": null,
+                        "dataset": null,
+                        "cluster": null,
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "foo",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            },
+                            {
+                                "fieldPath": "bar",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.StringType": {}
+                                    }
+                                },
+                                "nativeDataType": "string",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            }
+                        ],
+                        "primaryKeys": null,
+                        "foreignKeysSpecs": null
+                    }
+                }
+            ]
         }
-      ]
-    }
-  },
-  "proposedDelta": null
+    },
+    "proposedDelta": null
 },
 {
-  "auditHeader": null,
-  "proposedSnapshot": {
-    "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-      "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default.struct_test,PROD)",
-      "aspects": [
-        {
-          "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
-            "customProperties": {
-              "Database:": "default",
-              "Owner:": "root",
-              "CreateTime:": "Wed Jun 30 00:48:37 UTC 2021",
-              "LastAccessTime:": "UNKNOWN",
-              "Retention:": "0",
-              "Location:": "hdfs://namenode:8020/user/hive/warehouse/struct_test",
-              "Table Type:": "MANAGED_TABLE",
-              "Table Parameters: COLUMN_STATS_ACCURATE": "{\\\"BASIC_STATS\\\":\\\"true\\\"}",
-              "Table Parameters: numFiles": "0",
-              "Table Parameters: numRows": "0",
-              "Table Parameters: rawDataSize": "0",
-              "Table Parameters: totalSize": "0",
-              "Table Parameters: transient_lastDdlTime": "1625014117",
-              "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-              "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
-              "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
-              "Compressed:": "No",
-              "Num Buckets:": "-1",
-              "Bucket Columns:": "[]",
-              "Sort Columns:": "[]",
-              "Storage Desc Params: serialization.format": "1"
-            },
-            "externalUrl": null,
-            "description": null,
-            "uri": null,
-            "tags": []
-          }
-        },
-        {
-          "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
-            "schemaName": "default.struct_test",
-            "platform": "urn:li:dataPlatform:hive",
-            "version": 0,
-            "created": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "lastModified": {
-              "time": 1615443388097,
-              "actor": "urn:li:corpuser:etl",
-              "impersonator": null
-            },
-            "deleted": null,
-            "dataset": null,
-            "cluster": null,
-            "hash": "",
-            "platformSchema": {
-              "com.linkedin.pegasus2avro.schema.MySqlDDL": {
-                "tableSchema": ""
-              }
-            },
-            "fields": [
-              {
-                "fieldPath": "property_id",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.NumberType": {}
-                  }
+    "auditHeader": null,
+    "proposedSnapshot": {
+        "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,default.struct_test,PROD)",
+            "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                        "customProperties": {
+                            "Database:": "default",
+                            "Owner:": "root",
+                            "CreateTime:": "Fri Jul 02 22:51:46 UTC 2021",
+                            "LastAccessTime:": "UNKNOWN",
+                            "Retention:": "0",
+                            "Location:": "hdfs://namenode:8020/user/hive/warehouse/struct_test",
+                            "Table Type:": "MANAGED_TABLE",
+                            "Table Parameters: COLUMN_STATS_ACCURATE": "{\\\"BASIC_STATS\\\":\\\"true\\\"}",
+                            "Table Parameters: numFiles": "0",
+                            "Table Parameters: numRows": "0",
+                            "Table Parameters: rawDataSize": "0",
+                            "Table Parameters: totalSize": "0",
+                            "Table Parameters: transient_lastDdlTime": "1625266306",
+                            "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+                            "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
+                            "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                            "Compressed:": "No",
+                            "Num Buckets:": "-1",
+                            "Bucket Columns:": "[]",
+                            "Sort Columns:": "[]",
+                            "Storage Desc Params: serialization.format": "1"
+                        },
+                        "externalUrl": null,
+                        "description": null,
+                        "uri": null,
+                        "tags": []
+                    }
                 },
-                "nativeDataType": "int",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              },
-              {
-                "fieldPath": "service",
-                "jsonPath": null,
-                "nullable": true,
-                "description": null,
-                "type": {
-                  "type": {
-                    "com.linkedin.pegasus2avro.schema.NullType": {}
-                  }
-                },
-                "nativeDataType": "struct<type:string,provider:array<int>>",
-                "recursive": false,
-                "globalTags": null,
-                "glossaryTerms": null
-              }
-            ],
-            "primaryKeys": null,
-            "foreignKeysSpecs": null
-          }
+                {
+                    "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
+                        "schemaName": "default.struct_test",
+                        "platform": "urn:li:dataPlatform:hive",
+                        "version": 0,
+                        "created": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "lastModified": {
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
+                            "impersonator": null
+                        },
+                        "deleted": null,
+                        "dataset": null,
+                        "cluster": null,
+                        "hash": "",
+                        "platformSchema": {
+                            "com.linkedin.pegasus2avro.schema.MySqlDDL": {
+                                "tableSchema": ""
+                            }
+                        },
+                        "fields": [
+                            {
+                                "fieldPath": "property_id",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NumberType": {}
+                                    }
+                                },
+                                "nativeDataType": "int",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            },
+                            {
+                                "fieldPath": "service",
+                                "jsonPath": null,
+                                "nullable": true,
+                                "description": null,
+                                "type": {
+                                    "type": {
+                                        "com.linkedin.pegasus2avro.schema.NullType": {}
+                                    }
+                                },
+                                "nativeDataType": "struct<type:string,provider:array<int>>",
+                                "recursive": false,
+                                "globalTags": null,
+                                "glossaryTerms": null
+                            }
+                        ],
+                        "primaryKeys": null,
+                        "foreignKeysSpecs": null
+                    }
+                }
+            ]
         }
-      ]
-    }
-  },
-  "proposedDelta": null
+    },
+    "proposedDelta": null
 }
 ]

--- a/metadata-ingestion/tests/integration/looker/expected_output.json
+++ b/metadata-ingestion/tests/integration/looker/expected_output.json
@@ -13,13 +13,13 @@
                         "description": "Some text",
                         "lastModified": {
                             "created": {
-                                "time": 1615443388097,
-                                "actor": "urn:li:corpuser:etl",
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown",
                                 "impersonator": null
                             },
                             "lastModified": {
-                                "time": 1615443388097,
-                                "actor": "urn:li:corpuser:etl",
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown",
                                 "impersonator": null
                             },
                             "deleted": null
@@ -53,13 +53,13 @@
                         ],
                         "lastModified": {
                             "created": {
-                                "time": 1615443388097,
-                                "actor": "urn:li:corpuser:etl",
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown",
                                 "impersonator": null
                             },
                             "lastModified": {
-                                "time": 1615443388097,
-                                "actor": "urn:li:corpuser:etl",
+                                "time": 0,
+                                "actor": "urn:li:corpuser:unknown",
                                 "impersonator": null
                             },
                             "deleted": null
@@ -79,8 +79,8 @@
                             }
                         ],
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         }
                     }

--- a/metadata-ingestion/tests/integration/lookml/expected_output.json
+++ b/metadata-ingestion/tests/integration/lookml/expected_output.json
@@ -15,8 +15,8 @@
                         "upstreams": [
                             {
                                 "auditStamp": {
-                                    "time": 1615443388097,
-                                    "actor": "urn:li:corpuser:etl",
+                                    "time": 0,
+                                    "actor": "urn:li:corpuser:unknown",
                                     "impersonator": null
                                 },
                                 "dataset": "urn:li:dataset:(urn:li:dataPlatform:conn,my_table,PROD)",
@@ -31,13 +31,13 @@
                         "platform": "urn:li:dataPlatform:looker",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,

--- a/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mongodb/mongodb_mces_golden.json
@@ -20,13 +20,13 @@
                         "platform": "urn:li:dataPlatform:mongodb",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -67,13 +67,13 @@
                         "platform": "urn:li:dataPlatform:mongodb",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -451,13 +451,13 @@
                         "platform": "urn:li:dataPlatform:mongodb",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,

--- a/metadata-ingestion/tests/integration/mysql/mysql_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mysql/mysql_mces_golden.json
@@ -11,13 +11,13 @@
                         "platform": "urn:li:dataPlatform:mysql",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -166,13 +166,13 @@
                         "platform": "urn:li:dataPlatform:mysql",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -324,13 +324,13 @@
                         "platform": "urn:li:dataPlatform:mysql",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,

--- a/metadata-ingestion/tests/integration/sql_server/mssql_mces_golden.json
+++ b/metadata-ingestion/tests/integration/sql_server/mssql_mces_golden.json
@@ -11,13 +11,13 @@
                         "platform": "urn:li:dataPlatform:mssql",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,
@@ -82,13 +82,13 @@
                         "platform": "urn:li:dataPlatform:mssql",
                         "version": 0,
                         "created": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "lastModified": {
-                            "time": 1615443388097,
-                            "actor": "urn:li:corpuser:etl",
+                            "time": 0,
+                            "actor": "urn:li:corpuser:unknown",
                             "impersonator": null
                         },
                         "deleted": null,

--- a/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
+++ b/metadata-ingestion/tests/unit/glue/glue_mces_golden.json
@@ -20,8 +20,8 @@
                 }
               ],
               "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:datahub",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               }
             }
@@ -62,13 +62,13 @@
               "platform": "urn:li:dataPlatform:glue",
               "version": 0,
               "created": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:etl",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               },
               "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:etl",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               },
               "deleted": null,
@@ -217,8 +217,8 @@
                 }
               ],
               "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:datahub",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               }
             }
@@ -258,13 +258,13 @@
               "platform": "urn:li:dataPlatform:glue",
               "version": 0,
               "created": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:etl",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               },
               "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:etl",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               },
               "deleted": null,
@@ -325,8 +325,8 @@
                 }
               ],
               "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:datahub",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               }
             }
@@ -366,13 +366,13 @@
               "platform": "urn:li:dataPlatform:glue",
               "version": 0,
               "created": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:etl",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               },
               "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:etl",
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown",
                 "impersonator": null
               },
               "deleted": null,
@@ -736,16 +736,6 @@
             }
           },
           {
-            "com.linkedin.pegasus2avro.common.Ownership": {
-              "owners": [],
-              "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:datahub",
-                "impersonator": null
-              }
-            }
-          },
-          {
             "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
               "customProperties": {
                 "connection_type": "s3",
@@ -925,16 +915,6 @@
           {
             "com.linkedin.pegasus2avro.common.Status": {
               "removed": false
-            }
-          },
-          {
-            "com.linkedin.pegasus2avro.common.Ownership": {
-              "owners": [],
-              "lastModified": {
-                "time": 1586847600000,
-                "actor": "urn:li:corpuser:datahub",
-                "impersonator": null
-              }
             }
           },
           {

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -33,7 +33,7 @@ def test_simple_dataset_ownership_tranformation(mock_time):
                         ),
                     ],
                     lastModified=models.AuditStampClass(
-                        time=builder.get_sys_time(), actor="urn:li:corpuser:datahub"
+                        time=1625266033123, actor="urn:li:corpuser:datahub"
                     ),
                 )
             ],

--- a/metadata-models/src/main/pegasus/com/linkedin/common/Ownership.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/Ownership.pdl
@@ -14,7 +14,10 @@ record Ownership {
   owners: array[Owner]
 
   /**
-   * Audit stamp containing who last modified the record and when.
+   * Audit stamp containing who last modified the record and when. A value of 0 in the time field indicates missing data.
    */
-  lastModified: AuditStamp
+  lastModified: AuditStamp = {
+    "time": 0,
+    "actor": "urn:li:corpuser:unknown"
+  }
 }

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/Upstream.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/Upstream.pdl
@@ -9,8 +9,10 @@ import com.linkedin.common.DatasetUrn
 record Upstream {
 
   /**
-   * Audit stamp containing who reported the lineage and when
+   * Audit stamp containing who reported the lineage and when.
+   * WARNING: this field is deprecated and may be removed in a future release.
    */
+  @deprecated = "we no longer associate a timestamp per upstream edge"
   auditStamp: AuditStamp
 
   /**

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/Upstream.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/Upstream.pdl
@@ -13,7 +13,10 @@ record Upstream {
    * WARNING: this field is deprecated and may be removed in a future release.
    */
   @deprecated = "we no longer associate a timestamp per upstream edge"
-  auditStamp: AuditStamp
+  auditStamp: AuditStamp = {
+    "time": 0,
+    "actor": "urn:li:corpuser:unknown"
+  }
 
   /**
    * The upstream dataset the lineage points to


### PR DESCRIPTION
This will prevent us from minting extra aspect versions unnecessarily. Now many timestamp fields in PDL default to 0, which indicates a lack of data, and updates the UI to handle this properly.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
