### PR TITLE
fix(quickstart): Bumping Default Memory for GMS and Frontend

### DIFF
--- a/docker/datahub-frontend/env/docker.env
+++ b/docker/datahub-frontend/env/docker.env
@@ -3,7 +3,7 @@ DATAHUB_GMS_PORT=8080
 DATAHUB_SECRET=YouKnowNothing
 DATAHUB_APP_VERSION=1.0
 DATAHUB_PLAY_MEM_BUFFER_SIZE=10MB
-JAVA_OPTS=-Xms256m -Xmx256m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf/application.conf -Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf -Dlogback.configurationFile=datahub-frontend/conf/logback.xml -Dlogback.debug=false -Dpidfile.path=/dev/null
+JAVA_OPTS=-Xms512m -Xmx512m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf/application.conf -Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf -Dlogback.configurationFile=datahub-frontend/conf/logback.xml -Dlogback.debug=false -Dpidfile.path=/dev/null
 
 # Uncomment and set these to support SSL connection to GMS
 # NOTE: Currently GMS itself does not offer SSL support, these settings are intended for when there is a proxy in front

--- a/docker/datahub-gms/env/docker-without-neo4j.env
+++ b/docker/datahub-gms/env/docker-without-neo4j.env
@@ -9,7 +9,7 @@ KAFKA_SCHEMAREGISTRY_URL=http://schema-registry:8081
 ELASTICSEARCH_HOST=elasticsearch
 ELASTICSEARCH_PORT=9200
 GRAPH_SERVICE_IMPL=elasticsearch
-JAVA_OPTS=-Xms256m -Xmx256m
+JAVA_OPTS=-Xms1g -Xmx1g
 ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
 
 MAE_CONSUMER_ENABLED=true

--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -12,7 +12,7 @@ NEO4J_HOST=http://neo4j:7474
 NEO4J_URI=bolt://neo4j
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=datahub
-JAVA_OPTS=-Xms256m -Xmx256m
+JAVA_OPTS=-Xms1g -Xmx1g
 GRAPH_SERVICE_IMPL=neo4j
 ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
 

--- a/docker/datahub-gms/env/docker.mariadb.env
+++ b/docker/datahub-gms/env/docker.mariadb.env
@@ -13,5 +13,5 @@ NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=datahub
 MAE_CONSUMER_ENABLED=true
 MCE_CONSUMER_ENABLED=true
-JAVA_OPTS=-Xms256m -Xmx256m
+JAVA_OPTS=-Xms1g -Xmx1g
 ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml

--- a/docker/datahub-gms/env/docker.postgres.env
+++ b/docker/datahub-gms/env/docker.postgres.env
@@ -13,5 +13,5 @@ NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=datahub
 MAE_CONSUMER_ENABLED=true
 MCE_CONSUMER_ENABLED=true
-JAVA_OPTS=-Xms256m -Xmx256m
+JAVA_OPTS=-Xms1g -Xmx1g
 ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -29,7 +29,7 @@ services:
     - DATAHUB_SECRET=YouKnowNothing
     - DATAHUB_APP_VERSION=1.0
     - DATAHUB_PLAY_MEM_BUFFER_SIZE=10MB
-    - JAVA_OPTS=-Xms256m -Xmx256m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf/application.conf
+    - JAVA_OPTS=-Xms512m -Xmx512m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf/application.conf
       -Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf -Dlogback.configurationFile=datahub-frontend/conf/logback.xml
       -Dlogback.debug=false -Dpidfile.path=/dev/null
     - KAFKA_BOOTSTRAP_SERVER=broker:29092
@@ -57,7 +57,7 @@ services:
     - ELASTICSEARCH_HOST=elasticsearch
     - ELASTICSEARCH_PORT=9200
     - GRAPH_SERVICE_IMPL=elasticsearch
-    - JAVA_OPTS=-Xms256m -Xmx256m
+    - JAVA_OPTS=-Xms1g -Xmx1g
     - ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
     - MAE_CONSUMER_ENABLED=true
     - MCE_CONSUMER_ENABLED=true

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -29,7 +29,7 @@ services:
     - DATAHUB_SECRET=YouKnowNothing
     - DATAHUB_APP_VERSION=1.0
     - DATAHUB_PLAY_MEM_BUFFER_SIZE=10MB
-    - JAVA_OPTS=-Xms256m -Xmx256m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf/application.conf
+    - JAVA_OPTS=-Xms512m -Xmx512m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf/application.conf
       -Djava.security.auth.login.config=datahub-frontend/conf/jaas.conf -Dlogback.configurationFile=datahub-frontend/conf/logback.xml
       -Dlogback.debug=false -Dpidfile.path=/dev/null
     - KAFKA_BOOTSTRAP_SERVER=broker:29092
@@ -60,7 +60,7 @@ services:
     - NEO4J_URI=bolt://neo4j
     - NEO4J_USERNAME=neo4j
     - NEO4J_PASSWORD=datahub
-    - JAVA_OPTS=-Xms256m -Xmx256m
+    - JAVA_OPTS=-Xms1g -Xmx1g
     - GRAPH_SERVICE_IMPL=neo4j
     - ENTITY_REGISTRY_CONFIG_PATH=/datahub/datahub-gms/resources/entity-registry.yml
     - MAE_CONSUMER_ENABLED=true


### PR DESCRIPTION
Recently there have been reports of GMS failing on quickstart due to OOM. This PR addresses this by bumping the default heap allocation back up. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
