### PR TITLE
fix(gms): handling partial system metadata in gms

### DIFF
--- a/gms/client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/gms/client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -190,6 +190,10 @@ public class EntityClient {
 
     public Response<Void> updateWithSystemMetadata(@Nonnull final Entity entity,
         @Nullable final SystemMetadata systemMetadata) throws RemoteInvocationException {
+        if (systemMetadata == null) {
+            return update(entity);
+        }
+
         EntitiesDoIngestRequestBuilder requestBuilder =
             ENTITIES_REQUEST_BUILDERS.actionIngest().entityParam(entity).systemMetadataParam(systemMetadata);
 

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -141,10 +141,15 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
     validateOrThrow(entity, HttpStatus.S_422_UNPROCESSABLE_ENTITY);
 
     if (systemMetadata == null) {
-      SystemMetadata generatedSystemMetadata = new SystemMetadata();
-      generatedSystemMetadata.setLastObserved(System.currentTimeMillis());
-      generatedSystemMetadata.setRunId(DEFAULT_RUN_ID);
-      systemMetadata = generatedSystemMetadata;
+      systemMetadata = new SystemMetadata();
+    }
+
+    if (!systemMetadata.hasLastObserved()) {
+      systemMetadata.setLastObserved(System.currentTimeMillis());
+    }
+
+    if (!systemMetadata.hasRunId()) {
+      systemMetadata.setRunId(DEFAULT_RUN_ID);
     }
 
     final Set<String> projectedAspects = new HashSet<>(Arrays.asList("browsePaths"));

--- a/gms/impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/gms/impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Inject;

--- a/metadata-models/src/main/pegasus/com/linkedin/mxe/SystemMetadata.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/mxe/SystemMetadata.pdl
@@ -7,12 +7,12 @@ record SystemMetadata {
   /**
   * The timestamp the metadata was observed at
   */
-  lastObserved: optional long
+  lastObserved: optional long = 0
 
   /**
   * The run id that produced the metadata
   */
-  runId: optional string
+  runId: optional string = "no-run-id-provided"
 
   /**
   * Additional properties

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -361,3 +361,62 @@ def test_frontend_user_info(frontend_session, platform, dataset_name, env):
     data = response.json()
 
     assert len(data["owners"]) >= 1
+
+@pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
+def test_ingest_with_system_metadata():
+    response = requests.post(
+        f"{GMS_ENDPOINT}/entities?action=ingest",
+        headers=restli_default_headers,
+        json={
+          'entity':
+            {
+              'value':
+                {'com.linkedin.metadata.snapshot.CorpUserSnapshot':
+                  {'urn': 'urn:li:corpuser:datahub', 'aspects':
+                    [{'com.linkedin.identity.CorpUserInfo': {'active': True, 'displayName': 'Data Hub', 'email': 'datahub@linkedin.com', 'title': 'CEO', 'fullName': 'Data Hub'}}]
+                   }
+                  }
+                },
+              'systemMetadata': {'lastObserved': 1628097379571, 'runId': 'af0fe6e4-f547-11eb-81b2-acde48001122'}
+        },
+    )
+    response.raise_for_status()
+
+@pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
+def test_ingest_with_blank_system_metadata():
+    response = requests.post(
+        f"{GMS_ENDPOINT}/entities?action=ingest",
+        headers=restli_default_headers,
+        json={
+          'entity':
+            {
+              'value':
+                {'com.linkedin.metadata.snapshot.CorpUserSnapshot':
+                  {'urn': 'urn:li:corpuser:datahub', 'aspects':
+                    [{'com.linkedin.identity.CorpUserInfo': {'active': True, 'displayName': 'Data Hub', 'email': 'datahub@linkedin.com', 'title': 'CEO', 'fullName': 'Data Hub'}}]
+                   }
+                  }
+                },
+              'systemMetadata': {}
+        },
+    )
+    response.raise_for_status()
+
+@pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
+def test_ingest_without_system_metadata():
+    response = requests.post(
+        f"{GMS_ENDPOINT}/entities?action=ingest",
+        headers=restli_default_headers,
+        json={
+          'entity':
+            {
+              'value':
+                {'com.linkedin.metadata.snapshot.CorpUserSnapshot':
+                  {'urn': 'urn:li:corpuser:datahub', 'aspects':
+                    [{'com.linkedin.identity.CorpUserInfo': {'active': True, 'displayName': 'Data Hub', 'email': 'datahub@linkedin.com', 'title': 'CEO', 'fullName': 'Data Hub'}}]
+                   }
+                  }
+             },
+        },
+    )
+    response.raise_for_status()


### PR DESCRIPTION
If a partially constructed system metadata was received by GMS, it would error. Adding logic to fill in whatever blanks exist in system metadata here. Also adding smoke tests to test the various states we may receive system metadata

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
