### PR TITLE
perf(ingest): remove unused variable in Looker ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker.py
@@ -160,7 +160,6 @@ class LookerDashboardSource(Source):
             # We are not going to support parsing arbitrary Looker expressions here, so going to ignore these fields for now
             if "dimension" in field:
                 dimension = field["dimension"]
-                expression = field["expression"]  # noqa: F841
                 custom_field_to_underlying_field[dimension] = None
 
         # A query uses fields defined in views, find the views those fields use


### PR DESCRIPTION
I've been looking at opportunities to contribute on metadata ingestion, so I ran  `pylint metadata-ingestion/src/datahub` today.

This PR proposes fixing one of the warnings raised by `pylint`.

> metadata-ingestion/src/datahub/ingestion/source/looker.py:163:16: W0612: Unused variable 'expression' (unused-variable)

This PR proposes removing that variable, which I think should make the Looker ingestion code a tiny tiny tiny bit faster and, more importantly, eliminates the risk of that code breaking if the key `"expression"` doesn't show up in the parsed fields.

Thanks for your time and consideration.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
