### PR TITLE
fix(ingest): fix workunit name to be consistent with other sources

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -403,7 +403,7 @@ class GlueSource(Source):
                 continue
 
             mce = self._extract_record(table, full_table_name)
-            workunit = MetadataWorkUnit(id=f"glue-{full_table_name}", mce=mce)
+            workunit = MetadataWorkUnit(full_table_name, mce=mce)
             self.report.report_workunit(workunit)
             yield workunit
 


### PR DESCRIPTION
The name of the workunit caused confusion when I was testing with `console` sink that the ingestion would be named `glue-FULL_TABLE_NAME`. Changing it so it is consistent with rest of the sources and not add this prefix.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
