### PR TITLE
fix(ingest): allow custom Glue scripts

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
-
 from datahub.emitter import mce_builder
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport
@@ -101,7 +100,7 @@ class GlueSource(Source):
 
         return jobs
 
-    def get_dataflow_graph(self, script_path: str) -> Dict[str, Any]:
+    def get_dataflow_graph(self, script_path: str) -> Optional[Dict[str, Any]]:
         """
         Get the DAG of transforms and data sources/sinks for a job.
 
@@ -121,9 +120,20 @@ class GlueSource(Source):
         obj = self.s3_client.get_object(Bucket=bucket, Key=key)
         script = obj["Body"].read().decode("utf-8")
 
-        # extract the job DAG from the script
-        # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_dataflow_graph
-        return self.glue_client.get_dataflow_graph(PythonScript=script)
+        try:
+            # extract the job DAG from the script
+            # see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.get_dataflow_graph
+            return self.glue_client.get_dataflow_graph(PythonScript=script)
+
+        # sometimes the Python script can be user-modified and the script is not valid for graph extraction
+        except self.glue_client.exceptions.InvalidInputException as e:
+
+            self.report.report_warning(
+                script_path,
+                f"Error parsing DAG for Glue job. The script {script_path} cannot be processed by Glue (this usually occurs when it has been user-modified): {e}",
+            )
+
+            return
 
     def get_dataflow_s3_names(
         self, dataflow_graph: Dict[str, Any]
@@ -433,11 +443,15 @@ class GlueSource(Source):
             )
 
             for dag in dags.values():
-                for s3_name, extension in self.get_dataflow_s3_names(dag):
-                    s3_formats[s3_name].add(extension)
+                if dag is not None:
+                    for s3_name, extension in self.get_dataflow_s3_names(dag):
+                        s3_formats[s3_name].add(extension)
 
             # run second pass to generate node workunits
             for flow_urn, dag in dags.items():
+
+                if dag is None:
+                    continue
 
                 nodes, new_dataset_ids, new_dataset_mces = self.process_dataflow_graph(
                     dag, flow_urn, s3_formats

--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse
+
 from datahub.emitter import mce_builder
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.api.source import Source, SourceReport

--- a/metadata-ingestion/src/datahub/ingestion/source/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/glue.py
@@ -134,7 +134,7 @@ class GlueSource(Source):
                 f"Error parsing DAG for Glue job. The script {script_path} cannot be processed by Glue (this usually occurs when it has been user-modified): {e}",
             )
 
-            return
+            return None
 
     def get_dataflow_s3_names(
         self, dataflow_graph: Dict[str, Any]


### PR DESCRIPTION
Currently fails if trying to extract the DAG for a custom Python script; this PR catches this exception.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
