### PR TITLE
fix(ingest): default to unlimited query log delay in bigquery-usage

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/delayed_iter.py
+++ b/metadata-ingestion/src/datahub/utilities/delayed_iter.py
@@ -1,18 +1,19 @@
 import collections
-from typing import Deque, Iterable, TypeVar
+from typing import Deque, Iterable, Optional, TypeVar
 
 T = TypeVar("T")
 
 
-def delayed_iter(iterable: Iterable[T], delay: int) -> Iterable[T]:
+def delayed_iter(iterable: Iterable[T], delay: Optional[int]) -> Iterable[T]:
     """Waits to yield the i'th element until after the (i+n)'th element has been
-    materialized by the source iterator.
+    materialized by the source iterator. If delay is none, wait until the full
+    iterable has been materialized before yielding.
     """
 
     cache: Deque[T] = collections.deque([], maxlen=delay)
 
     for item in iterable:
-        if len(cache) >= delay:
+        if delay is not None and len(cache) >= delay:
             yield cache.popleft()
         cache.append(item)
 

--- a/metadata-ingestion/tests/unit/test_utilities.py
+++ b/metadata-ingestion/tests/unit/test_utilities.py
@@ -4,12 +4,12 @@ from datahub.utilities.delayed_iter import delayed_iter
 def test_delayed_iter():
     events = []
 
-    def maker():
-        for i in range(4):
+    def maker(n):
+        for i in range(n):
             events.append(("add", i))
             yield i
 
-    for i in delayed_iter(maker(), 2):
+    for i in delayed_iter(maker(4), 2):
         events.append(("remove", i))
 
     assert events == [
@@ -21,4 +21,15 @@ def test_delayed_iter():
         ("remove", 1),
         ("remove", 2),
         ("remove", 3),
+    ]
+
+    events.clear()
+    for i in delayed_iter(maker(2), None):
+        events.append(("remove", i))
+
+    assert events == [
+        ("add", 0),
+        ("add", 1),
+        ("remove", 0),
+        ("remove", 1),
     ]


### PR DESCRIPTION
This will help us ensure correctness, at the cost of higher memory usage. However, it can always be tuned via config.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
