### PR TITLE
fix(ingest): ensure workunits are created for all LookML views

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from dataclasses import replace
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 import pydantic
 
@@ -217,10 +217,7 @@ class LookerViewFileLoader:
             return None
 
     def load_viewfile(
-        self,
-        path: str,
-        connection: str,
-        reporter: LookMLSourceReport,
+        self, path: str, connection: str, reporter: LookMLSourceReport
     ) -> Optional[LookerViewFile]:
         """
         Given a path to ``.view.lkml`` file, create a ``LookerViewFile`` instance.
@@ -389,9 +386,9 @@ class LookerView:
         # lives in, so we try them all!
         for include in looker_viewfile.resolved_includes:
             included_looker_viewfile = looker_viewfile_loader.load_viewfile(
-                path=include,
-                connection=connection,
-                reporter=reporter,
+                include,
+                connection,
+                reporter,
             )
             if not included_looker_viewfile:
                 logger.warning(
@@ -627,7 +624,7 @@ class LookMLSource(Source):
 
         # some views can be mentioned by multiple 'include' statements, so this set is be used to prevent
         # creating duplicate MCE messages
-        views_with_workunits = set()
+        views_with_workunits: Set[str] = set()
 
         # The ** means "this directory and all subdirectories", and hence should
         # include all the files we want.
@@ -655,9 +652,9 @@ class LookMLSource(Source):
 
                 logger.debug(f"Attempting to load view file: {include}")
                 looker_viewfile = viewfile_loader.load_viewfile(
-                    path=include,
-                    connection=model.connection,
-                    reporter=self.reporter,
+                    include,
+                    model.connection,
+                    self.reporter,
                 )
                 if looker_viewfile is not None:
                     for raw_view in looker_viewfile.views:

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -608,7 +608,7 @@ class LookMLSource(Source):
             str(self.source_config.base_folder), self.reporter
         )
 
-        # some views can be mentioned by multiple 'include' statements, so this set is be used to prevent
+        # some views can be mentioned by multiple 'include' statements, so this set is used to prevent
         # creating duplicate MCE messages
         views_with_workunits: Set[str] = set()
 

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -386,9 +386,7 @@ class LookerView:
         # lives in, so we try them all!
         for include in looker_viewfile.resolved_includes:
             included_looker_viewfile = looker_viewfile_loader.load_viewfile(
-                include,
-                connection,
-                reporter,
+                include, connection, reporter
             )
             if not included_looker_viewfile:
                 logger.warning(
@@ -652,9 +650,7 @@ class LookMLSource(Source):
 
                 logger.debug(f"Attempting to load view file: {include}")
                 looker_viewfile = viewfile_loader.load_viewfile(
-                    include,
-                    model.connection,
-                    self.reporter,
+                    include, model.connection, self.reporter
                 )
                 if looker_viewfile is not None:
                     for raw_view in looker_viewfile.views:

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -219,19 +219,7 @@ class LookerViewFileLoader:
     def load_viewfile(
         self, path: str, connection: str, reporter: LookMLSourceReport
     ) -> Optional[LookerViewFile]:
-        """
-        Given a path to ``.view.lkml`` file, create a ``LookerViewFile`` instance.
-
-        Parameters
-        ----------
-            path:
-                String with an absolute path to a ``.view.lkml`` file
-            connection:
-                String with a connection name (e.g. ``"redshift"``)
-            reporter:
-                ``LookMLSourceReport`` instance, used to generate a summary report at the end of ingestion
-        """
-        viewfile = self._load_viewfile(path=path, reporter=reporter)
+        viewfile = self._load_viewfile(path, reporter)
         if viewfile is None:
             return None
 


### PR DESCRIPTION
In metadata ingestion for LookML files, the method `LookerViewFileLoader.load_viewfile()` is responsible for reading in a `.view.lkml` file, parsing it with `lkml`, and returning a `LookerViewFile` instance from it.

https://github.com/linkedin/datahub/blob/328b098d0156f01a91a226e03003152fadc1ac03/metadata-ingestion/src/datahub/ingestion/source/lookml.py#L207-L213

Since one view file could be matched by `include` statements in multiple model/view files, it's possible for `datahub ingest` to result in multiple `load_viewfile()` calls for the same view file. To avoid re-parsing the same file multiple times, the `LookerViewFileLoader` holds a cache of parsed files.

https://github.com/linkedin/datahub/blob/328b098d0156f01a91a226e03003152fadc1ac03/metadata-ingestion/src/datahub/ingestion/source/lookml.py#L203-L204

After some investigation today, I found that there is another place in LookML metadata ingestion where that cache is also being used as a source of truth for "which viewfiles have had workunits created for them".

https://github.com/linkedin/datahub/blob/328b098d0156f01a91a226e03003152fadc1ac03/metadata-ingestion/src/datahub/ingestion/source/lookml.py#L632-L633

That can lead to some views being silently skipped (i.e., never having their metadata ingestion), if the first time they were loaded was in this other check where `load_viewfile()` is used during the process of resolving views that extend other views.

https://github.com/linkedin/datahub/blob/328b098d0156f01a91a226e03003152fadc1ac03/metadata-ingestion/src/datahub/ingestion/source/lookml.py#L372-L377

This PR proposes adding a flag to `load_viewfile()` that allows the use of that method without updating the loader's cache. In manual tests against a DataHub instance I have access to, I found that this fixed the "some views are not getting Datasets created" issue I was facing.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

## Notes for Reviewers

I added argument `update_cache` with a default value to make this change backwards-compatible, but I think it would be a bit safer to not have that default value at all. Do I need to care about backwards-compatibility from the perspective of people doing `from datahub.ingestion.source.lookml import LookerViewFileLoader`?

Thanks for your time and consideration.