### PR TITLE
fix(gql): removing data platform caching in gql

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataplatform/DataPlatformType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataplatform/DataPlatformType.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 public class DataPlatformType implements EntityType<DataPlatform> {
 
     private final DataPlatforms _dataPlatformsClient;
-    private Map<String, DataPlatform> _urnToPlatform;
 
     public DataPlatformType(final DataPlatforms dataPlatformsClient) {
         _dataPlatformsClient = dataPlatformsClient;
@@ -30,13 +29,12 @@ public class DataPlatformType implements EntityType<DataPlatform> {
     @Override
     public List<DataFetcherResult<DataPlatform>> batchLoad(final List<String> urns, final QueryContext context) {
         try {
-            if (_urnToPlatform == null) {
-                _urnToPlatform = _dataPlatformsClient.getAllPlatforms().stream()
-                        .map(DataPlatformMapper::map)
-                        .collect(Collectors.toMap(DataPlatform::getUrn, platform -> platform));
-            }
+            Map<String, DataPlatform> urnToPlatform = _dataPlatformsClient.getAllPlatforms()
+                .stream()
+                .map(DataPlatformMapper::map)
+                .collect(Collectors.toMap(DataPlatform::getUrn, platform -> platform));
             return urns.stream()
-                    .map(key -> _urnToPlatform.containsKey(key) ? _urnToPlatform.get(key) : getUnknownDataPlatform(key))
+                    .map(key -> urnToPlatform.containsKey(key) ? urnToPlatform.get(key) : getUnknownDataPlatform(key))
                 .map(dataPlatform -> DataFetcherResult.<DataPlatform>newResult().data(dataPlatform).build())
                     .collect(Collectors.toList());
         } catch (Exception e) {


### PR DESCRIPTION
We initially cached data platforms in the graphql layer because data platforms were hardcoded. With no-code, data platforms no longer are hardcoded and may be updated at any time. As a result, we should no longer cache them in graphql.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
