### PR TITLE
fix(ingest): Fix glob pattern and handle possible recursion in lookml

### DIFF
--- a/metadata-ingestion/README.md
+++ b/metadata-ingestion/README.md
@@ -700,7 +700,7 @@ source:
 
 Note! The integration can use [`sql-metadata`](https://pypi.org/project/sql-metadata/) to try to parse the tables the
 views depends on. As these SQL's can be complicated, and the package doesn't official support all the SQL dialects that
-Looker support, the result might not be correct. This parsing is disables by default, but can be enabled by setting
+Looker supports, the result might not be correct. This parsing is disabled by default, but can be enabled by setting
 `parse_table_names_from_sql: True`.
 
 ### Looker dashboards `looker`

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -314,22 +314,25 @@ class LookerView:  # pragma: no cover
                     include, connection
                 )
                 if maybe_looker_viewfile is not None:
-                    for view in looker_viewfile.views:
-                        maybe_looker_view = LookerView.from_looker_dict(
-                            view,
-                            connection,
-                            looker_viewfile,
-                            looker_viewfile_loader,
-                            parse_table_names_from_sql,
-                        )
-                        if maybe_looker_view is None:
-                            continue
+                    for raw_view in looker_viewfile.views:
+                        raw_view_name = raw_view["name"]
+                        # Make sure to skip loading view we are currently trying to resolve
+                        if raw_view_name != view_name:
+                            maybe_looker_view = LookerView.from_looker_dict(
+                                raw_view,
+                                connection,
+                                looker_viewfile,
+                                looker_viewfile_loader,
+                                parse_table_names_from_sql,
+                            )
+                            if maybe_looker_view is None:
+                                continue
 
-                        if (
-                            maybe_looker_view is not None
-                            and maybe_looker_view.view_name in extends
-                        ):
-                            extends_to_looker_view.append(maybe_looker_view)
+                            if (
+                                maybe_looker_view is not None
+                                and maybe_looker_view.view_name in extends
+                            ):
+                                extends_to_looker_view.append(maybe_looker_view)
 
             if len(extends_to_looker_view) != 1:
                 logger.warning(

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -521,7 +521,7 @@ class LookMLSource(Source):  # pragma: no cover
         model_files = sorted(
             f
             for f in glob.glob(
-                f"{self.source_config.base_folder}/**/*.model.lkml", recursive=True
+                f"{self.source_config.base_folder}/**.model.lkml", recursive=True
             )
         )
         for file_path in model_files:


### PR DESCRIPTION
This PR fixes the glob pattern, which didn't allow for having `*.model.lkml` files in the root of the `base_folder` and also handles a possible scenario of recursion. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
