### PR TITLE
fix(ingest): Glue mapping patch

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -560,15 +560,25 @@ def get_column_type(
         "varchar": StringTypeClass,
     }
 
+    field_starts_type_mapping = {
+        "array": ArrayTypeClass,
+        "set": ArrayTypeClass,
+        "map": MapTypeClass,
+        "struct": MapTypeClass,
+        "varchar": StringTypeClass,
+        "decimal": NumberTypeClass
+    }
+
+    type_class = None
     if field_type in field_type_mapping.keys():
         type_class = field_type_mapping[field_type]
-    elif field_type.startswith("array"):
-        type_class = ArrayTypeClass
-    elif field_type.startswith("map") or field_type.startswith("struct"):
-        type_class = MapTypeClass
-    elif field_type.startswith("set"):
-        type_class = ArrayTypeClass
     else:
+        for key in field_starts_type_mapping.keys():
+            if field_type.startswith(key):
+                type_class = field_starts_type_mapping[key]
+                break
+
+    if type_class is None:
         glue_source.report.report_warning(
             field_type,
             f"The type '{field_type}' is not recognised for field '{field_name}' in table '{table_name}', setting as StringTypeClass.",

--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -566,7 +566,7 @@ def get_column_type(
         "map": MapTypeClass,
         "struct": MapTypeClass,
         "varchar": StringTypeClass,
-        "decimal": NumberTypeClass
+        "decimal": NumberTypeClass,
     }
 
     type_class = None


### PR DESCRIPTION
Without this fix was getting errors due to `varchar(x)` and `decimal(x, y)` types in our glue catalog

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
