### PR TITLE
refactor(test): Refactor GraphService tests

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -4,8 +4,6 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.graph.elastic.ESGraphQueryDAO;
 import com.linkedin.metadata.graph.elastic.ESGraphWriteDAO;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
-import com.linkedin.metadata.query.Filter;
-import com.linkedin.metadata.query.RelationshipFilter;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import org.apache.http.HttpHost;
@@ -19,10 +17,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.net.URISyntaxException;
-import java.time.Duration;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
@@ -92,7 +87,7 @@ class WaitOnWriteGraphService implements GraphService {
     _duration = duration;
   }
 
-  private void wait_duration() {
+  private void waitDuration() {
     try {
       TimeUnit.SECONDS.sleep(_duration.getSeconds());
     } catch (InterruptedException e) {
@@ -103,36 +98,44 @@ class WaitOnWriteGraphService implements GraphService {
   @Override
   public void addEdge(Edge edge) {
     _service.addEdge(edge);
-    wait_duration();
+    waitDuration();
   }
 
   @Nonnull
   @Override
-  public List<String> findRelatedUrns(@Nullable String sourceType, @Nonnull Filter sourceEntityFilter, @Nullable String destinationType, @Nonnull Filter destinationEntityFilter, @Nonnull List<String> relationshipTypes, @Nonnull RelationshipFilter relationshipFilter, int offset, int count) {
-    return _service.findRelatedUrns(sourceType, sourceEntityFilter, destinationType, destinationEntityFilter, relationshipTypes, relationshipFilter, offset, count);
+  public List<String> findRelatedUrns(@Nullable String sourceType, @Nonnull Filter sourceEntityFilter,
+                                      @Nullable String destinationType, @Nonnull Filter destinationEntityFilter,
+                                      @Nonnull List<String> relationshipTypes, @Nonnull RelationshipFilter relationshipFilter,
+                                      int offset, int count) {
+    return _service.findRelatedUrns(
+            sourceType, sourceEntityFilter,
+            destinationType, destinationEntityFilter,
+            relationshipTypes, relationshipFilter,
+            offset, count
+    );
   }
 
   @Override
   public void removeNode(@Nonnull Urn urn) {
     _service.removeNode(urn);
-    wait_duration();
+    waitDuration();
   }
 
   @Override
   public void removeEdgesFromNode(@Nonnull Urn urn, @Nonnull List<String> relationshipTypes, @Nonnull RelationshipFilter relationshipFilter) {
     _service.removeEdgesFromNode(urn, relationshipTypes, relationshipFilter);
-    wait_duration();
+    waitDuration();
   }
 
   @Override
   public void configure() {
     _service.configure();
-    wait_duration();
+    waitDuration();
   }
 
   @Override
   public void clear() {
     _service.clear();
-    wait_duration();
+    waitDuration();
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -72,7 +72,7 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   }
 
   @Override
-  protected GraphService getGraphService() {
+  protected @Nonnull GraphService getGraphService() {
     return _client;
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -73,69 +73,11 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   @Override
   protected GraphService getGraphService() {
-    return new WaitOnWriteGraphService(_client, Duration.ofSeconds(5));
-  }
-}
-
-class WaitOnWriteGraphService implements GraphService {
-
-  private final GraphService _service;
-  private final Duration _duration;
-
-  public WaitOnWriteGraphService(GraphService service, Duration duration) {
-    _service = service;
-    _duration = duration;
-  }
-
-  private void waitDuration() {
-    try {
-      TimeUnit.SECONDS.sleep(_duration.getSeconds());
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
+    return _client;
   }
 
   @Override
-  public void addEdge(Edge edge) {
-    _service.addEdge(edge);
-    waitDuration();
-  }
-
-  @Nonnull
-  @Override
-  public List<String> findRelatedUrns(@Nullable String sourceType, @Nonnull Filter sourceEntityFilter,
-                                      @Nullable String destinationType, @Nonnull Filter destinationEntityFilter,
-                                      @Nonnull List<String> relationshipTypes, @Nonnull RelationshipFilter relationshipFilter,
-                                      int offset, int count) {
-    return _service.findRelatedUrns(
-            sourceType, sourceEntityFilter,
-            destinationType, destinationEntityFilter,
-            relationshipTypes, relationshipFilter,
-            offset, count
-    );
-  }
-
-  @Override
-  public void removeNode(@Nonnull Urn urn) {
-    _service.removeNode(urn);
-    waitDuration();
-  }
-
-  @Override
-  public void removeEdgesFromNode(@Nonnull Urn urn, @Nonnull List<String> relationshipTypes, @Nonnull RelationshipFilter relationshipFilter) {
-    _service.removeEdgesFromNode(urn, relationshipTypes, relationshipFilter);
-    waitDuration();
-  }
-
-  @Override
-  public void configure() {
-    _service.configure();
-    waitDuration();
-  }
-
-  @Override
-  public void clear() {
-    _service.clear();
-    waitDuration();
+  protected void syncAfterWrite() throws Exception {
+    TimeUnit.SECONDS.sleep(5);
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -15,7 +15,8 @@ import static org.testng.Assert.assertEquals;
 
 abstract public class GraphServiceTestBase {
 
-  abstract protected GraphService getGraphService();
+  abstract protected GraphService getGraphService() throws Exception;
+  abstract protected void syncAfterWrite() throws Exception;
 
   @Test
   public void testAddEdge() throws Exception {
@@ -27,6 +28,7 @@ abstract public class GraphServiceTestBase {
         "DownstreamOf");
 
     client.addEdge(edge1);
+    syncAfterWrite();
 
     List<String> edgeTypes = new ArrayList<>();
     edgeTypes.add("DownstreamOf");
@@ -57,6 +59,7 @@ abstract public class GraphServiceTestBase {
         "DownstreamOf");
 
     client.addEdge(edge1);
+    syncAfterWrite();
 
     List<String> edgeTypes = new ArrayList<>();
     edgeTypes.add("DownstreamOf");
@@ -87,6 +90,7 @@ abstract public class GraphServiceTestBase {
         "DownstreamOf");
 
     client.addEdge(edge1);
+    syncAfterWrite();
 
     List<String> edgeTypes = new ArrayList<>();
     edgeTypes.add("DownstreamOf");
@@ -110,6 +114,7 @@ abstract public class GraphServiceTestBase {
         "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
         edgeTypes,
         relationshipFilter);
+    syncAfterWrite();
 
     List<String> relatedUrnsPostDelete = client.findRelatedUrns(
         "",

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -5,6 +5,7 @@ import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
 import org.testng.annotations.Test;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,9 +14,32 @@ import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
 
 
+/**
+ * Base class for testing any GraphService implementation.
+ * Derive the test class from this base and get your GraphService implementation
+ * tested with all these tests.
+ *
+ * You can add implementation specific tests in derived classes, or add general tests
+ * here and have all existing implementations tested in the same way.
+ */
 abstract public class GraphServiceTestBase {
 
+  /**
+   * Provides the current GraphService instance to test. This is being called by the test method
+   * at most once. The serviced graph should be empty.
+   *
+   * @return the GraphService instance to test
+   * @throws Exception on failure
+   */
+  @Nonnull
   abstract protected GraphService getGraphService() throws Exception;
+
+  /**
+   * Allows the specific GraphService test implementation to wait for GraphService writes to
+   * be synced / become available to reads.
+   *
+   * @throws Exception on failure
+   */
   abstract protected void syncAfterWrite() throws Exception;
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1,0 +1,126 @@
+package com.linkedin.metadata.graph;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.metadata.query.RelationshipFilter;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static org.testng.Assert.assertEquals;
+
+
+abstract public class GraphServiceTestBase {
+
+  abstract protected GraphService getGraphService();
+
+  @Test
+  public void testAddEdge() throws Exception {
+    GraphService client = getGraphService();
+
+    Edge edge1 = new Edge(
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+        "DownstreamOf");
+
+    client.addEdge(edge1);
+
+    List<String> edgeTypes = new ArrayList<>();
+    edgeTypes.add("DownstreamOf");
+    RelationshipFilter relationshipFilter = new RelationshipFilter();
+    relationshipFilter.setDirection(RelationshipDirection.OUTGOING);
+    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+    List<String> relatedUrns = client.findRelatedUrns(
+        "",
+        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        "",
+        EMPTY_FILTER,
+        edgeTypes,
+        relationshipFilter,
+        0,
+        10);
+
+    assertEquals(relatedUrns.size(), 1);
+  }
+
+  @Test
+  public void testAddEdgeReverse() throws Exception {
+    GraphService client = getGraphService();
+
+    Edge edge1 = new Edge(
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        "DownstreamOf");
+
+    client.addEdge(edge1);
+
+    List<String> edgeTypes = new ArrayList<>();
+    edgeTypes.add("DownstreamOf");
+    RelationshipFilter relationshipFilter = new RelationshipFilter();
+    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
+    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+    List<String> relatedUrns = client.findRelatedUrns(
+        "",
+        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        "",
+        EMPTY_FILTER,
+        edgeTypes,
+        relationshipFilter,
+        0,
+        10);
+
+    assertEquals(relatedUrns.size(), 1);
+  }
+
+  @Test
+  public void testRemoveEdgesFromNode() throws Exception {
+    GraphService client = getGraphService();
+
+    Edge edge1 = new Edge(
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        "DownstreamOf");
+
+    client.addEdge(edge1);
+
+    List<String> edgeTypes = new ArrayList<>();
+    edgeTypes.add("DownstreamOf");
+    RelationshipFilter relationshipFilter = new RelationshipFilter();
+    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
+    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+    List<String> relatedUrns = client.findRelatedUrns(
+        "",
+        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        "",
+        EMPTY_FILTER,
+        edgeTypes,
+        relationshipFilter,
+        0,
+        10);
+
+    assertEquals(relatedUrns.size(), 1);
+
+    client.removeEdgesFromNode(Urn.createFromString(
+        "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        edgeTypes,
+        relationshipFilter);
+
+    List<String> relatedUrnsPostDelete = client.findRelatedUrns(
+        "",
+        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+        "",
+        EMPTY_FILTER,
+        edgeTypes,
+        relationshipFilter,
+        0,
+        10);
+
+    assertEquals(relatedUrnsPostDelete.size(), 0);
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -5,6 +5,8 @@ import org.neo4j.driver.GraphDatabase;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
+import javax.annotation.Nonnull;
+
 
 public class Neo4jGraphServiceTest extends GraphServiceTestBase {
 
@@ -26,7 +28,7 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
   }
 
   @Override
-  protected GraphService getGraphService() {
+  protected @Nonnull GraphService getGraphService() {
     return _client;
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -29,4 +29,8 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
   protected GraphService getGraphService() {
     return _client;
   }
+
+  @Override
+  protected void syncAfterWrite() { }
+
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -1,21 +1,12 @@
 package com.linkedin.metadata.graph;
 
-import com.linkedin.common.urn.Urn;
-import com.linkedin.metadata.query.RelationshipDirection;
-import com.linkedin.metadata.query.RelationshipFilter;
-import java.util.ArrayList;
-import java.util.List;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import static com.linkedin.metadata.dao.utils.QueryUtils.*;
-import static org.testng.Assert.*;
 
 
-public class Neo4jGraphServiceTest {
+public class Neo4jGraphServiceTest extends GraphServiceTestBase {
 
   private Neo4jTestServerBuilder _serverBuilder;
   private Driver _driver;
@@ -34,104 +25,8 @@ public class Neo4jGraphServiceTest {
     _serverBuilder.shutdown();
   }
 
-  @Test
-  public void testAddEdge() throws Exception {
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        "DownstreamOf");
-
-    _client.addEdge(edge1);
-
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.OUTGOING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-    List<String> relatedUrns = _client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrns.size(), 1);
-  }
-
-  @Test
-  public void testAddEdgeReverse() throws Exception {
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "DownstreamOf");
-
-    _client.addEdge(edge1);
-
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-    List<String> relatedUrns = _client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrns.size(), 1);
-  }
-
-  @Test
-  public void testRemoveEdgesFromNode() throws Exception {
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "DownstreamOf");
-
-    _client.addEdge(edge1);
-
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-    List<String> relatedUrns = _client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrns.size(), 1);
-
-    _client.removeEdgesFromNode(Urn.createFromString(
-        "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        edgeTypes,
-        relationshipFilter);
-
-    List<String> relatedUrnsPostDelete = _client.findRelatedUrns(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10);
-
-    assertEquals(relatedUrnsPostDelete.size(), 0);
+  @Override
+  protected GraphService getGraphService() {
+    return _client;
   }
 }


### PR DESCRIPTION
This refactors `ElasticSearchGraphServiceTest.java` and `Neo4jGraphServiceTest.java` to reduce code duplication and establish a set of tests shared across those `GraphService` implementations. This ensures all implementations are tested in the same way, while individual implementations can still add implementation specific tests.

Adding another `GraphService` implementation can then easily be tested at the same level as existing implementations.