### PR TITLE
feat(ingest-proposal): adding support for MCP in kafka sink

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/kafka_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/kafka_emitter.py
@@ -1,30 +1,66 @@
-from typing import Callable
+import logging
+from typing import Callable, Union
 
 from confluent_kafka import SerializingProducer
 from confluent_kafka.schema_registry import SchemaRegistryClient
 from confluent_kafka.schema_registry.avro import AvroSerializer
 from confluent_kafka.serialization import SerializationContext, StringSerializer
-from pydantic import Field
+from pydantic import Field, root_validator
 
-from datahub.configuration.common import ConfigModel
+from datahub.configuration.common import ConfigModel, ConfigurationError
 from datahub.configuration.kafka import KafkaProducerConnectionConfig
-from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
-from datahub.metadata.schemas import getMetadataChangeEventSchema
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
+    MetadataChangeEvent,
+    MetadataChangeProposal,
+)
+from datahub.metadata.schemas import (
+    getMetadataChangeEventSchema,
+    getMetadataChangeProposalSchema,
+)
 
-DEFAULT_KAFKA_TOPIC = "MetadataChangeEvent_v4"
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MCE_KAFKA_TOPIC = "MetadataChangeEvent_v4"
+DEFAULT_MCP_KAFKA_TOPIC = "MetadataChangeProposal_v1"
+MCE_KEY = "MetadataChangeEvent"
+MCP_KEY = "MetadataChangeProposal"
 
 
 class KafkaEmitterConfig(ConfigModel):
     connection: KafkaProducerConnectionConfig = Field(
         default_factory=KafkaProducerConnectionConfig
     )
-    topic: str = DEFAULT_KAFKA_TOPIC
+    topic: str = DEFAULT_MCE_KAFKA_TOPIC
+    topic_routes: dict = {
+        MCE_KEY: DEFAULT_MCE_KAFKA_TOPIC,
+        MCP_KEY: DEFAULT_MCP_KAFKA_TOPIC,
+    }
+
+    @root_validator
+    def validate_topic_routes(cls: "KafkaEmitterConfig", values: dict) -> dict:
+        old_topic = values["topic"]
+        new_mce_topic = values["topic_routes"][MCE_KEY]
+        if old_topic != DEFAULT_MCE_KAFKA_TOPIC:
+            # Looks like a non default topic has been set using the old style
+            if new_mce_topic != DEFAULT_MCE_KAFKA_TOPIC:
+                # Looks like a non default topic has ALSO been set using the new style
+                raise ConfigurationError(
+                    "Using both topic and topic_routes configuration for Kafka is not supported. Use only topic_routes"
+                )
+            else:
+                logger.warning(
+                    "Looks like you're using the deprecated `topic` configuration. Please migrate to `topic_routes`."
+                )
+                # upgrade topic provided to topic_routes mce entry
+                values["topic_routes"][MCE_KEY] = values["topic"]
+        return values
 
 
 class DatahubKafkaEmitter:
     def __init__(self, config: KafkaEmitterConfig):
         self.config = config
-
         schema_registry_conf = {
             "url": self.config.connection.schema_registry_url,
             **self.config.connection.schema_registry_config,
@@ -37,20 +73,58 @@ class DatahubKafkaEmitter:
             tuple_encoding = mce.to_obj(tuples=True)
             return tuple_encoding
 
-        avro_serializer = AvroSerializer(
+        mce_avro_serializer = AvroSerializer(
             schema_str=getMetadataChangeEventSchema(),
             schema_registry_client=schema_registry_client,
             to_dict=convert_mce_to_dict,
         )
 
-        producer_config = {
-            "bootstrap.servers": self.config.connection.bootstrap,
-            "key.serializer": StringSerializer("utf_8"),
-            "value.serializer": avro_serializer,
-            **self.config.connection.producer_config,
+        def convert_mcp_to_dict(
+            mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper],
+            ctx: SerializationContext,
+        ) -> dict:
+            tuple_encoding = mcp.to_obj(tuples=True)
+            return tuple_encoding
+
+        mcp_avro_serializer = AvroSerializer(
+            schema_str=getMetadataChangeProposalSchema(),
+            schema_registry_client=schema_registry_client,
+            to_dict=convert_mcp_to_dict,
+        )
+
+        # We maintain a map of producers for each kind of event
+        producers_config = {
+            MCE_KEY: {
+                "bootstrap.servers": self.config.connection.bootstrap,
+                "key.serializer": StringSerializer("utf_8"),
+                "value.serializer": mce_avro_serializer,
+                **self.config.connection.producer_config,
+            },
+            MCP_KEY: {
+                "bootstrap.servers": self.config.connection.bootstrap,
+                "key.serializer": StringSerializer("utf_8"),
+                "value.serializer": mcp_avro_serializer,
+                **self.config.connection.producer_config,
+            },
         }
 
-        self.producer = SerializingProducer(producer_config)
+        self.producers = {
+            key: SerializingProducer(value) for (key, value) in producers_config.items()
+        }
+
+    def emit(
+        self,
+        item: Union[
+            MetadataChangeEvent,
+            MetadataChangeProposal,
+            MetadataChangeProposalWrapper,
+        ],
+        callback: Callable[[Exception, str], None],
+    ) -> None:
+        if isinstance(item, (MetadataChangeProposal, MetadataChangeProposalWrapper)):
+            return self.emit_mcp_async(item, callback)
+        else:
+            return self.emit_mce_async(item, callback)
 
     def emit_mce_async(
         self,
@@ -58,13 +132,30 @@ class DatahubKafkaEmitter:
         callback: Callable[[Exception, str], None],
     ) -> None:
         # Call poll to trigger any callbacks on success / failure of previous writes
-        self.producer.poll(0)
-        self.producer.produce(
-            topic=self.config.topic,
+        producer: SerializingProducer = self.producers[MCE_KEY]
+        producer.poll(0)
+        producer.produce(
+            topic=self.config.topic_routes[MCE_KEY],
             key=mce.proposedSnapshot.urn,
             value=mce,
             on_delivery=callback,
         )
 
+    def emit_mcp_async(
+        self,
+        mcp: Union[MetadataChangeProposal, MetadataChangeProposalWrapper],
+        callback: Callable[[Exception, str], None],
+    ) -> None:
+        # Call poll to trigger any callbacks on success / failure of previous writes
+        producer: SerializingProducer = self.producers[MCP_KEY]
+        producer.poll(0)
+        producer.produce(
+            topic=self.config.topic_routes[MCP_KEY],
+            key=mcp.entityUrn,
+            value=mcp,
+            on_delivery=callback,
+        )
+
     def flush(self) -> None:
-        self.producer.flush()
+        for producer in self.producers.values():
+            producer.flush()

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -276,7 +276,7 @@ class SQLAlchemySource(Source):
         if self.config.profiling.enabled and not self._can_run_profiler():
             raise ConfigurationError(
                 "Table profiles requested but profiler plugin is not enabled. "
-                f"Try running: pip install '{__package_name__}[sql-profiler]'"
+                f"Try running: pip install '{__package_name__}[sql-profiles]'"
             )
 
     def get_inspectors(self) -> Iterable[Inspector]:

--- a/metadata-ingestion/tests/unit/test_kafka_emitter.py
+++ b/metadata-ingestion/tests/unit/test_kafka_emitter.py
@@ -1,0 +1,48 @@
+import unittest
+
+import pytest
+
+from datahub.configuration.common import ConfigurationError
+from datahub.emitter.kafka_emitter import (
+    DEFAULT_MCE_KAFKA_TOPIC,
+    DEFAULT_MCP_KAFKA_TOPIC,
+    MCE_KEY,
+    MCP_KEY,
+    KafkaEmitterConfig,
+)
+
+
+class KafkaEmitterTest(unittest.TestCase):
+    def test_kafka_emitter_config(self):
+        emitter_config = KafkaEmitterConfig.parse_obj(
+            {"connection": {"bootstrap": "foobar:9092"}}
+        )
+        assert emitter_config.topic_routes[MCE_KEY] == DEFAULT_MCE_KAFKA_TOPIC
+        assert emitter_config.topic_routes[MCP_KEY] == DEFAULT_MCP_KAFKA_TOPIC
+
+    """
+    Respecifying old and new topic config should barf
+    """
+
+    def test_kafka_emitter_config_old_and_new(self):
+        with pytest.raises(ConfigurationError):
+            emitter_config = KafkaEmitterConfig.parse_obj(  # noqa 841
+                {
+                    "connection": {"bootstrap": "foobar:9092"},
+                    "topic": "NewTopic",
+                    "topic_routes": {MCE_KEY: "NewTopic"},
+                }
+            )
+
+    """
+    Old topic config provided should get auto-upgraded to new topic_routes
+    """
+
+    def test_kafka_emitter_config_topic_upgrade(self):
+        emitter_config = KafkaEmitterConfig.parse_obj(
+            {"connection": {"bootstrap": "foobar:9092"}, "topic": "NewTopic"}
+        )
+        assert emitter_config.topic_routes[MCE_KEY] == "NewTopic"  # MCE topic upgraded
+        assert (
+            emitter_config.topic_routes[MCP_KEY] == DEFAULT_MCP_KAFKA_TOPIC
+        )  # No change to MCP

--- a/metadata-ingestion/tests/unit/test_kafka_sink.py
+++ b/metadata-ingestion/tests/unit/test_kafka_sink.py
@@ -1,10 +1,18 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from typing import Union
+from unittest.mock import MagicMock, call, patch
 
 import datahub.emitter.mce_builder as builder
-from datahub.ingestion.api.common import RecordEnvelope
+import datahub.metadata.schema_classes as models
+from datahub.emitter.kafka_emitter import MCE_KEY
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
 from datahub.ingestion.api.sink import SinkReport, WriteCallback
 from datahub.ingestion.sink.datahub_kafka import DatahubKafkaSink, _KafkaCallback
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import (
+    MetadataChangeEvent,
+    MetadataChangeProposal,
+)
 
 
 class KafkaSinkTest(unittest.TestCase):
@@ -15,7 +23,9 @@ class KafkaSinkTest(unittest.TestCase):
             {"connection": {"bootstrap": "foobar:9092"}}, mock_context
         )
         kafka_sink.close()
-        assert mock_producer.call_count == 1  # constructor should be called
+        assert (
+            mock_producer.call_count == 2
+        )  # constructor should be called twice (once each for mce,mcp)
 
     def validate_kafka_callback(self, mock_k_callback, record_envelope, write_callback):
         assert mock_k_callback.call_count == 1  # KafkaCallback constructed
@@ -23,16 +33,43 @@ class KafkaSinkTest(unittest.TestCase):
         assert constructor_args[1] == record_envelope
         assert constructor_args[2] == write_callback
 
+    @patch("datahub.ingestion.sink.datahub_kafka._KafkaCallback", autospec=True)
+    @patch("datahub.emitter.kafka_emitter.SerializingProducer", autospec=True)
+    def test_kafka_sink_mcp(self, mock_producer, mock_callback):
+        from datahub.emitter.mcp import MetadataChangeProposalWrapper
+
+        mcp = MetadataChangeProposalWrapper(
+            entityType="dataset",
+            entityUrn="urn:li:dataset:(urn:li:dataPlatform:mysql,User.UserAccount,PROD)",
+            changeType=models.ChangeTypeClass.UPSERT,
+            aspectName="datasetProfile",
+            aspect=models.DatasetProfileClass(
+                rowCount=2000,
+                columnCount=15,
+                timestampMillis=1626995099686,
+            ),
+        )
+        kafka_sink = DatahubKafkaSink.create(
+            {"connection": {"bootstrap": "localhost:9092"}},
+            PipelineContext(run_id="test"),
+        )
+        kafka_sink.write_record_async(
+            RecordEnvelope(record=mcp, metadata={}), mock_callback
+        )
+        kafka_sink.close()
+        assert mock_producer.call_count == 2  # constructor should be called
+
     @patch("datahub.ingestion.sink.datahub_kafka.PipelineContext", autospec=True)
     @patch("datahub.emitter.kafka_emitter.SerializingProducer", autospec=True)
     @patch("datahub.ingestion.sink.datahub_kafka._KafkaCallback", autospec=True)
     def test_kafka_sink_write(self, mock_k_callback, mock_producer, mock_context):
-        mock_producer_instance = mock_producer.return_value
         mock_k_callback_instance = mock_k_callback.return_value
         callback = MagicMock(spec=WriteCallback)
         kafka_sink = DatahubKafkaSink.create(
             {"connection": {"bootstrap": "foobar:9092"}}, mock_context
         )
+        mock_producer_instance = kafka_sink.emitter.producers[MCE_KEY]
+
         mce = builder.make_lineage_mce(
             [
                 builder.make_dataset_urn("bigquery", "upstream1"),
@@ -41,7 +78,13 @@ class KafkaSinkTest(unittest.TestCase):
             builder.make_dataset_urn("bigquery", "downstream1"),
         )
 
-        re = RecordEnvelope(record=mce, metadata={})
+        re: RecordEnvelope[
+            Union[
+                MetadataChangeEvent,
+                MetadataChangeProposal,
+                MetadataChangeProposalWrapper,
+            ]
+        ] = RecordEnvelope(record=mce, metadata={})
         kafka_sink.write_record_async(re, callback)
 
         mock_producer_instance.poll.assert_called_once()  # producer should call poll() first
@@ -65,7 +108,7 @@ class KafkaSinkTest(unittest.TestCase):
         mock_producer_instance = mock_producer.return_value
         kafka_sink = DatahubKafkaSink.create({}, mock_context)
         kafka_sink.close()
-        mock_producer_instance.flush.assert_called_once()
+        mock_producer_instance.flush.assert_has_calls([call(), call()])
 
     @patch("datahub.ingestion.sink.datahub_kafka.RecordEnvelope", autospec=True)
     @patch("datahub.ingestion.sink.datahub_kafka.WriteCallback", autospec=True)


### PR DESCRIPTION
Add support for MCP in kafka sink which allows us to ingest timeseries aspect through kafka. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
