### PR TITLE
feat(metadata-ingestion): use node comment as description in dbt

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -68,6 +68,7 @@ class DBTNode:
     database: str
     schema: str
     name: str  # name, identifier
+    comment: str
 
     datahub_urn: str
 
@@ -130,6 +131,13 @@ def extract_dbt_entities(
         if "identifier" in node and not load_catalog:
             name = node["identifier"]
 
+        comment = key
+
+        if key in all_catalog_entities and all_catalog_entities[key]["metadata"].get(
+            "comment"
+        ):
+            comment = all_catalog_entities[key]["metadata"]["comment"]
+
         materialization = None
         upstream_urns = []
 
@@ -166,6 +174,7 @@ def extract_dbt_entities(
             node_type=node["resource_type"],
             max_loaded_at=sources_by_id.get(key, {}).get("max_loaded_at"),
             name=name,
+            comment=comment,
             upstream_urns=upstream_urns,
             materialization=materialization,
             catalog_type=catalog_type,
@@ -424,7 +433,7 @@ class DBTSource(Source):
             )
 
             dbt_properties = DatasetPropertiesClass(
-                description=node.dbt_name,
+                description=node.comment,
                 customProperties=get_custom_properties(node),
                 tags=[],
             )


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

This PR change the dbt node description from the node key (for ex. `model.source.table`) to the node metadata comment if it's available (manifest nodes do not have metadata) and defined (typically a more descriptive string than the key).