### PR TITLE
fix(lineage): fixing lineage abbreviations

### DIFF
--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -15,6 +15,17 @@ function truncate(input, length) {
     return input;
 }
 
+function getLastTokenOfTitle(title: string): string {
+    const lastToken = title?.split('.').slice(-1)[0];
+
+    // if the last token does not contain any content, the string should not be tokenized on `.`
+    if (lastToken.replace(/\s/g, '').length === 0) {
+        return title;
+    }
+
+    return lastToken;
+}
+
 export const width = 212;
 export const height = 80;
 const iconWidth = 42;
@@ -176,7 +187,7 @@ export default function LineageEntityNode({
                         textAnchor="start"
                         fill={isCenterNode ? '#304D85' : 'black'}
                     >
-                        {truncate(node.data.name?.split('.').slice(-1)[0], 16)}
+                        {truncate(getLastTokenOfTitle(node.data.name), 16)}
                     </text>
                 </Group>
                 {unexploredHiddenChildren && isHovered ? (


### PR DESCRIPTION
Avoid showing a blank lineage node for entities whose names end in `.`

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
