### PR TITLE
fix(ingestion): match nested LookML files mentioned in 'include' statements

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -112,6 +112,11 @@ class LookerModel:
     def resolve_includes(
         includes: List[str], base_folder: str, path: str, reporter: LookMLSourceReport
     ) -> List[str]:
+        """Resolve ``include`` statements in LookML model files to a list of ``.lkml`` files.
+
+        For rules on how LookML ``include`` statements are written, see
+            https://docs.looker.com/data-modeling/getting-started/ide-folders#wildcard_examples
+        """
         resolved = []
         for inc in includes:
             # Filter out dashboards - we get those through the looker source.
@@ -128,7 +133,8 @@ class LookerModel:
             else:
                 # Need to handle a relative path.
                 glob_expr = str(pathlib.Path(path).parent / inc)
-            outputs = glob.glob(glob_expr) + glob.glob(f"{glob_expr}.lkml")
+            # "**" matches an arbitrary number of directories in LookML
+            outputs = glob.glob(glob_expr, recursive=True) + glob.glob(f"{glob_expr}.lkml", recursive=True)
             if "*" not in inc and not outputs:
                 reporter.report_failure(path, f"cannot resolve include {inc}")
             elif not outputs:

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -134,7 +134,9 @@ class LookerModel:
                 # Need to handle a relative path.
                 glob_expr = str(pathlib.Path(path).parent / inc)
             # "**" matches an arbitrary number of directories in LookML
-            outputs = glob.glob(glob_expr, recursive=True) + glob.glob(f"{glob_expr}.lkml", recursive=True)
+            outputs = glob.glob(glob_expr, recursive=True) + glob.glob(
+                f"{glob_expr}.lkml", recursive=True
+            )
             if "*" not in inc and not outputs:
                 reporter.report_failure(path, f"cannot resolve include {inc}")
             elif not outputs:


### PR DESCRIPTION
The LookML metadata ingestion logic includes a method, `resolve_includes()`, whose goal is to turn [LookML `include` statements](https://docs.looker.com/reference/model-params/include) into valid Python `glob` patterns. This is used to identify `.lkml` files to be read in and used to create MCE messages.

I believe that a mistake in that logic leads to files in deeply-nested directories being ignored by `datahub ingest`.

the LookML

```text
include: "/**/some_cool_view.view.lkml"
```

is treated as equivalent to

```python
glob.glob(f"{config['base_folder']}/**/some_cool_view.lkml")
````

But I believe that's incorrect. According to https://docs.looker.com/data-modeling/getting-started/ide-folders#wildcard_examples, `**` matches all directories at any level of nesting. Without `recursive=True`, that `glob.glob()` call says "match files called `some_cool_view.view.lkml` exactly one directory below `base_folder`".

This PR proposes a fix to make this project's Python code match LookML's treatment of wildcards more closely.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

### Notes for reviewers

I tested this against a DataHub environment I have access to and can confirm that before this change (as of `acryl-datahub==0.8.6.1`), `.view.lkml` files nested more than one directory below the `base_folder` were not found, and after this change they are.

Thanks for your time and consideration.