### PR TITLE
fix(search): Fix index builder to access minimum required indices

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IndexBuilder.java
@@ -99,9 +99,10 @@ public class IndexBuilder {
     }
 
     log.info("Reindex from {} to {} succeeded", indexName, tempIndexName);
+    String indexNamePattern = indexName + "_*";
     // Check if the original index is aliased or not
     GetAliasesResponse aliasesResponse =
-        searchClient.indices().getAlias(new GetAliasesRequest(indexName), RequestOptions.DEFAULT);
+        searchClient.indices().getAlias(new GetAliasesRequest(indexName).indices(indexNamePattern), RequestOptions.DEFAULT);
     // If not aliased, delete the original index
     if (aliasesResponse.getAliases().isEmpty()) {
       searchClient.indices().delete(new DeleteIndexRequest().indices(indexName), RequestOptions.DEFAULT);
@@ -112,7 +113,7 @@ public class IndexBuilder {
     }
 
     // Add alias for the new index
-    AliasActions removeAction = AliasActions.remove().alias(indexName).index("*");
+    AliasActions removeAction = AliasActions.remove().alias(indexName).index(indexNamePattern);
     AliasActions addAction = AliasActions.add().alias(indexName).index(tempIndexName);
     searchClient.indices()
         .updateAliases(new IndicesAliasesRequest().addAliasAction(removeAction).addAliasAction(addAction),


### PR DESCRIPTION
Currently it checks aliases and deletes aliases for all indices, which is unnecessary. Check for the specific indices we want to look at. 

This allows us to set index permissions based on the index template. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
