### PR TITLE
fix(versioned aspects): handle fetching null aspects from AspectType

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/aspect/AspectType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/aspect/AspectType.java
@@ -6,6 +6,7 @@ import com.linkedin.datahub.graphql.generated.Aspect;
 import com.linkedin.entity.client.AspectClient;
 import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.client.RestLiResponseException;
 import graphql.execution.DataFetcherResult;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +32,13 @@ public class AspectType {
           VersionedAspect entity = _aspectClient.getAspect(key.getUrn(), key.getAspectName(), key.getVersion());
           return DataFetcherResult.<Aspect>newResult().data(AspectMapper.map(entity)).build();
         } catch (RemoteInvocationException e) {
+          if (e instanceof RestLiResponseException) {
+            // if no aspect is found, restli will return a 404 rather than null
+            // https://linkedin.github.io/rest.li/user_guide/restli_server#returning-nulls
+            if(((RestLiResponseException) e).getStatus() == 404) {
+              return DataFetcherResult.<Aspect>newResult().data(null).build();
+            }
+          }
           throw new RuntimeException(String.format("Failed to load Aspect for entity %s", key.getUrn()), e);
         }
       }).collect(Collectors.toList());


### PR DESCRIPTION
Restli specifies resources should return 404s when a resource is fetched but does not exist:

https://linkedin.github.io/rest.li/user_guide/restli_server#returning-nulls

However, in graphql we do not special case 404 errors and propagate the error to the client. In the Entity world, this makes sense because we mint an empty entity when a non-existent entity is fetched. This means the entity resource always returns something. The Aspect resource cannot return an empty aspect, since we do not have the ability to dynamically construct empty aspects (nor do we necc. want to).

This fix handles 404 errors and passes a null version of the aspect to the client.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
