### PR TITLE
fix(ingest): use logger.warning instead of logger.warn

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -65,7 +65,7 @@ class DatahubRestEmitter:
 
     def __init__(self, gms_server: str, token: Optional[str] = None):
         if ":9002" in gms_server:
-            logger.warn(
+            logger.warning(
                 "the rest emitter should connect to GMS (usually port 8080) instead of frontend"
             )
         self._gms_server = gms_server

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -229,7 +229,7 @@ class KafkaConnectSource(Source):
             if connector_manifest.type == "sink":
                 # TODO: Sink Connector not yet implemented
                 self.report.report_dropped(connector_manifest.name)
-                logger.warn(
+                logger.warning(
                     f"Skipping connector {connector_manifest.name}. Sink Connector not yet implemented"
                 )
                 pass

--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -117,7 +117,7 @@ class LookerDashboard:
 
 class LookerDashboardSource(Source):
     source_config: LookerDashboardSourceConfig
-    report = LookerDashboardSourceReport()
+    reporter: LookerDashboardSourceReport
 
     def __init__(self, config: LookerDashboardSourceConfig, ctx: PipelineContext):
         super().__init__(ctx)
@@ -415,8 +415,8 @@ class LookerDashboardSource(Source):
                 )
             except SDKError:
                 # A looker dashboard could be deleted in between the list and the get
-                logger.warning(
-                    f"Error occuried while loading dashboard {dashboard_id}. Skipping."
+                self.reporter.report_warning(
+                    dashboard_id, f"Error occurred while loading dashboard {dashboard_id}. Skipping."
                 )
                 continue
 

--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -416,7 +416,8 @@ class LookerDashboardSource(Source):
             except SDKError:
                 # A looker dashboard could be deleted in between the list and the get
                 self.reporter.report_warning(
-                    dashboard_id, f"Error occurred while loading dashboard {dashboard_id}. Skipping."
+                    dashboard_id,
+                    f"Error occurred while loading dashboard {dashboard_id}. Skipping.",
                 )
                 continue
 

--- a/metadata-ingestion/src/datahub/ingestion/source/snowflake.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/snowflake.py
@@ -73,7 +73,7 @@ class SnowflakeConfig(BaseSnowflakeConfig, SQLAlchemyConfig):
 
     @pydantic.validator("database")
     def note_database_opt_deprecation(cls, v, values, **kwargs):
-        logger.warn(
+        logger.warning(
             "snowflake's `database` option has been deprecated; use database_pattern instead"
         )
         values["database_pattern"].allow = f"^{v}$"


### PR DESCRIPTION
The logger.warn method is deprecated in favor of warning.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
