### PR TITLE
fix(react): avoid displaying "0" for ignored timestamps

### DIFF
--- a/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
+++ b/datahub-web-react/src/app/entity/chart/profile/ChartHeader.tsx
@@ -56,7 +56,7 @@ export default function ChartHeader({
                 urn={urn}
             />
             <AvatarsGroup owners={ownership?.owners} entityRegistry={entityRegistry} size="large" />
-            {info?.lastModified?.time && (
+            {!!info?.lastModified?.time && (
                 <Typography.Text type="secondary">
                     Last modified at {new Date(info?.lastModified.time).toLocaleDateString('en-US')}
                 </Typography.Text>

--- a/datahub-web-react/src/app/entity/shared/Ownership.tsx
+++ b/datahub-web-react/src/app/entity/shared/Ownership.tsx
@@ -315,7 +315,7 @@ export const Ownership: React.FC<Props> = ({ owners, lastModifiedAt, updateOwner
 
     return (
         <>
-            {lastModifiedAt && (
+            {!!lastModifiedAt && (
                 <UpdatedText>
                     Last updated <b>{new Date(lastModifiedAt).toLocaleDateString('en-US')}</b>
                 </UpdatedText>


### PR DESCRIPTION
In react:
```js
(0 && 'foo') renders 0
(false && 'foo') renders nothing
(truthy && 'foo') renders foo
```

Using `!!value` forces conversion to a bool, which will prevent a stay "0" from being rendered.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
