### PR TITLE
fix(blank searches on search page): fixing case where someone issues a null query on the search page

### DIFF
--- a/datahub-web-react/src/app/search/SearchPage.tsx
+++ b/datahub-web-react/src/app/search/SearchPage.tsx
@@ -55,7 +55,7 @@ export const SearchPage = () => {
     const filters: Array<FacetFilterInput> = useFilters(params);
 
     const onSearch = (q: string, type?: EntityType) => {
-        if (query.trim().length === 0) {
+        if (q.trim().length === 0) {
             return;
         }
         analytics.event({


### PR DESCRIPTION
This was fixed on a few other pages successfully but this check was actually referencing an external variable. Updated to check the new query rather than the old one.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
