### PR TITLE
fix(ingest): ensure that LookML files are always parsed in the same order

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -139,8 +139,9 @@ class LookerModel:
                 # Need to handle a relative path.
                 glob_expr = str(pathlib.Path(path).parent / inc)
             # "**" matches an arbitrary number of directories in LookML
-            outputs = glob.glob(glob_expr, recursive=True) + glob.glob(
-                f"{glob_expr}.lkml", recursive=True
+            outputs = sorted(
+                glob.glob(glob_expr, recursive=True)
+                + glob.glob(f"{glob_expr}.lkml", recursive=True)
             )
             if "*" not in inc and not outputs:
                 reporter.report_failure(path, f"cannot resolve include {inc}")


### PR DESCRIPTION
Metadata ingestion for LookML requires a few operations that list files using `glob.glob()`. This PR proposes sorting those lists of files by name, to ensure that given the same set of `.lkml` files, `datahub ingest` will process them in the same order every time.

The ordering of results from `glob.glob()` is not guaranteed to be the same on different filesystems. See https://stackoverflow.com/a/6773661 for more details.

## How this improves `datahub ingest`

I faced a really difficult bug today. I created a docker image with an entrypoint that ran something like `datahub ingest -c /recipes/recipe.yaml`.

I found that I got different behavior in these two methods of running containers using that image:

* in a container on my laptop
    - ```shell
       git clone https://lookml-files.git
       docker run -v $(pwd)/lookml-files:/model-files my-ingestion-image:${TAG}
       ```
* starting a pod in k8s using [git-sync](https://github.com/kubernetes/git-sync) to clone from `lookml-files.git` and mount it into a container at `/model-files`

Eventually, I discovered a separate bug where the order of parsing mattered (proposed fix in #2965 ). A strong guarantee that `datahub ingest` processes files in the same order every time would have sped up my debugging of that issue, and would have given me higher confidence that ingestion running in k8s would match the behavior I saw in my development environment.

## Checklist

- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

Thanks for your time and consideration!
