### PR TITLE
fix(ingestion): pin snowflake sqlalchemy connector

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -97,8 +97,8 @@ plugins: Dict[str, Set[str]] = {
     "postgres": sql_common | {"psycopg2-binary", "GeoAlchemy2"},
     "redshift": sql_common | {"sqlalchemy-redshift", "psycopg2-binary", "GeoAlchemy2"},
     "sagemaker": aws_common,
-    "snowflake": sql_common | {"snowflake-sqlalchemy"},
-    "snowflake-usage": sql_common | {"snowflake-sqlalchemy"},
+    "snowflake": sql_common | {"snowflake-sqlalchemy<=1.2.4"},
+    "snowflake-usage": sql_common | {"snowflake-sqlalchemy<=1.2.4"},
     "superset": {"requests"},
 }
 
@@ -188,6 +188,7 @@ full_test_dev_requirements = {
             "mongodb",
             "mssql",
             "mysql",
+            "snowflake",
         ]
         for dependency in plugins[plugin]
     ),

--- a/metadata-ingestion/tests/unit/test_snowflake_source.py
+++ b/metadata-ingestion/tests/unit/test_snowflake_source.py
@@ -1,7 +1,10 @@
-from datahub.ingestion.source.snowflake import SnowflakeConfig
+import pytest
 
 
+@pytest.mark.integration
 def test_snowflake_uri():
+    from datahub.ingestion.source.snowflake import SnowflakeConfig
+
     config = SnowflakeConfig.parse_obj(
         {
             "username": "user",


### PR DESCRIPTION
Version 1.2.5 was released today (https://pypi.org/project/snowflake-sqlalchemy/1.2.5/), but yields errors for us, as below. We pin our version to 1.2.4 for now, since we still depend on SQLAlchemy 1.3.24.

```
tests/unit/test_snowflake_source.py:1: in <module>
    from datahub.ingestion.source.snowflake import SnowflakeConfig
src/datahub/ingestion/source/snowflake.py:7: in <module>
    import snowflake.sqlalchemy  # noqa: F401
venv/lib/python3.8/site-packages/snowflake/sqlalchemy/__init__.py:25: in <module>
    from . import base, snowdialect
venv/lib/python3.8/site-packages/snowflake/sqlalchemy/base.py:17: in <module>
    from .custom_commands import AWSBucket, AzureContainer, ExternalStage
venv/lib/python3.8/site-packages/snowflake/sqlalchemy/custom_commands.py:14: in <module>
    from sqlalchemy.sql.roles import FromClauseRole
E   ModuleNotFoundError: No module named 'sqlalchemy.sql.roles'
```

This issue is breaking the build for a couple other PRs:
- https://github.com/linkedin/datahub/pull/2920
- https://github.com/linkedin/datahub/pull/2921
- https://github.com/linkedin/datahub/pull/2922

See https://github.com/snowflakedb/snowflake-sqlalchemy/issues/234 for details about this issue.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
