### PR TITLE
fix(ingest): change LookMLSource._get_upsteam_lineage() to _get_upstream_lineage()

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -397,7 +397,7 @@ class LookMLSource(Source):  # pragma: no cover
                 f"Could not find a platform for looker view with connection: {connection}"
             )
 
-    def _get_upsteam_lineage(self, looker_view: LookerView) -> UpstreamLineage:
+    def _get_upstream_lineage(self, looker_view: LookerView) -> UpstreamLineage:
         upstreams = []
         for sql_table_name in looker_view.sql_table_names:
             upstream = UpstreamClass(
@@ -498,7 +498,7 @@ class LookMLSource(Source):  # pragma: no cover
             aspects=[],  # we append to this list later on
         )
         dataset_snapshot.aspects.append(Status(removed=False))
-        dataset_snapshot.aspects.append(self._get_upsteam_lineage(looker_view))
+        dataset_snapshot.aspects.append(self._get_upstream_lineage(looker_view))
         dataset_snapshot.aspects.append(self._get_schema(looker_view))
 
         mce = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)


### PR DESCRIPTION
## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

## Description

This PR proposes changing the method `datahub.ingestion.source.lookml.LookMLSource._get_upsteam_lineage()` to `_get_upstream_lineage()`. I believe `upsteam` is a typo.

I'm not aware of any functional issues caused by that typo, but it does mean that this method might be missed if searching through the codebase for lineage-related code (as I did this morning with something like `git grep -i upstream metadata-ingestion/src`).

I checked with `git grep _get_upsteam_lineage` and can confirm there are no other places in this project's code referencing this method. Since the method name begins with `_`, I'm assuming that it is considered private and can safely be changed.

Thanks for your time and consideration.
