### PR TITLE
Encode Original URI in Authentication Redirect

### DIFF
--- a/datahub-frontend/app/react/controllers/AuthenticationController.java
+++ b/datahub-frontend/app/react/controllers/AuthenticationController.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.typesafe.config.Config;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.context.session.SessionStore;
@@ -32,6 +35,8 @@ import static react.auth.AuthUtils.*;
 
 public class AuthenticationController extends Controller {
 
+    private static final String AUTH_REDIRECT_URI_PARAM = "redirect_uri";
+
     private final Logger _logger = LoggerFactory.getLogger(AuthenticationController.class.getName());
     private final Config _configs;
     private final OidcConfigs _oidcConfigs;
@@ -58,8 +63,11 @@ public class AuthenticationController extends Controller {
      */
     @Nonnull
     public Result authenticate() {
+
+        final Optional<String> maybeRedirectPath = Optional.ofNullable(ctx().request().getQueryString(AUTH_REDIRECT_URI_PARAM));
+
         if (AuthUtils.isAuthenticated(ctx())) {
-            return redirect("/");
+            return redirect(maybeRedirectPath.orElse("/"));
         }
 
         // 1. If indirect auth is enabled, redirect to IdP
@@ -72,12 +80,16 @@ public class AuthenticationController extends Controller {
 
         // 2. If JAAS auth is enabled, fallback to it
         if (_jaasConfigs.isJAASEnabled()) {
-            return redirect(LOGIN_ROUTE);
+            String loginRedirectPath = LOGIN_ROUTE;
+            if (maybeRedirectPath.isPresent()) {
+                loginRedirectPath = loginRedirectPath + String.format("?%s=%s", AUTH_REDIRECT_URI_PARAM,  encodeRedirectUri(maybeRedirectPath.get()));
+            }
+            return redirect(loginRedirectPath);
         }
 
         // 3. If no auth enabled, fallback to using default user account & redirect.
         session().put(ACTOR, DEFAULT_ACTOR_URN.toString());
-        return redirect("/").withCookies(createActorCookie(DEFAULT_ACTOR_URN.toString(), _configs.hasPath(SESSION_TTL_CONFIG_PATH)
+        return redirect(maybeRedirectPath.orElse("/")).withCookies(createActorCookie(DEFAULT_ACTOR_URN.toString(), _configs.hasPath(SESSION_TTL_CONFIG_PATH)
                 ? _configs.getInt(SESSION_TTL_CONFIG_PATH)
                 : DEFAULT_SESSION_TTL_HOURS));
     }
@@ -123,5 +135,13 @@ public class AuthenticationController extends Controller {
             .withHttpOnly(false)
             .withMaxAge(Duration.of(30, ChronoUnit.DAYS))
             .build());
+    }
+
+    private String encodeRedirectUri(final String redirectUri) {
+        try {
+            return URLEncoder.encode(redirectUri, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(String.format("Failed to encode redirect URI %s", redirectUri), e);
+        }
     }
 }

--- a/datahub-web-react/src/app/Routes.tsx
+++ b/datahub-web-react/src/app/Routes.tsx
@@ -19,8 +19,9 @@ const ProtectedRoute = ({
 }: {
     isLoggedIn: boolean;
 } & RouteProps) => {
+    const currentPath = window.location.pathname + window.location.search;
     if (!isLoggedIn) {
-        window.location.replace(PageRoutes.AUTHENTICATE);
+        window.location.replace(`${PageRoutes.AUTHENTICATE}?redirect_uri=${encodeURIComponent(currentPath)}`);
         return null;
     }
     return <Route {...props} />;

--- a/datahub-web-react/src/app/auth/LogIn.tsx
+++ b/datahub-web-react/src/app/auth/LogIn.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState } from 'react';
+import * as QueryString from 'query-string';
 import { Input, Button, Form, message, Image } from 'antd';
 import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import { useReactiveVar } from '@apollo/client';
 import { useTheme } from 'styled-components';
-import { Redirect } from 'react-router';
+import { Redirect, useLocation } from 'react-router';
 import styles from './login.module.css';
 import { Message } from '../shared/Message';
 import { isLoggedInVar } from './checkAuthStatus';
@@ -18,6 +19,7 @@ export type LogInProps = Record<string, never>;
 
 export const LogIn: React.VFC<LogInProps> = () => {
     const isLoggedIn = useReactiveVar(isLoggedInVar);
+    const location = useLocation();
 
     const themeConfig = useTheme();
     const [loading, setLoading] = useState(false);
@@ -47,7 +49,9 @@ export const LogIn: React.VFC<LogInProps> = () => {
     }, []);
 
     if (isLoggedIn) {
-        return <Redirect to="/" />;
+        const params = QueryString.parse(location.search);
+        const maybeRedirectUri = params.redirect_uri;
+        return <Redirect to={(maybeRedirectUri && decodeURIComponent(maybeRedirectUri as string)) || '/'} />;
     }
 
     return (

--- a/docker/datahub-frontend/env/docker.env
+++ b/docker/datahub-frontend/env/docker.env
@@ -24,7 +24,7 @@ JAVA_OPTS=-Xms512m -Xmx512m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf
 # AUTH_OIDC_SCOPE=
 
 # Uncomment to disable JAAS username / password authentication (enabled by default)
-AUTH_JAAS_ENABLED=false
+# AUTH_JAAS_ENABLED=false
 
 # Uncomment to disable persistence of client-side analytics events
 # DATAHUB_ANALYTICS_ENABLED=false

--- a/docker/datahub-frontend/env/docker.env
+++ b/docker/datahub-frontend/env/docker.env
@@ -24,7 +24,7 @@ JAVA_OPTS=-Xms512m -Xmx512m -Dhttp.port=9002 -Dconfig.file=datahub-frontend/conf
 # AUTH_OIDC_SCOPE=
 
 # Uncomment to disable JAAS username / password authentication (enabled by default)
-# AUTH_JAAS_ENABLED=false
+AUTH_JAAS_ENABLED=false
 
 # Uncomment to disable persistence of client-side analytics events
 # DATAHUB_ANALYTICS_ENABLED=false


### PR DESCRIPTION
Today, authentication checks erase the original URL path in cases where a user is not authenticated. This PR fixes this behavior and implements a redirect back to the original target URI on successful authentication, including when logging in via username and password. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
