### PR TITLE
fix(mce logs): upgrading log status up MCE processor

### DIFF
--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeEventsProcessor.java
@@ -52,7 +52,7 @@ public class MetadataChangeEventsProcessor {
 
     try {
       event = EventUtils.avroToPegasusMCE(record);
-      log.debug("MetadataChangeEvent {}", event);
+      log.info("MetadataChangeEvent {}", event);
       if (event.hasProposedSnapshot()) {
         processProposedSnapshot(event);
       }


### PR DESCRIPTION
in the MAE processor we log with `log.info`. This adds a `log.info` line to the MCE consumer so that it is obvious when MCE consumer is processing or not.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
