### PR TITLE
fix(blank pages): removing apollo caching

### DIFF
--- a/datahub-web-react/src/App.tsx
+++ b/datahub-web-react/src/App.tsx
@@ -48,62 +48,11 @@ const errorLink = onError(({ networkError }) => {
 const client = new ApolloClient({
     connectToDevTools: true,
     link: errorLink.concat(httpLink),
-    cache: new InMemoryCache({
-        typePolicies: {
-            Query: {
-                fields: {
-                    dataset: {
-                        merge(existing, incoming) {
-                            return { ...existing, ...incoming };
-                        },
-                    },
-                },
-            },
-            Dataset: {
-                keyFields: ['urn'],
-            },
-            CorpUser: {
-                keyFields: ['urn'],
-            },
-            Dashboard: {
-                keyFields: ['urn'],
-            },
-            Chart: {
-                keyFields: ['urn'],
-            },
-            DataFlow: {
-                keyFields: ['urn'],
-            },
-            DataJob: {
-                keyFields: ['urn'],
-            },
-            MLFeatureTable: {
-                keyFields: ['urn'],
-            },
-            MLModel: {
-                keyFields: ['urn'],
-            },
-            MLModelGroup: {
-                keyFields: ['urn'],
-            },
-        },
-        possibleTypes: {
-            EntityWithRelationships: [
-                'Dataset',
-                'Chart',
-                'Dashboard',
-                'DataJob',
-                'MLFeature',
-                'MLPrimaryKey',
-                'MLModel',
-                'MLModelGroup',
-            ],
-        },
-    }),
+    cache: new InMemoryCache(),
     credentials: 'include',
     defaultOptions: {
         watchQuery: {
-            fetchPolicy: 'cache-and-network',
+            fetchPolicy: 'no-cache',
             nextFetchPolicy: 'cache-first',
         },
         query: {


### PR DESCRIPTION
Apollo caching has created some strange scenarios for us lately. In certain cases, it appears to swallow responses from graphql and return null entities even when the response has a fully fleshed out entity.

We should disable the apollo cache until we have time to thoroughly understand apollo's caching behavior.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
