### PR TITLE
fix(restore-indices): add system metadata restoration to restore-indices

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -13,6 +13,7 @@ import com.linkedin.metadata.entity.ebean.EbeanUtils;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.mxe.MetadataAuditOperation;
+import com.linkedin.mxe.SystemMetadata;
 import io.ebean.EbeanServer;
 import io.ebean.PagedList;
 import java.util.Map;
@@ -101,13 +102,15 @@ public class SendMAEStep implements UpgradeStep {
             return new DefaultUpgradeStepResult(id(), UpgradeStepResult.Result.FAILED);
           }
 
+          SystemMetadata latestSystemMetadata = EbeanUtils.parseSystemMetadata(aspect.getSystemMetadata());
+
           // 5. Produce MAE events for the aspect record
           _entityService.produceMetadataAuditEvent(
               urn,
               null,
               aspectRecord,
               null,
-              null,
+              latestSystemMetadata,
               MetadataAuditOperation.UPDATE
           );
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -83,9 +84,14 @@ public class ElasticSearchSystemMetadataService implements SystemMetadataService
   }
 
   @Override
-  public void insert(SystemMetadata systemMetadata, String urn, String aspect) {
-    String document = toDocument(systemMetadata, urn, aspect);
+  public void insert(@Nullable SystemMetadata systemMetadata, String urn, String aspect) {
+    if (systemMetadata == null) {
+      return;
+    }
+
     String docId = toDocId(urn, aspect);
+
+    String document = toDocument(systemMetadata, urn, aspect);
     _esDAO.upsertDocument(docId, document);
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/SystemMetadataService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/SystemMetadataService.java
@@ -4,6 +4,7 @@ import com.linkedin.metadata.run.AspectRowSummary;
 import com.linkedin.metadata.run.IngestionRunSummary;
 import com.linkedin.mxe.SystemMetadata;
 import java.util.List;
+import javax.annotation.Nullable;
 
 
 public interface SystemMetadataService {
@@ -11,7 +12,7 @@ public interface SystemMetadataService {
 
   void deleteUrn(String finalOldUrn);
 
-  void insert(SystemMetadata systemMetadata, String urn, String aspect);
+  void insert(@Nullable SystemMetadata systemMetadata, String urn, String aspect);
 
   List<AspectRowSummary> findByRunId(String runId);
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
@@ -22,7 +22,6 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
-
 public class ElasticSearchSystemMetadataServiceTest {
 
   private ElasticsearchContainer _elasticsearchContainer;
@@ -185,5 +184,16 @@ public class ElasticSearchSystemMetadataServiceTest {
 
     assertEquals(rows.size(), 2);
     rows.forEach(row -> assertEquals(row.getRunId(), "abc-456"));
+  }
+
+  @Test
+  public void testInsertNullData() throws Exception {
+    _client.insert(null, "urn:li:chart:1", "chartKey");
+
+    TimeUnit.SECONDS.sleep(5);
+
+    List<IngestionRunSummary> runs = _client.listRuns(0, 20);
+
+    assertEquals(runs.size(), 0);
   }
 }


### PR DESCRIPTION
Now, restore indices will also restore system metadata index.

Also, in the case MAE sees null system metadata, we should ignore updating the system metadata service rather than throwing a NPE.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
