### PR TITLE
fix(tags): fixing tag applied to module for tags w/ colons in the name

### DIFF
--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -1093,7 +1093,7 @@ export const mocks = [
             variables: {
                 input: {
                     type: 'GLOSSARY_TERM',
-                    query: 'tags:abc-sample-tag',
+                    query: 'tags:"abc-sample-tag"',
                     start: 0,
                     count: 1,
                     filters: [],
@@ -1275,7 +1275,7 @@ export const mocks = [
             variables: {
                 input: {
                     type: 'CORP_USER',
-                    query: 'tags:abc-sample-tag',
+                    query: 'tags:"abc-sample-tag"',
                     start: 0,
                     count: 1,
                     filters: [],
@@ -1302,7 +1302,7 @@ export const mocks = [
             variables: {
                 input: {
                     type: 'DATASET',
-                    query: 'tags:abc-sample-tag',
+                    query: 'tags:"abc-sample-tag"',
                     start: 0,
                     count: 1,
                     filters: [],

--- a/datahub-web-react/src/app/entity/tag/TagProfile.tsx
+++ b/datahub-web-react/src/app/entity/tag/TagProfile.tsx
@@ -84,7 +84,7 @@ export default function TagProfile() {
     const history = useHistory();
 
     const allSearchResultsByType = useGetAllEntitySearchResults({
-        query: `tags:${data?.tag?.name}`,
+        query: `tags:"${data?.tag?.name}"`,
         start: 0,
         count: 1,
         filters: [],


### PR DESCRIPTION
The search query that populates this module was not quoting the search term, so tags with colons were not properly being found.

![image](https://user-images.githubusercontent.com/2455694/127419758-54f027ee-1c88-4d48-af90-ab1be89230a2.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
