### PR TITLE
test(GraphService): Thorough graph service tests

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/GraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/GraphService.java
@@ -9,8 +9,58 @@ import javax.annotation.Nullable;
 
 public interface GraphService {
 
+  /**
+   * Adds an edge to the graph. This creates the source and destination nodes, if they do not exist.
+   */
   void addEdge(final Edge edge);
 
+  /**
+   * Find related entities (nodes) connected to a source entity via edges of given relationship types. Related entities
+   * can be filtered by source and destination type (use `null` for any type), by source and destination entity filter
+   * and relationship filter. Pagination of the result is controlled via `offset` and `count`.
+   *
+   * Starting from a node as the source entity, determined by `sourceType` and `sourceEntityFilter`,
+   * related entities are found along the direction of edges (`RelationshipDirection.OUTGOING`) or in opposite
+   * direction of edges (`RelationshipDirection.INCOMING`). The destination entities are further filtered by `destinationType`
+   * and `destinationEntityFilter`, and then returned as related entities.
+   *
+   * This does not return duplicate related entities, even if entities are connected to source entities via multiple edges.
+   * An empty list of relationship types returns an empty result.
+   *
+   * In other words, the source and destination entity is not to be understood as the source and destination of the edge,
+   * but as the source and destination of "finding related entities", where always the destination entities are returned.
+   * This understanding is important when it comes to `RelationshipDirection.INCOMING`. The origin of the edge becomes
+   * the destination entity and the source entity is where the edge points to.
+   *
+   * Example I:
+   *   dataset one --DownstreamOf-> dataset two --DownstreamOf-> dataset three
+   *
+   *   findRelatedEntities(null, EMPTY_FILTER, null, EMPTY_FILTER, ["DownstreamOf"], RelationshipFilter.setDirection(RelationshipDirection.OUTGOING), 0, 100)
+   *   - RelatedEntity("DownstreamOf", "dataset two")
+   *   - RelatedEntity("DownstreamOf", "dataset three")
+   *
+   *   findRelatedEntities(null, EMPTY_FILTER, null, EMPTY_FILTER, ["DownstreamOf"], RelationshipFilter.setDirection(RelationshipDirection.INCOMING), 0, 100)
+   *   - RelatedEntity("DownstreamOf", "dataset one")
+   *   - RelatedEntity("DownstreamOf", "dataset two")
+   *
+   * Example II:
+   *   dataset one --HasOwner-> user one
+   *
+   *   findRelatedEntities(null, EMPTY_FILTER, null, EMPTY_FILTER, ["HasOwner"], RelationshipFilter.setDirection(RelationshipDirection.OUTGOING), 0, 100)
+   *   - RelatedEntity("HasOwner", "user one")
+   *
+   *   findRelatedEntities(null, EMPTY_FILTER, null, EMPTY_FILTER, ["HasOwner"], RelationshipFilter.setDirection(RelationshipDirection.INCOMING), 0, 100)
+   *   - RelatedEntity("HasOwner", "dataset one")
+   *
+   * Calling this method with {@link com.linkedin.metadata.query.RelationshipDirection} `UNDIRECTED` in `relationshipFilter`
+   * is equivalent to the union of `OUTGOING` and `INCOMING` (without duplicates).
+   *
+   * Example III:
+   *   findRelatedEntities(null, EMPTY_FILTER, null, EMPTY_FILTER, ["DownstreamOf"], RelationshipFilter.setDirection(RelationshipDirection.UNDIRECTED), 0, 100)
+   *   - RelatedEntity("DownstreamOf", "dataset one")
+   *   - RelatedEntity("DownstreamOf", "dataset two")
+   *   - RelatedEntity("DownstreamOf", "dataset three")
+   */
   @Nonnull
   RelatedEntitiesResult findRelatedEntities(
       @Nullable final String sourceType,
@@ -22,8 +72,19 @@ public interface GraphService {
       final int offset,
       final int count);
 
+  /**
+   * Removes the given node (if it exists) as well as all edges (incoming and outgoing) of the node.
+   */
   void removeNode(@Nonnull final Urn urn);
 
+  /**
+   * Removes edges of the given relationship types from the given node after applying the relationship filter.
+   *
+   * An empty list of relationship types removes nothing from the node.
+   *
+   * Calling this method with a {@link com.linkedin.metadata.query.RelationshipDirection} `UNDIRECTED` in `relationshipFilter`
+   * is equivalent to the union of `OUTGOING` and `INCOMING` (without duplicates).
+   */
   void removeEdgesFromNode(
       @Nonnull final Urn urn,
       @Nonnull final List<String> relationshipTypes,
@@ -31,5 +92,8 @@ public interface GraphService {
 
   void configure();
 
+  /**
+   * Removes all edges and nodes from the graph.
+   */
   void clear();
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/Neo4jGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/Neo4jGraphService.java
@@ -114,7 +114,7 @@ public class Neo4jGraphService implements GraphService {
       matchTemplate = "MATCH (src%s %s)-[r%s %s]->(dest%s %s)";
     }
 
-    final String returnNodes = "RETURN dest, type(r)"; // Return both related entity and the relationship type.
+    final String returnNodes = String.format("RETURN dest%s, type(r)", destinationType); // Return both related entity and the relationship type.
     final String returnCount = "RETURN count(*)"; // For getting the total results.
 
     String relationshipTypeFilter = "";

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -203,6 +203,13 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   @Test
   @Override
+  public void testConcurrentAddEdge() {
+    // https://github.com/linkedin/datahub/issues/3124
+    throw new SkipException("This test is flaky for ElasticSearchGraphService, ~5% of the runs fail on a race condition");
+  }
+
+  @Test
+  @Override
   public void testConcurrentRemoveEdgesFromNode() {
     // https://github.com/linkedin/datahub/issues/3118
     throw new SkipException("ElasticSearchGraphService produces duplicates");

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -94,7 +94,7 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   @Override
   protected void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
     assertEquals(actual.start, expected.start);
-    assertEqualsAnyOrder(actual.entities, expected.entities, relatedEntityComparator);
+    assertEqualsAnyOrder(actual.entities, expected.entities, RELATED_ENTITY_COMPARATOR);
   }
 
   @Override

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.graph;
 
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.ElasticSearchTestUtils;
 import com.linkedin.metadata.graph.elastic.ESGraphQueryDAO;
 import com.linkedin.metadata.graph.elastic.ESGraphWriteDAO;
@@ -41,12 +42,6 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
   private static final int HTTP_PORT = 9200;
 
-  @BeforeMethod
-  public void wipe() throws Exception {
-    _client.clear();
-    syncAfterWrite();
-  }
-
   @BeforeTest
   public void setup() {
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
@@ -54,6 +49,12 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
     _searchClient = buildRestClient();
     _client = buildService();
     _client.configure();
+  }
+
+  @BeforeMethod
+  public void wipe() throws Exception {
+    _client.clear();
+    syncAfterWrite();
   }
 
   @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -93,13 +93,17 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   @Override
   protected void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
+    // https://github.com/linkedin/datahub/issues/3115
+    // ElasticSearchGraphService produces duplicates, which is here ignored until fixed
+    // actual.count and actual.total not tested due to duplicates
     assertEquals(actual.start, expected.start);
     assertEqualsAnyOrder(actual.entities, expected.entities, RELATED_ENTITY_COMPARATOR);
   }
 
   @Override
   protected <T> void assertEqualsAnyOrder(List<T> actual, List<T> expected, Comparator<T> comparator) {
-    // ElasticSearchGraphService produces duplicates, which is here compensated until fixed
+    // https://github.com/linkedin/datahub/issues/3115
+    // ElasticSearchGraphService produces duplicates, which is here ignored until fixed
     assertEquals(
             new HashSet<>(actual),
             new HashSet<>(expected)
@@ -112,7 +116,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
                                                         RelationshipFilter relationships,
                                                         List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
-      throw new SkipException("ElasticSearchGraphService does not implement undirected relationship filter");
+      // https://github.com/linkedin/datahub/issues/3114
+      throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
     super.testFindRelatedEntitiesSourceEntityFilter(sourceEntityFilter, relationshipTypes, relationships, expectedRelatedEntities);
   }
@@ -123,7 +128,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
                                                              RelationshipFilter relationships,
                                                              List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
-      throw new SkipException("ElasticSearchGraphService does not implement undirected relationship filter");
+      // https://github.com/linkedin/datahub/issues/3114
+      throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
     super.testFindRelatedEntitiesDestinationEntityFilter(destinationEntityFilter, relationshipTypes, relationships, expectedRelatedEntities);
   }
@@ -134,9 +140,11 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
                                                 RelationshipFilter relationships,
                                                 List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
-      throw new SkipException("ElasticSearchGraphService does not implement undirected relationship filter");
+      // https://github.com/linkedin/datahub/issues/3114
+      throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
     if (datasetType != null && datasetType.isEmpty()) {
+      // https://github.com/linkedin/datahub/issues/3116
       throw new SkipException("ElasticSearchGraphService does not support empty source type");
     }
     super.testFindRelatedEntitiesSourceType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
@@ -148,9 +156,11 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
                                                      RelationshipFilter relationships,
                                                      List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
-      throw new SkipException("ElasticSearchGraphService does not implement undirected relationship filter");
+      // https://github.com/linkedin/datahub/issues/3114
+      throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
     if (datasetType != null && datasetType.isEmpty()) {
+      // https://github.com/linkedin/datahub/issues/3116
       throw new SkipException("ElasticSearchGraphService does not support empty destination type");
     }
     super.testFindRelatedEntitiesDestinationType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
@@ -159,6 +169,7 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   @Test
   @Override
   public void testFindRelatedEntitiesNoRelationshipTypes() {
+    // https://github.com/linkedin/datahub/issues/3117
     throw new SkipException("ElasticSearchGraphService does not support empty list of relationship types");
   }
 
@@ -171,7 +182,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
                                       List<RelatedEntity> expectedOutgoingRelatedUrnsAfterRemove,
                                       List<RelatedEntity> expectedIncomingRelatedUrnsAfterRemove) throws Exception {
     if (relationshipFilter.getDirection() == RelationshipDirection.UNDIRECTED) {
-      throw new SkipException("ElasticSearchGraphService does not implement undirected relationship filter");
+      // https://github.com/linkedin/datahub/issues/3114
+      throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
     super.testRemoveEdgesFromNode(
             nodeToRemoveFrom,
@@ -184,6 +196,7 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   @Test
   @Override
   public void testRemoveEdgesFromNodeNoRelationshipTypes() {
+    // https://github.com/linkedin/datahub/issues/3117
     throw new SkipException("ElasticSearchGraphService does not support empty list of relationship types");
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -199,4 +199,19 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
     // https://github.com/linkedin/datahub/issues/3117
     throw new SkipException("ElasticSearchGraphService does not support empty list of relationship types");
   }
+
+  @Test
+  @Override
+  public void testConcurrentRemoveEdgesFromNode() {
+    // https://github.com/linkedin/datahub/issues/3118
+    throw new SkipException("ElasticSearchGraphService produces duplicates");
+  }
+
+  @Test
+  @Override
+  public void testConcurrentRemoveNodes() {
+    // https://github.com/linkedin/datahub/issues/3118
+    throw new SkipException("ElasticSearchGraphService produces duplicates");
+  }
+
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1021,8 +1021,7 @@ abstract public class GraphServiceTestBase {
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
             0, 100);
 
-    // can be replaced with a single removeEdgesFromNode and undirectedRelationships
-    // once supported by all implementations
+    // can be replaced with a single removeEdgesFromNode and undirectedRelationships once supported by all implementations
     service.removeEdgesFromNode(
             nodeToRemoveFrom,
             Collections.emptyList(),
@@ -1075,10 +1074,16 @@ abstract public class GraphServiceTestBase {
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
             0, 100);
 
+    // can be replaced with a single removeEdgesFromNode and undirectedRelationships once supported by all implementations
     service.removeEdgesFromNode(
             nodeToRemoveFrom,
-            Collections.emptyList(),
-            undirectedRelationships
+            Arrays.asList(downstreamOf, hasOwner, knowsUser),
+            outgoingRelationships
+    );
+    service.removeEdgesFromNode(
+            nodeToRemoveFrom,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser),
+            incomingRelationships
     );
     syncAfterWrite();
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1,19 +1,31 @@
 package com.linkedin.metadata.graph;
 
 import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.query.Filter;
 import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
-import java.util.stream.Collectors;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
-
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Base class for testing any GraphService implementation.
@@ -22,8 +34,89 @@ import static org.testng.Assert.assertEquals;
  *
  * You can add implementation specific tests in derived classes, or add general tests
  * here and have all existing implementations tested in the same way.
+ *
+ * Note this base class does not test GraphService.addEdge explicitly. This method is tested
+ * indirectly by all tests via `getPopulatedGraphService` at the beginning of each test.
+ * The `getPopulatedGraphService` method calls `GraphService.addEdge` to populate the Graph.
+ * Feel free to add a test to your test implementation that calls `getPopulatedGraphService` and
+ * asserts the state of the graph in an implementation specific way.
  */
 abstract public class GraphServiceTestBase {
+
+  /**
+   * Some test URN types.
+   */
+  protected static String datasetType = "dataset";
+  protected static String userType = "user";
+
+  /**
+   * Some test datasets.
+   */
+  protected static String datasetOneUrnString = "urn:li:" + datasetType + ":(urn:li:dataPlatform:type,SampleDatasetOne,PROD)";
+  protected static String datasetTwoUrnString = "urn:li:" + datasetType + ":(urn:li:dataPlatform:type,SampleDatasetTwo,PROD)";
+  protected static String datasetThreeUrnString = "urn:li:" + datasetType + ":(urn:li:dataPlatform:type,SampleDatasetThree,PROD)";
+  protected static String datasetFourUrnString = "urn:li:" + datasetType + ":(urn:li:dataPlatform:type,SampleDatasetFour,PROD)";
+
+  protected static Urn datasetOneUrn = createFromString(datasetOneUrnString);
+  protected static Urn datasetTwoUrn = createFromString(datasetTwoUrnString);
+  protected static Urn datasetThreeUrn = createFromString(datasetThreeUrnString);
+  protected static Urn datasetFourUrn = createFromString(datasetFourUrnString);
+
+  /**
+   * Some dataset owners.
+   */
+  protected static String userOneUrnString = "urn:li:" + userType + ":(urn:li:user:system,Ingress,PROD)";
+  protected static String userTwoUrnString = "urn:li:" + userType + ":(urn:li:user:individual,UserA,DEV)";
+
+  protected static Urn userOneUrn = createFromString(userOneUrnString);
+  protected static Urn userTwoUrn = createFromString(userTwoUrnString);
+
+  /**
+   * Some test relationships.
+   */
+  protected static String downstreamOf = "DownstreamOf";
+  protected static String hasOwner = "HasOwner";
+  protected static String knowsUser = "KnowsUser";
+  protected static Set<String> allRelationshipTypes = new HashSet<>(Arrays.asList(downstreamOf, hasOwner, knowsUser));
+
+  /**
+   * Some test related entities.
+   */
+  protected static RelatedEntity downstreamOfDatasetOneRelatedEntity = new RelatedEntity(downstreamOf, datasetOneUrnString);
+  protected static RelatedEntity downstreamOfDatasetTwoRelatedEntity = new RelatedEntity(downstreamOf, datasetTwoUrnString);
+  protected static RelatedEntity downstreamOfDatasetThreeRelatedEntity = new RelatedEntity(downstreamOf, datasetThreeUrnString);
+  protected static RelatedEntity downstreamOfDatasetFourRelatedEntity = new RelatedEntity(downstreamOf, datasetFourUrnString);
+  protected static RelatedEntity hasOwnerDatasetOneRelatedEntity = new RelatedEntity(hasOwner, datasetOneUrnString);
+  protected static RelatedEntity hasOwnerDatasetTwoRelatedEntity = new RelatedEntity(hasOwner, datasetTwoUrnString);
+  protected static RelatedEntity hasOwnerDatasetThreeRelatedEntity = new RelatedEntity(hasOwner, datasetThreeUrnString);
+  protected static RelatedEntity hasOwnerDatasetFourRelatedEntity = new RelatedEntity(hasOwner, datasetFourUrnString);
+  protected static RelatedEntity hasOwnerUserOneRelatedEntity = new RelatedEntity(hasOwner, userOneUrnString);
+  protected static RelatedEntity hasOwnerUserTwoRelatedEntity = new RelatedEntity(hasOwner, userTwoUrnString);
+  protected static RelatedEntity knowsUserOneRelatedEntity = new RelatedEntity(knowsUser, userOneUrnString);
+  protected static RelatedEntity knowsUserTwoRelatedEntity = new RelatedEntity(knowsUser, userTwoUrnString);
+
+  /**
+   * Some relationship filters.
+   */
+  protected static RelationshipFilter outgoingRelationships = createRelationshipFilter(RelationshipDirection.OUTGOING);
+  protected static RelationshipFilter incomingRelationships = createRelationshipFilter(RelationshipDirection.INCOMING);
+  protected static RelationshipFilter undirectedRelationships = createRelationshipFilter(RelationshipDirection.UNDIRECTED);
+
+  /**
+   * Any source and destination type value.
+   */
+  protected static @Nullable String anyType = null;
+
+  @Test
+  public void testStaticUrns() {
+    assertNotNull(datasetOneUrn);
+    assertNotNull(datasetTwoUrn);
+    assertNotNull(datasetThreeUrn);
+    assertNotNull(datasetFourUrn);
+
+    assertNotNull(userOneUrn);
+    assertNotNull(userTwoUrn);
+  }
 
   /**
    * Provides the current GraphService instance to test. This is being called by the test method
@@ -43,129 +136,846 @@ abstract public class GraphServiceTestBase {
    */
   abstract protected void syncAfterWrite() throws Exception;
 
-  @Test
-  public void testAddEdge() throws Exception {
-    GraphService client = getGraphService();
+  /**
+   * Calls getGraphService to retrieve the test GraphService and populates it
+   * with edges via `GraphService.addEdge`.
+   *
+   * @return test GraphService
+   * @throws Exception on failure
+   */
+  protected GraphService getPopulatedGraphService() throws Exception {
+    GraphService service = getGraphService();
 
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        "DownstreamOf");
+    List<Edge> edges = Arrays.asList(
+            new Edge(datasetTwoUrn, datasetOneUrn, downstreamOf),
+            new Edge(datasetThreeUrn, datasetTwoUrn, downstreamOf),
+            new Edge(datasetFourUrn, datasetTwoUrn, downstreamOf),
 
-    client.addEdge(edge1);
+            new Edge(datasetOneUrn, userOneUrn, hasOwner),
+            new Edge(datasetTwoUrn, userOneUrn, hasOwner),
+            new Edge(datasetThreeUrn, userTwoUrn, hasOwner),
+            new Edge(datasetFourUrn, userTwoUrn, hasOwner),
+
+            new Edge(userOneUrn, userTwoUrn, knowsUser),
+            new Edge(userTwoUrn, userOneUrn, knowsUser)
+    );
+
+    edges.forEach(service::addEdge);
     syncAfterWrite();
 
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.OUTGOING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+    return service;
+  }
 
-    List<String> relatedUrns = client.findRelatedEntities(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10).getEntities()
-        .stream()
-        .map(RelatedEntity::getUrn)
-        .collect(Collectors.toList());
+  protected static RelationshipFilter createRelationshipFilter(RelationshipDirection direction) {
+    return createRelationshipFilter(EMPTY_FILTER, direction);
+  }
 
-    assertEquals(relatedUrns.size(), 1);
+  protected static RelationshipFilter createRelationshipFilter(@Nonnull Filter filter,
+                                                               @Nonnull RelationshipDirection direction) {
+    return new RelationshipFilter()
+            .setCriteria(filter.getCriteria())
+            .setDirection(direction);
+  }
+
+  protected static @Nullable
+  Urn createFromString(@Nonnull String rawUrn) {
+    try {
+      return Urn.createFromString(rawUrn);
+    } catch (URISyntaxException e) {
+      return null;
+    }
+  }
+
+  protected static void assertEqualsAnyOrder(RelatedEntitiesResult actual, List<RelatedEntity> expected) {
+      assertEqualsAnyOrder(actual, new RelatedEntitiesResult(0, expected.size(), expected.size(), expected));
+  }
+
+  protected static void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
+    // assertEquals(actual.start, expected.start);
+    //assertEquals(actual.count, expected.count);
+    //assertEquals(actual.total, expected.total);
+    assertEqualsAnyOrder(actual.entities, expected.entities);
+  }
+
+  protected static <T> void assertEqualsAnyOrder(List<T> actual, List<T> expected) {
+    // TODO: expect no duplicates
+    assertEquals(
+            new HashSet<>(actual),
+            new HashSet<>(expected)
+    );
+  }
+
+  @DataProvider(name = "FindRelatedEntitiesSourceEntityFilterTests")
+  public Object[][] getFindRelatedEntitiesSourceEntityFilterTests() {
+    return new Object[][] {
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(hasOwner),
+                    outgoingRelationships,
+                    Arrays.asList(hasOwnerUserOneRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(hasOwner),
+                    incomingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(hasOwner),
+                    undirectedRelationships,
+                    Arrays.asList(hasOwnerUserOneRelatedEntity)
+            },
+
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(hasOwner),
+                    outgoingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(hasOwner),
+                    incomingRelationships,
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(hasOwner),
+                    undirectedRelationships,
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity)
+            }
+    };
+  }
+
+  @Test(dataProvider = "FindRelatedEntitiesSourceEntityFilterTests")
+  public void testFindRelatedEntitiesSourceEntityFilter(Filter sourceEntityFilter,
+                                                        List<String> relationshipTypes,
+                                                        RelationshipFilter relationships,
+                                                        List<RelatedEntity> expectedRelatedEntities) throws Exception {
+    doTestFindRelatedEntities(
+            sourceEntityFilter,
+            EMPTY_FILTER,
+            relationshipTypes,
+            relationships,
+            expectedRelatedEntities
+    );
+  }
+
+  @DataProvider(name = "FindRelatedEntitiesDestinationEntityFilterTests")
+  public Object[][] getFindRelatedEntitiesDestinationEntityFilterTests() {
+    return new Object[][] {
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", datasetTwoUrnString),
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity)
+            },
+
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList()
+            },
+
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(hasOwner),
+                    outgoingRelationships,
+                    Arrays.asList(hasOwnerUserOneRelatedEntity)
+            },
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(hasOwner),
+                    incomingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    newFilter("urn", userOneUrnString),
+                    Arrays.asList(hasOwner),
+                    undirectedRelationships,
+                    Arrays.asList(hasOwnerUserOneRelatedEntity)
+            }
+    };
+  }
+
+  @Test(dataProvider = "FindRelatedEntitiesDestinationEntityFilterTests")
+  public void testFindRelatedEntitiesDestinationEntityFilter(Filter destinationEntityFilter,
+                                                             List<String> relationshipTypes,
+                                                             RelationshipFilter relationships,
+                                                             List<RelatedEntity> expectedRelatedEntities) throws Exception {
+    doTestFindRelatedEntities(
+            EMPTY_FILTER,
+            destinationEntityFilter,
+            relationshipTypes,
+            relationships,
+            expectedRelatedEntities
+    );
+  }
+
+  private void doTestFindRelatedEntities(
+          final Filter sourceEntityFilter,
+          final Filter destinationEntityFilter,
+          List<String> relationshipTypes,
+          final RelationshipFilter relationshipFilter,
+          List<RelatedEntity> expectedRelatedEntities
+  ) throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    RelatedEntitiesResult relatedEntities = service.findRelatedEntities(
+            anyType, sourceEntityFilter,
+            anyType, destinationEntityFilter,
+            relationshipTypes, relationshipFilter,
+            0, 10
+    );
+
+    assertEqualsAnyOrder(relatedEntities, expectedRelatedEntities);
+  }
+
+  @DataProvider(name = "FindRelatedEntitiesSourceTypeTests")
+  public Object[][] getFindRelatedEntitiesSourceTypeTests() {
+    return new Object[][]{
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+
+            // "" used to be any type before v0.9.0, which is now encoded by null
+            new Object[] {
+                    "",
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Collections.emptyList()
+            },
+            new Object[] {
+                    "",
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Collections.emptyList()
+            },
+            new Object[] {
+                    "",
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Collections.emptyList()
+            },
+
+            new Object[]{
+                    datasetType,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity)
+            },
+            new Object[]{
+                    datasetType,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+            new Object[]{
+                    datasetType,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+
+            new Object[]{
+                    userType,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList()
+            },
+            new Object[]{
+                    userType,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList()
+            },
+            new Object[]{
+                    userType,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList()
+            },
+
+            new Object[]{
+                    userType,
+                    Arrays.asList(hasOwner),
+                    outgoingRelationships,
+                    Arrays.asList()
+            },
+            new Object[]{
+                    userType,
+                    Arrays.asList(hasOwner),
+                    incomingRelationships,
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+            },
+            new Object[]{
+                    userType,
+                    Arrays.asList(hasOwner),
+                    undirectedRelationships,
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+            }
+    };
+  }
+
+  @Test(dataProvider = "FindRelatedEntitiesSourceTypeTests")
+  public void testFindRelatedEntitiesSourceType(String datasetType,
+                                                List<String> relationshipTypes,
+                                                RelationshipFilter relationships,
+                                                List<RelatedEntity> expectedRelatedEntities) throws Exception {
+    doTestFindRelatedEntities(
+            datasetType,
+            anyType,
+            relationshipTypes,
+            relationships,
+            expectedRelatedEntities
+    );
+  }
+
+  @DataProvider(name = "FindRelatedEntitiesDestinationTypeTests")
+  public Object[][] getFindRelatedEntitiesDestinationTypeTests() {
+    return new Object[][] {
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+            new Object[] {
+                    null,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+
+            new Object[] {
+                    "",
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Collections.emptyList()
+            },
+            new Object[] {
+                    "",
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Collections.emptyList()
+            },
+            new Object[] {
+                    "",
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Collections.emptyList()
+            },
+
+            new Object[] {
+                    datasetType,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity)
+            },
+            new Object[] {
+                    datasetType,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+            new Object[] {
+                    datasetType,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+
+            new Object[] {
+                    datasetType,
+                    Arrays.asList(hasOwner),
+                    outgoingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    datasetType,
+                    Arrays.asList(hasOwner),
+                    incomingRelationships,
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+            },
+            new Object[] {
+                    datasetType,
+                    Arrays.asList(hasOwner),
+                    undirectedRelationships,
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+            },
+
+            new Object[] {
+                    userType,
+                    Arrays.asList(hasOwner),
+                    outgoingRelationships,
+                    Arrays.asList(hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity)
+            },
+            new Object[] {
+                    userType,
+                    Arrays.asList(hasOwner),
+                    incomingRelationships,
+                    Arrays.asList()
+            },
+            new Object[] {
+                    userType,
+                    Arrays.asList(hasOwner),
+                    undirectedRelationships,
+                    Arrays.asList(hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity)
+            }
+    };
+  }
+
+  @Test(dataProvider = "FindRelatedEntitiesDestinationTypeTests")
+  public void testFindRelatedEntitiesDestinationType(String datasetType,
+                                                     List<String> relationshipTypes,
+                                                     RelationshipFilter relationships,
+                                                     List<RelatedEntity> expectedRelatedEntities) throws Exception {
+    doTestFindRelatedEntities(
+            anyType,
+            datasetType,
+            relationshipTypes,
+            relationships,
+            expectedRelatedEntities
+    );
+  }
+
+  private void doTestFindRelatedEntities(
+          final String sourceType,
+          final String destinationType,
+          final List<String> relationshipTypes,
+          final RelationshipFilter relationshipFilter,
+          List<RelatedEntity> expectedRelatedEntities
+  ) throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    RelatedEntitiesResult relatedEntities = service.findRelatedEntities(
+            sourceType, EMPTY_FILTER,
+            destinationType, EMPTY_FILTER,
+            relationshipTypes, relationshipFilter,
+            0, 10
+    );
+
+    assertEqualsAnyOrder(relatedEntities, expectedRelatedEntities);
   }
 
   @Test
-  public void testAddEdgeReverse() throws Exception {
-    GraphService client = getGraphService();
+  public void testFindRelatedEntitiesNoRelationshipTypes() throws Exception {
+    GraphService service = getPopulatedGraphService();
 
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "DownstreamOf");
+    RelatedEntitiesResult relatedEntities = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Collections.emptyList(), outgoingRelationships,
+            0, 10
+    );
 
-    client.addEdge(edge1);
-    syncAfterWrite();
+    assertEquals(relatedEntities.entities, Collections.emptyList());
 
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+    // does the test actually test something? is the Collections.emptyList() the only reason why we did not get any related urns?
+    RelatedEntitiesResult relatedEntitiesAll = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
+            0, 10
+    );
 
-    List<String> relatedUrns = client.findRelatedEntities(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10)
-        .getEntities()
-        .stream()
-        .map(RelatedEntity::getUrn)
-        .collect(Collectors.toList());
-
-    assertEquals(relatedUrns.size(), 1);
+    assertNotEquals(relatedEntities, Collections.emptyList());
   }
 
   @Test
-  public void testRemoveEdgesFromNode() throws Exception {
-    GraphService client = getGraphService();
+  public void testFindRelatedEntitiesAllFilters() throws Exception {
+    GraphService service = getPopulatedGraphService();
 
-    Edge edge1 = new Edge(
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-        Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "DownstreamOf");
+    RelatedEntitiesResult relatedEntities = service.findRelatedEntities(
+            datasetType, newFilter("urn", datasetOneUrnString),
+            userType, newFilter("urn", userOneUrnString),
+            Arrays.asList(hasOwner), outgoingRelationships,
+            0, 10
+    );
 
-    client.addEdge(edge1);
-    syncAfterWrite();
+    assertEquals(relatedEntities.entities, Arrays.asList(hasOwnerUserOneRelatedEntity));
 
-    List<String> edgeTypes = new ArrayList<>();
-    edgeTypes.add("DownstreamOf");
-    RelationshipFilter relationshipFilter = new RelationshipFilter();
-    relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-    relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+    relatedEntities = service.findRelatedEntities(
+            datasetType, newFilter("urn", datasetOneUrnString),
+            userType, newFilter("urn", userTwoUrnString),
+            Arrays.asList(hasOwner), incomingRelationships,
+            0, 10
+    );
 
-    List<String> relatedUrns = client.findRelatedEntities(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10)
-        .getEntities()
-        .stream()
-        .map(RelatedEntity::getUrn)
-        .collect(Collectors.toList());
-
-    assertEquals(relatedUrns.size(), 1);
-
-    client.removeEdgesFromNode(Urn.createFromString(
-        "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        edgeTypes,
-        relationshipFilter);
-    syncAfterWrite();
-
-    List<String> relatedUrnsPostDelete = client.findRelatedEntities(
-        "",
-        newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-        "",
-        EMPTY_FILTER,
-        edgeTypes,
-        relationshipFilter,
-        0,
-        10)
-        .getEntities()
-        .stream()
-        .map(RelatedEntity::getUrn)
-        .collect(Collectors.toList());
-
-    assertEquals(relatedUrnsPostDelete.size(), 0);
+    assertEquals(relatedEntities.entities, Collections.emptyList());
   }
+
+  @Test
+  public void testFindRelatedEntitiesOffsetAndCount() throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    RelatedEntitiesResult allRelatedEntities = service.findRelatedEntities(
+            datasetType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf), outgoingRelationships,
+            0, 100
+    );
+
+    assertEqualsAnyOrder(allRelatedEntities, Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity));
+
+    List<RelatedEntity> individualRelatedEntities = new ArrayList<>();
+    IntStream.range(0, allRelatedEntities.entities.size())
+            .forEach(idx -> individualRelatedEntities.addAll(
+                    service.findRelatedEntities(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(downstreamOf), outgoingRelationships,
+                    idx, 1
+                ).entities
+            ));
+    Assert.assertEquals(individualRelatedEntities, allRelatedEntities.entities);
+  }
+
+  @DataProvider(name = "RemoveEdgesFromNodeTests")
+  public Object[][] getRemoveEdgesFromNodeTests() {
+    return new Object[][] {
+            new Object[] {
+                    datasetTwoUrn,
+                    Arrays.asList(downstreamOf),
+                    outgoingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity),
+                    Arrays.asList(downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity),
+                    Arrays.asList(),
+                    Arrays.asList(downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+            },
+            new Object[] {
+                    datasetTwoUrn,
+                    Arrays.asList(downstreamOf),
+                    incomingRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity),
+                    Arrays.asList(downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity),
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity),
+                    Arrays.asList(),
+            },
+            new Object[] {
+                    datasetTwoUrn,
+                    Arrays.asList(downstreamOf),
+                    undirectedRelationships,
+                    Arrays.asList(downstreamOfDatasetOneRelatedEntity),
+                    Arrays.asList(downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity),
+                    Arrays.asList(),
+                    Arrays.asList()
+            },
+
+            new Object[] {
+                    userOneUrn,
+                    Arrays.asList(hasOwner, knowsUser),
+                    outgoingRelationships,
+                    Arrays.asList(knowsUserTwoRelatedEntity),
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, knowsUserOneRelatedEntity),
+                    Arrays.asList(),
+                    Arrays.asList(datasetOneUrnString, datasetTwoUrnString, userTwoUrnString)
+            },
+            new Object[] {
+                    userOneUrn,
+                    Arrays.asList(hasOwner, knowsUser),
+                    incomingRelationships,
+                    Arrays.asList(knowsUserTwoRelatedEntity),
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, knowsUserTwoRelatedEntity),
+                    Arrays.asList(knowsUserTwoRelatedEntity),
+                    Arrays.asList()
+            },
+            new Object[] {
+                    userOneUrn,
+                    Arrays.asList(hasOwner, knowsUser),
+                    undirectedRelationships,
+                    Arrays.asList(knowsUserTwoRelatedEntity),
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, knowsUserTwoRelatedEntity),
+                    Arrays.asList(),
+                    Arrays.asList()
+            }
+    };
+  }
+
+  @Test(dataProvider = "RemoveEdgesFromNodeTests")
+  public void testRemoveEdgesFromNode(@Nonnull Urn nodeToRemoveFrom,
+                                      @Nonnull List<String> relationTypes,
+                                      @Nonnull RelationshipFilter relationshipFilter,
+                                      List<RelatedEntity> expectedOutgoingRelatedUrnsBeforeRemove,
+                                      List<RelatedEntity> expectedIncomingRelatedUrnsBeforeRemove,
+                                      List<RelatedEntity> expectedOutgoingRelatedUrnsAfterRemove,
+                                      List<RelatedEntity> expectedIncomingRelatedUrnsAfterRemove) throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    List<String> allOtherRelationTypes =
+            allRelationshipTypes.stream()
+                    .filter(relation -> !relationTypes.contains(relation))
+                    .collect(Collectors.toList());
+    assertTrue(allOtherRelationTypes.size() > 0);
+
+    RelatedEntitiesResult actualOutgoingRelatedUrnsBeforeRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            relationTypes, outgoingRelationships,
+            0, 10);
+    RelatedEntitiesResult actualIncomingRelatedUrnsBeforeRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            relationTypes, incomingRelationships,
+            0, 10);
+    assertEqualsAnyOrder(actualOutgoingRelatedUrnsBeforeRemove, expectedOutgoingRelatedUrnsBeforeRemove);
+    assertEqualsAnyOrder(actualIncomingRelatedUrnsBeforeRemove, expectedIncomingRelatedUrnsBeforeRemove);
+
+    // we expect these do not change
+    RelatedEntitiesResult relatedEntitiesOfOtherRelationTypesBeforeRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            allOtherRelationTypes, undirectedRelationships,
+            0, 10);
+
+    service.removeEdgesFromNode(
+            nodeToRemoveFrom,
+            relationTypes,
+            relationshipFilter
+    );
+    syncAfterWrite();
+
+    RelatedEntitiesResult actualOutgoingRelatedUrnsAfterRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            relationTypes, outgoingRelationships,
+            0, 10);
+    RelatedEntitiesResult actualIncomingRelatedUrnsAfterRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            relationTypes, incomingRelationships,
+            0, 10);
+    assertEqualsAnyOrder(actualOutgoingRelatedUrnsAfterRemove, expectedOutgoingRelatedUrnsAfterRemove);
+    assertEqualsAnyOrder(actualIncomingRelatedUrnsAfterRemove, expectedIncomingRelatedUrnsAfterRemove);
+
+    // assert these did not change
+    RelatedEntitiesResult relatedEntitiesOfOtherRelationTypesAfterRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            allOtherRelationTypes, undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(relatedEntitiesOfOtherRelationTypesAfterRemove, relatedEntitiesOfOtherRelationTypesBeforeRemove);
+  }
+
+  @Test
+  public void testRemoveEdgesFromNodeNoRelationshipTypes() throws Exception {
+    GraphService service = getPopulatedGraphService();
+    Urn nodeToRemoveFrom = datasetOneUrn;
+
+    RelatedEntitiesResult relatedEntitiesBeforeRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+
+    service.removeEdgesFromNode(
+            nodeToRemoveFrom,
+            Collections.emptyList(),
+            undirectedRelationships
+    );
+    syncAfterWrite();
+
+    RelatedEntitiesResult relatedEntitiesAfterRemove = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(relatedEntitiesBeforeRemove, relatedEntitiesAfterRemove);
+
+    // does the test actually test something? is the Collections.emptyList() the only reason why we did not see changes?
+    service.removeEdgesFromNode(
+            nodeToRemoveFrom,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser),
+            undirectedRelationships
+    );
+    syncAfterWrite();
+
+    RelatedEntitiesResult relatedEntitiesAfterRemoveAll = service.findRelatedEntities(
+            anyType, newFilter("urn", nodeToRemoveFrom.toString()),
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(relatedEntitiesAfterRemoveAll, Collections.emptyList());
+  }
+
+  @Test
+  public void testRemoveNode() throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    // assert the initial graph: check all nodes related to DownstreamOf and hasOwner edges
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(downstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+    );
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    userType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(hasOwner), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+    );
+
+    service.removeNode(datasetTwoUrn);
+    syncAfterWrite();
+
+    // assert the modified graph: check all nodes related to DownstreamOf and hasOwner edges
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(downstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Collections.emptyList()
+    );
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    userType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(hasOwner), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+    );
+  }
+
+  @Test
+  public void testClear() throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    // assert the initial graph: check all nodes related to upstreamOf and nextVersionOf edges
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    anyType, EMPTY_FILTER,
+                    datasetType, EMPTY_FILTER,
+                    Arrays.asList(downstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+    );
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    anyType, EMPTY_FILTER,
+                    userType, EMPTY_FILTER,
+                    Arrays.asList(hasOwner), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity)
+    );
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    anyType, EMPTY_FILTER,
+                    userType, EMPTY_FILTER,
+                    Arrays.asList(knowsUser), undirectedRelationships,
+                    0, 10
+            ),
+            Arrays.asList(knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity)
+    );
+
+    service.clear();
+    syncAfterWrite();
+
+    // assert the modified graph: check all nodes related to upstreamOf and nextVersionOf edges again
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(downstreamOf), undirectedRelationships,
+                    0, 10
+            ),
+            Collections.emptyList()
+    );
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    userType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
+                    Arrays.asList(hasOwner), undirectedRelationships,
+                    0, 10
+            ),
+            Collections.emptyList()
+    );
+    assertEqualsAnyOrder(
+            service.findRelatedEntities(
+                    anyType, EMPTY_FILTER,
+                    userType, EMPTY_FILTER,
+                    Arrays.asList(knowsUser), undirectedRelationships,
+                    0, 10
+            ),
+            Collections.emptyList()
+    );
+  }
+
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newRelationshipFilter;
 import static org.testng.Assert.*;
 
 /**
@@ -117,9 +118,9 @@ abstract public class GraphServiceTestBase {
   /**
    * Some relationship filters.
    */
-  protected static RelationshipFilter outgoingRelationships = createRelationshipFilter(RelationshipDirection.OUTGOING);
-  protected static RelationshipFilter incomingRelationships = createRelationshipFilter(RelationshipDirection.INCOMING);
-  protected static RelationshipFilter undirectedRelationships = createRelationshipFilter(RelationshipDirection.UNDIRECTED);
+  protected static RelationshipFilter outgoingRelationships = newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING);
+  protected static RelationshipFilter incomingRelationships = newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING);
+  protected static RelationshipFilter undirectedRelationships = newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED);
 
   /**
    * Any source and destination type value.
@@ -183,17 +184,6 @@ abstract public class GraphServiceTestBase {
     syncAfterWrite();
 
     return service;
-  }
-
-  protected static RelationshipFilter createRelationshipFilter(RelationshipDirection direction) {
-    return createRelationshipFilter(EMPTY_FILTER, direction);
-  }
-
-  protected static RelationshipFilter createRelationshipFilter(@Nonnull Filter filter,
-                                                               @Nonnull RelationshipDirection direction) {
-    return new RelationshipFilter()
-            .setCriteria(filter.getCriteria())
-            .setDirection(direction);
   }
 
   protected static @Nullable

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -62,6 +62,8 @@ abstract public class GraphServiceTestBase {
   protected static Urn datasetThreeUrn = createFromString(datasetThreeUrnString);
   protected static Urn datasetFourUrn = createFromString(datasetFourUrnString);
 
+  protected static String unknownUrnString = "urn:li:unknown:(urn:li:unknown:Unknown)";
+
   /**
    * Some dataset owners.
    */
@@ -70,6 +72,8 @@ abstract public class GraphServiceTestBase {
 
   protected static Urn userOneUrn = createFromString(userOneUrnString);
   protected static Urn userTwoUrn = createFromString(userTwoUrnString);
+
+  protected static Urn unknownUrn = createFromString("urn:li:unknown:(urn:li:unknown:Unknown)");
 
   /**
    * Some test relationships.
@@ -80,18 +84,20 @@ abstract public class GraphServiceTestBase {
   protected static Set<String> allRelationshipTypes = new HashSet<>(Arrays.asList(downstreamOf, hasOwner, knowsUser));
 
   /**
-   * Some test related entities.
+   * Some expected related entities.
    */
   protected static RelatedEntity downstreamOfDatasetOneRelatedEntity = new RelatedEntity(downstreamOf, datasetOneUrnString);
   protected static RelatedEntity downstreamOfDatasetTwoRelatedEntity = new RelatedEntity(downstreamOf, datasetTwoUrnString);
   protected static RelatedEntity downstreamOfDatasetThreeRelatedEntity = new RelatedEntity(downstreamOf, datasetThreeUrnString);
   protected static RelatedEntity downstreamOfDatasetFourRelatedEntity = new RelatedEntity(downstreamOf, datasetFourUrnString);
+
   protected static RelatedEntity hasOwnerDatasetOneRelatedEntity = new RelatedEntity(hasOwner, datasetOneUrnString);
   protected static RelatedEntity hasOwnerDatasetTwoRelatedEntity = new RelatedEntity(hasOwner, datasetTwoUrnString);
   protected static RelatedEntity hasOwnerDatasetThreeRelatedEntity = new RelatedEntity(hasOwner, datasetThreeUrnString);
   protected static RelatedEntity hasOwnerDatasetFourRelatedEntity = new RelatedEntity(hasOwner, datasetFourUrnString);
   protected static RelatedEntity hasOwnerUserOneRelatedEntity = new RelatedEntity(hasOwner, userOneUrnString);
   protected static RelatedEntity hasOwnerUserTwoRelatedEntity = new RelatedEntity(hasOwner, userTwoUrnString);
+
   protected static RelatedEntity knowsUserOneRelatedEntity = new RelatedEntity(knowsUser, userOneUrnString);
   protected static RelatedEntity knowsUserTwoRelatedEntity = new RelatedEntity(knowsUser, userTwoUrnString);
 
@@ -865,6 +871,41 @@ abstract public class GraphServiceTestBase {
   }
 
   @Test
+  public void testRemoveEdgesFromUnknownNode() throws Exception {
+    GraphService service = getPopulatedGraphService();
+    Urn nodeToRemoveFrom = unknownUrn;
+
+    RelatedEntitiesResult entitiesBeforeRemove = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(
+            entitiesBeforeRemove,
+            Arrays.asList(
+                    downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity,
+                    hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                    hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity,
+                    knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
+            )
+    );
+
+    service.removeEdgesFromNode(
+            nodeToRemoveFrom,
+            Collections.emptyList(),
+            undirectedRelationships
+    );
+    syncAfterWrite();
+
+    RelatedEntitiesResult entitiesAfterRemove = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(entitiesBeforeRemove, entitiesAfterRemove);
+  }
+
+  @Test
   public void testRemoveNode() throws Exception {
     GraphService service = getPopulatedGraphService();
 
@@ -910,6 +951,36 @@ abstract public class GraphServiceTestBase {
             ),
             Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
     );
+  }
+
+  @Test
+  public void testRemoveUnknownNode() throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    RelatedEntitiesResult entitiesBeforeRemove = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(
+            entitiesBeforeRemove,
+            Arrays.asList(
+                    downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity,
+                    hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                    hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity,
+                    knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
+            )
+    );
+
+    service.removeNode(unknownUrn);
+    syncAfterWrite();
+
+    RelatedEntitiesResult entitiesAfterRemove = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), undirectedRelationships,
+            0, 10);
+    assertEqualsAnyOrder(entitiesBeforeRemove, entitiesAfterRemove);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -11,7 +11,13 @@ import org.testng.annotations.Test;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -42,12 +48,14 @@ abstract public class GraphServiceTestBase {
     @Override
     public int compare(RelatedEntity left, RelatedEntity right) {
         int cmp = left.relationshipType.compareTo(right.relationshipType);
-        if (cmp != 0) { return cmp; }
+        if (cmp != 0) {
+            return cmp;
+        }
         return left.urn.compareTo(right.urn);
     }
   }
 
-  protected static final RelatedEntityComparator relatedEntityComparator = new RelatedEntityComparator();
+  protected static final RelatedEntityComparator RELATED_ENTITY_COMPARATOR = new RelatedEntityComparator();
 
   /**
    * Some test URN types.
@@ -206,7 +214,7 @@ abstract public class GraphServiceTestBase {
     assertEquals(actual.start, expected.start);
     assertEquals(actual.count, expected.count);
     assertEquals(actual.total, expected.total);
-    assertEqualsAnyOrder(actual.entities, expected.entities, relatedEntityComparator);
+    assertEqualsAnyOrder(actual.entities, expected.entities, RELATED_ENTITY_COMPARATOR);
   }
 
   protected <T> void assertEqualsAnyOrder(List<T> actual, List<T> expected) {
@@ -445,7 +453,10 @@ abstract public class GraphServiceTestBase {
                     null,
                     Arrays.asList(downstreamOf),
                     undirectedRelationships,
-                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
+                            downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity
+                    )
             },
 
             // "" used to be any type before v0.9.0, which is now encoded by null
@@ -484,7 +495,10 @@ abstract public class GraphServiceTestBase {
                     datasetType,
                     Arrays.asList(downstreamOf),
                     undirectedRelationships,
-                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
+                            downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity
+                    )
             },
 
             new Object[]{
@@ -516,13 +530,19 @@ abstract public class GraphServiceTestBase {
                     userType,
                     Arrays.asList(hasOwner),
                     incomingRelationships,
-                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                            hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity
+                    )
             },
             new Object[]{
                     userType,
                     Arrays.asList(hasOwner),
                     undirectedRelationships,
-                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                            hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity
+                    )
             }
     };
   }
@@ -560,7 +580,10 @@ abstract public class GraphServiceTestBase {
                     null,
                     Arrays.asList(downstreamOf),
                     undirectedRelationships,
-                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
+                            downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity
+                    )
             },
 
             new Object[] {
@@ -598,7 +621,10 @@ abstract public class GraphServiceTestBase {
                     datasetType,
                     Arrays.asList(downstreamOf),
                     undirectedRelationships,
-                    Arrays.asList(downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
+                            downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity
+                    )
             },
 
             new Object[] {
@@ -611,13 +637,19 @@ abstract public class GraphServiceTestBase {
                     datasetType,
                     Arrays.asList(hasOwner),
                     incomingRelationships,
-                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                            hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity
+                    )
             },
             new Object[] {
                     datasetType,
                     Arrays.asList(hasOwner),
                     undirectedRelationships,
-                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity)
+                    Arrays.asList(
+                            hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                            hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity
+                    )
             },
 
             new Object[] {
@@ -695,7 +727,7 @@ abstract public class GraphServiceTestBase {
 
     Urn nullUrn = createFromString("urn:li:null:(urn:li:null:Null)");
     assertNotNull(nullUrn);
-    RelatedEntity downstreamOfNullUrnRelatedEntity = new RelatedEntity(downstreamOf, nullUrn.toString());
+    RelatedEntity nullRelatedEntity = new RelatedEntity(downstreamOf, nullUrn.toString());
 
     doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service);
     doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service);
@@ -707,8 +739,8 @@ abstract public class GraphServiceTestBase {
 
     service.addEdge(new Edge(datasetOneUrn, nullUrn, downstreamOf));
     syncAfterWrite();
-    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity);
-    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity, downstreamOfDatasetOneRelatedEntity);
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service, nullRelatedEntity);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, nullRelatedEntity, downstreamOfDatasetOneRelatedEntity);
   }
 
   @Test
@@ -717,7 +749,7 @@ abstract public class GraphServiceTestBase {
 
     Urn nullUrn = createFromString("urn:li:null:(urn:li:null:Null)");
     assertNotNull(nullUrn);
-    RelatedEntity downstreamOfNullUrnRelatedEntity = new RelatedEntity(downstreamOf, nullUrn.toString());
+    RelatedEntity nullRelatedEntity = new RelatedEntity(downstreamOf, nullUrn.toString());
 
     doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service);
     doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service);
@@ -729,8 +761,8 @@ abstract public class GraphServiceTestBase {
 
     service.addEdge(new Edge(datasetOneUrn, nullUrn, downstreamOf));
     syncAfterWrite();
-    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity);
-    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity, downstreamOfDatasetOneRelatedEntity);
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service, nullRelatedEntity);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, nullRelatedEntity, downstreamOfDatasetOneRelatedEntity);
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -73,7 +73,7 @@ abstract public class GraphServiceTestBase {
   protected static Urn userOneUrn = createFromString(userOneUrnString);
   protected static Urn userTwoUrn = createFromString(userTwoUrnString);
 
-  protected static Urn unknownUrn = createFromString("urn:li:unknown:(urn:li:unknown:Unknown)");
+  protected static Urn unknownUrn = createFromString(unknownUrnString);
 
   /**
    * Some test relationships.
@@ -219,11 +219,11 @@ abstract public class GraphServiceTestBase {
               anyType, EMPTY_FILTER,
               anyType, EMPTY_FILTER,
               Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-              0, 10);
+              0, 100);
       assertEqualsAnyOrder(
               relatedOutgoingEntitiesBeforeRemove,
               Arrays.asList(
-                      downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity,
+                      downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
                       hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity,
                       knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
               )
@@ -232,12 +232,12 @@ abstract public class GraphServiceTestBase {
               anyType, EMPTY_FILTER,
               anyType, EMPTY_FILTER,
               Arrays.asList(downstreamOf, hasOwner, knowsUser), incomingRelationships,
-              0, 10);
+              0, 100);
       assertEqualsAnyOrder(
               relatedIncomingEntitiesBeforeRemove,
               Arrays.asList(
-                      downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
-                      hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity,
+                      downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity,
+                      hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity,
                       knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
               )
       );
@@ -663,6 +663,41 @@ abstract public class GraphServiceTestBase {
   }
 
   @Test
+  public void testFindRelatedEntitiesRelationshipTypes() throws Exception {
+    GraphService service = getPopulatedGraphService();
+
+    RelatedEntitiesResult allOutgoingRelatedEntities = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
+            0, 100
+    );
+    assertEqualsAnyOrder(
+            allOutgoingRelatedEntities,
+            Arrays.asList(
+                    downstreamOfDatasetOneRelatedEntity, downstreamOfDatasetTwoRelatedEntity,
+                    hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity,
+                    knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
+            )
+    );
+
+    RelatedEntitiesResult allIncomingRelatedEntities = service.findRelatedEntities(
+            anyType, EMPTY_FILTER,
+            anyType, EMPTY_FILTER,
+            Arrays.asList(downstreamOf, hasOwner, knowsUser), incomingRelationships,
+            0, 100
+    );
+    assertEqualsAnyOrder(
+            allIncomingRelatedEntities,
+            Arrays.asList(
+                    downstreamOfDatasetTwoRelatedEntity, downstreamOfDatasetThreeRelatedEntity, downstreamOfDatasetFourRelatedEntity,
+                    hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity,
+                    knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
+            )
+    );
+  }
+
+  @Test
   public void testFindRelatedEntitiesNoRelationshipTypes() throws Exception {
     GraphService service = getPopulatedGraphService();
 
@@ -770,9 +805,9 @@ abstract public class GraphServiceTestBase {
                     Arrays.asList(hasOwner, knowsUser),
                     outgoingRelationships,
                     Arrays.asList(knowsUserTwoRelatedEntity),
-                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, knowsUserOneRelatedEntity),
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, knowsUserTwoRelatedEntity),
                     Arrays.asList(),
-                    Arrays.asList(datasetOneUrnString, datasetTwoUrnString, userTwoUrnString)
+                    Arrays.asList(hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetTwoRelatedEntity, knowsUserTwoRelatedEntity)
             },
             new Object[] {
                     userOneUrn,
@@ -815,12 +850,12 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             relationTypes, outgoingRelationships,
-            0, 10);
+            0, 100);
     RelatedEntitiesResult actualIncomingRelatedUrnsBeforeRemove = service.findRelatedEntities(
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             relationTypes, incomingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(actualOutgoingRelatedUrnsBeforeRemove, expectedOutgoingRelatedUrnsBeforeRemove);
     assertEqualsAnyOrder(actualIncomingRelatedUrnsBeforeRemove, expectedIncomingRelatedUrnsBeforeRemove);
 
@@ -829,12 +864,12 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             allOtherRelationTypes, outgoingRelationships,
-            0, 10);
+            0, 100);
     RelatedEntitiesResult relatedEntitiesOfOtherIncomingRelationTypesBeforeRemove = service.findRelatedEntities(
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             allOtherRelationTypes, incomingRelationships,
-            0, 10);
+            0, 100);
 
     service.removeEdgesFromNode(
             nodeToRemoveFrom,
@@ -847,12 +882,12 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             relationTypes, outgoingRelationships,
-            0, 10);
+            0, 100);
     RelatedEntitiesResult actualIncomingRelatedUrnsAfterRemove = service.findRelatedEntities(
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             relationTypes, incomingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(actualOutgoingRelatedUrnsAfterRemove, expectedOutgoingRelatedUrnsAfterRemove);
     assertEqualsAnyOrder(actualIncomingRelatedUrnsAfterRemove, expectedIncomingRelatedUrnsAfterRemove);
 
@@ -861,12 +896,12 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             allOtherRelationTypes, outgoingRelationships,
-            0, 10);
+            0, 100);
     RelatedEntitiesResult relatedEntitiesOfOtherIncomingRelationTypesAfterRemove = service.findRelatedEntities(
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             allOtherRelationTypes, incomingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(relatedEntitiesOfOtherOutgoingRelationTypesAfterRemove, relatedEntitiesOfOtherOutgoingRelationTypesBeforeRemove);
     assertEqualsAnyOrder(relatedEntitiesOfOtherIncomingRelationTypesAfterRemove, relatedEntitiesOfOtherIncomingRelationTypesBeforeRemove);
   }
@@ -881,7 +916,7 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
 
     service.removeEdgesFromNode(
             nodeToRemoveFrom,
@@ -894,7 +929,7 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(relatedOutgoingEntitiesAfterRemove, relatedOutgoingEntitiesBeforeRemove);
 
     // does the test actually test something? is the Collections.emptyList() the only reason why we did not see changes?
@@ -909,7 +944,7 @@ abstract public class GraphServiceTestBase {
             anyType, newFilter("urn", nodeToRemoveFrom.toString()),
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(relatedOutgoingEntitiesAfterRemoveAll, Collections.emptyList());
   }
 
@@ -923,7 +958,7 @@ abstract public class GraphServiceTestBase {
             anyType, EMPTY_FILTER,
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
 
     service.removeEdgesFromNode(
             nodeToRemoveFrom,
@@ -936,7 +971,7 @@ abstract public class GraphServiceTestBase {
             anyType, EMPTY_FILTER,
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(relatedOutgoingEntitiesAfterRemove, relatedOutgoingEntitiesBeforeRemove);
   }
 
@@ -944,20 +979,19 @@ abstract public class GraphServiceTestBase {
   public void testRemoveNode() throws Exception {
     GraphService service = getPopulatedGraphService();
 
-    // populated graph asserted in testPopulatedGraphService
     service.removeNode(datasetTwoUrn);
     syncAfterWrite();
 
     // assert the modified graph
     assertEqualsAnyOrder(
             service.findRelatedEntities(
-                    datasetType, EMPTY_FILTER,
+                    anyType, EMPTY_FILTER,
                     anyType, EMPTY_FILTER,
                     Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-                    0, 10
+                    0, 100
             ),
             Arrays.asList(
-                    hasOwnerDatasetOneRelatedEntity, hasOwnerDatasetThreeRelatedEntity, hasOwnerDatasetFourRelatedEntity,
+                    hasOwnerUserOneRelatedEntity, hasOwnerUserTwoRelatedEntity,
                     knowsUserOneRelatedEntity, knowsUserTwoRelatedEntity
             )
     );
@@ -972,7 +1006,7 @@ abstract public class GraphServiceTestBase {
             anyType, EMPTY_FILTER,
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
 
     service.removeNode(unknownUrn);
     syncAfterWrite();
@@ -981,7 +1015,7 @@ abstract public class GraphServiceTestBase {
             anyType, EMPTY_FILTER,
             anyType, EMPTY_FILTER,
             Arrays.asList(downstreamOf, hasOwner, knowsUser), outgoingRelationships,
-            0, 10);
+            0, 100);
     assertEqualsAnyOrder(entitiesBeforeRemove, entitiesAfterRemove);
   }
 
@@ -1000,7 +1034,7 @@ abstract public class GraphServiceTestBase {
                     datasetType, EMPTY_FILTER,
                     anyType, EMPTY_FILTER,
                     Arrays.asList(downstreamOf), outgoingRelationships,
-                    0, 10
+                    0, 100
             ),
             Collections.emptyList()
     );
@@ -1009,7 +1043,7 @@ abstract public class GraphServiceTestBase {
                     userType, EMPTY_FILTER,
                     anyType, EMPTY_FILTER,
                     Arrays.asList(hasOwner), outgoingRelationships,
-                    0, 10
+                    0, 100
             ),
             Collections.emptyList()
     );
@@ -1018,7 +1052,7 @@ abstract public class GraphServiceTestBase {
                     anyType, EMPTY_FILTER,
                     userType, EMPTY_FILTER,
                     Arrays.asList(knowsUser), outgoingRelationships,
-                    0, 10
+                    0, 100
             ),
             Collections.emptyList()
     );

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -674,6 +674,65 @@ abstract public class GraphServiceTestBase {
     assertEqualsAnyOrder(relatedEntities, expectedRelatedEntities);
   }
 
+  private void doTestFindRelatedEntitiesEntityType(@Nullable String sourceType,
+                                                   @Nullable String destinationType,
+                                                   @Nonnull String relationshipType,
+                                                   @Nonnull RelationshipFilter relationshipFilter,
+                                                   @Nonnull GraphService service,
+                                                   @Nonnull RelatedEntity... expectedEntities) {
+    RelatedEntitiesResult actualEntities = service.findRelatedEntities(
+            sourceType, EMPTY_FILTER,
+            destinationType, EMPTY_FILTER,
+            Arrays.asList(relationshipType), relationshipFilter,
+            0, 100
+    );
+    assertEqualsAnyOrder(actualEntities, Arrays.asList(expectedEntities));
+  }
+
+  @Test
+  public void testFindRelatedEntitiesNullSourceType() throws Exception {
+    GraphService service = getGraphService();
+
+    Urn nullUrn = createFromString("urn:li:null:(urn:li:null:Null)");
+    assertNotNull(nullUrn);
+    RelatedEntity downstreamOfNullUrnRelatedEntity = new RelatedEntity(downstreamOf, nullUrn.toString());
+
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service);
+
+    service.addEdge(new Edge(datasetTwoUrn, datasetOneUrn, downstreamOf));
+    syncAfterWrite();
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, downstreamOfDatasetOneRelatedEntity);
+
+    service.addEdge(new Edge(datasetOneUrn, nullUrn, downstreamOf));
+    syncAfterWrite();
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity, downstreamOfDatasetOneRelatedEntity);
+  }
+
+  @Test
+  public void testFindRelatedEntitiesNullDestinationType() throws Exception {
+    GraphService service = getGraphService();
+
+    Urn nullUrn = createFromString("urn:li:null:(urn:li:null:Null)");
+    assertNotNull(nullUrn);
+    RelatedEntity downstreamOfNullUrnRelatedEntity = new RelatedEntity(downstreamOf, nullUrn.toString());
+
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service);
+
+    service.addEdge(new Edge(datasetTwoUrn, datasetOneUrn, downstreamOf));
+    syncAfterWrite();
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, downstreamOfDatasetOneRelatedEntity);
+
+    service.addEdge(new Edge(datasetOneUrn, nullUrn, downstreamOf));
+    syncAfterWrite();
+    doTestFindRelatedEntitiesEntityType(anyType, "null", downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity);
+    doTestFindRelatedEntitiesEntityType(anyType, null, downstreamOf, outgoingRelationships, service, downstreamOfNullUrnRelatedEntity, downstreamOfDatasetOneRelatedEntity);
+  }
+
   @Test
   public void testFindRelatedEntitiesRelationshipTypes() throws Exception {
     GraphService service = getPopulatedGraphService();

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -37,12 +37,14 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
   }
 
   @Override
-  protected @Nonnull GraphService getGraphService() {
+  protected @Nonnull
+  GraphService getGraphService() {
     return _client;
   }
 
   @Override
-  protected void syncAfterWrite() { }
+  protected void syncAfterWrite() {
+  }
 
   @Override
   protected void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
@@ -83,6 +85,18 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
 
   @Test
   @Override
+  public void testFindRelatedEntitiesNullSourceType() throws Exception {
+    throw new SkipException("Neo4jGraphService does not support 'null' entity type string");
+  }
+
+  @Test
+  @Override
+  public void testFindRelatedEntitiesNullDestinationType() throws Exception {
+    throw new SkipException("Neo4jGraphService does not support 'null' entity type string");
+  }
+
+  @Test
+  @Override
   public void testFindRelatedEntitiesNoRelationshipTypes() {
     throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
   }
@@ -92,5 +106,4 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
   public void testRemoveEdgesFromNodeNoRelationshipTypes() {
     throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
   }
-
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -47,13 +47,17 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
 
   @Override
   protected void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
+    // https://github.com/linkedin/datahub/issues/3118
+    // Neo4jGraphService produces duplicates, which is here ignored until fixed
+    // actual.count and actual.total not tested due to duplicates
     assertEquals(actual.start, expected.start);
     assertEqualsAnyOrder(actual.entities, expected.entities, RELATED_ENTITY_COMPARATOR);
   }
 
   @Override
   protected <T> void assertEqualsAnyOrder(List<T> actual, List<T> expected, Comparator<T> comparator) {
-    // Neo4jGraphService produces duplicates, which is here compensated until fixed
+    // https://github.com/linkedin/datahub/issues/3118
+    // Neo4jGraphService produces duplicates, which is here ignored until fixed
     assertEquals(
             new HashSet<>(actual),
             new HashSet<>(expected)
@@ -66,10 +70,13 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
                                                 RelationshipFilter relationships,
                                                 List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (datasetType != null && datasetType.isEmpty()) {
+      // https://github.com/linkedin/datahub/issues/3119
       throw new SkipException("Neo4jGraphService does not support empty source type");
     }
     if (datasetType != null && datasetType.equals(GraphServiceTestBase.userType)) {
-      throw new SkipException("Neo4jGraphService has different source and destination semantics");
+      // https://github.com/linkedin/datahub/issues/3123
+      // only test cases with "user" type fail due to this bug
+      throw new SkipException("Neo4jGraphService does not apply source / destination types");
     }
     super.testFindRelatedEntitiesSourceType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
   }
@@ -80,10 +87,13 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
                                                      RelationshipFilter relationships,
                                                      List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (datasetType != null && datasetType.isEmpty()) {
+      // https://github.com/linkedin/datahub/issues/3119
       throw new SkipException("Neo4jGraphService does not support empty destination type");
     }
     if (relationshipTypes.contains(hasOwner)) {
-      throw new SkipException("Neo4jGraphService has different source and destination semantics");
+      // https://github.com/linkedin/datahub/issues/3123
+      // only test cases with "HasOwner" relatioship fail due to this bug
+      throw new SkipException("Neo4jGraphService does not apply source / destination types");
     }
     super.testFindRelatedEntitiesDestinationType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
   }
@@ -91,24 +101,28 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
   @Test
   @Override
   public void testFindRelatedEntitiesNullSourceType() throws Exception {
+    // https://github.com/linkedin/datahub/issues/3121
     throw new SkipException("Neo4jGraphService does not support 'null' entity type string");
   }
 
   @Test
   @Override
   public void testFindRelatedEntitiesNullDestinationType() throws Exception {
+    // https://github.com/linkedin/datahub/issues/3121
     throw new SkipException("Neo4jGraphService does not support 'null' entity type string");
   }
 
   @Test
   @Override
   public void testFindRelatedEntitiesNoRelationshipTypes() {
+    // https://github.com/linkedin/datahub/issues/3120
     throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
   }
 
   @Test
   @Override
   public void testRemoveEdgesFromNodeNoRelationshipTypes() {
+    // https://github.com/linkedin/datahub/issues/3120
     throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.graph;
 
-import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
@@ -49,7 +48,7 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
   @Override
   protected void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
     assertEquals(actual.start, expected.start);
-    assertEqualsAnyOrder(actual.entities, expected.entities, relatedEntityComparator);
+    assertEqualsAnyOrder(actual.entities, expected.entities, RELATED_ENTITY_COMPARATOR);
   }
 
   @Override

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -69,6 +69,9 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
     if (datasetType != null && datasetType.isEmpty()) {
       throw new SkipException("Neo4jGraphService does not support empty source type");
     }
+    if (datasetType != null && datasetType.equals(GraphServiceTestBase.userType)) {
+      throw new SkipException("Neo4jGraphService has different source and destination semantics");
+    }
     super.testFindRelatedEntitiesSourceType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
   }
 
@@ -79,6 +82,9 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
                                                      List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (datasetType != null && datasetType.isEmpty()) {
       throw new SkipException("Neo4jGraphService does not support empty destination type");
+    }
+    if (relationshipTypes.contains(hasOwner)) {
+      throw new SkipException("Neo4jGraphService has different source and destination semantics");
     }
     super.testFindRelatedEntitiesDestinationType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
   }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -125,4 +125,26 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
     // https://github.com/linkedin/datahub/issues/3120
     throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
   }
+
+  @Test
+  @Override
+  public void testConcurrentAddEdge() {
+    // https://github.com/linkedin/datahub/issues/3141
+    throw new SkipException("Neo4jGraphService does not manage to add all edges added concurrently");
+  }
+
+  @Test
+  @Override
+  public void testConcurrentRemoveEdgesFromNode() {
+    // https://github.com/linkedin/datahub/issues/3118
+    throw new SkipException("Neo4jGraphService produces duplicates");
+  }
+
+  @Test
+  @Override
+  public void testConcurrentRemoveNodes() {
+    // https://github.com/linkedin/datahub/issues/3118
+    throw new SkipException("Neo4jGraphService produces duplicates");
+  }
+
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/Neo4jGraphServiceTest.java
@@ -1,11 +1,20 @@
 package com.linkedin.metadata.graph;
 
+import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.metadata.query.RelationshipFilter;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
+import org.testng.SkipException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
 
 
 public class Neo4jGraphServiceTest extends GraphServiceTestBase {
@@ -34,5 +43,54 @@ public class Neo4jGraphServiceTest extends GraphServiceTestBase {
 
   @Override
   protected void syncAfterWrite() { }
+
+  @Override
+  protected void assertEqualsAnyOrder(RelatedEntitiesResult actual, RelatedEntitiesResult expected) {
+    assertEquals(actual.start, expected.start);
+    assertEqualsAnyOrder(actual.entities, expected.entities, relatedEntityComparator);
+  }
+
+  @Override
+  protected <T> void assertEqualsAnyOrder(List<T> actual, List<T> expected, Comparator<T> comparator) {
+    // Neo4jGraphService produces duplicates, which is here compensated until fixed
+    assertEquals(
+            new HashSet<>(actual),
+            new HashSet<>(expected)
+    );
+  }
+
+  @Override
+  public void testFindRelatedEntitiesSourceType(String datasetType,
+                                                List<String> relationshipTypes,
+                                                RelationshipFilter relationships,
+                                                List<RelatedEntity> expectedRelatedEntities) throws Exception {
+    if (datasetType != null && datasetType.isEmpty()) {
+      throw new SkipException("Neo4jGraphService does not support empty source type");
+    }
+    super.testFindRelatedEntitiesSourceType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
+  }
+
+  @Override
+  public void testFindRelatedEntitiesDestinationType(String datasetType,
+                                                     List<String> relationshipTypes,
+                                                     RelationshipFilter relationships,
+                                                     List<RelatedEntity> expectedRelatedEntities) throws Exception {
+    if (datasetType != null && datasetType.isEmpty()) {
+      throw new SkipException("Neo4jGraphService does not support empty destination type");
+    }
+    super.testFindRelatedEntitiesDestinationType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
+  }
+
+  @Test
+  @Override
+  public void testFindRelatedEntitiesNoRelationshipTypes() {
+    throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
+  }
+
+  @Test
+  @Override
+  public void testRemoveEdgesFromNodeNoRelationshipTypes() {
+    throw new SkipException("Neo4jGraphService does not support empty list of relationship types");
+  }
 
 }


### PR DESCRIPTION
Adds a more complex test graph and tests all `GraphService` methods thoroughly. In the current implementation, tests depend on the order of test execution, as they share the state of the tested service.

As the interface is not documented, a couple of questions on which results to expect from the given graph arose:
- Is it expected that `findRelatedUrns` returns duplicates, i.e. Urns may occur multiple times?
  - Answer: findRelatedUrns should not return duplicates.
- Should `findRelatedUrns` with `RelationshipDirection.UNDIRECTED` return the union of `RelationshipDirection.OUTGOING` and `RelationshipDirection.INCOMING`?
  - Answer: It should return the union of outgoing & incoming.
- The `sourceType` and `destinationType` of `findRelatedUrns` are explicitly `@Nullable`. Does `null` represent any type?
  - Answer: Yes, `null` `sourceType` or `destinationType` represents any type.
- From current tests it looks like `""` is also interpreted as any type. Should this be deprecated in favour of `null` and disallow empty types? When a type is given (non-null), it should be a useful type string.
  - Answer: Yes, we should use `null` to reference any type.
- Should `removeEdgesFromNode` with `RelationshipDirection.UNDIRECTED` be equivalent to calling it with `RelationshipDirection.OUTGOING` and `RelationshipDirection.INCOMING`?
  - Answer: Yes, `removeEdgesFromNode` with `RelationshipDirection.UNDIRECTED` should be equivalent to calling it with `RelationshipDirection.OUTGOING` and `RelationshipDirection.INCOMING`.
- Is it expected to always have at least one relationship type given when calling `findRelatedUrns` and `removeEdgesFromNode`? Is an implementation allowed to enforce this limitation?
  - Answer: Yes, it is expected to have at least one relationship type for a query.

`ElasticSearchGraphServiceTest` fails these tests while above questions are open.

It further seems like no Neo4j tests are running. This includes a fix for #2678.