### PR TITLE
feat(quickstart): linking to slack from quickstart

### DIFF
--- a/metadata-ingestion/src/datahub/cli/docker.py
+++ b/metadata-ingestion/src/datahub/cli/docker.py
@@ -269,6 +269,10 @@ def quickstart(
         "or head to http://localhost:9002 (username: datahub, password: datahub) to play around with the frontend.",
         fg="green",
     )
+    click.secho(
+        "Need support? Get in touch on Slack: https://slack.datahubproject.io/",
+        fg="magenta",
+    )
 
 
 @docker.command()


### PR DESCRIPTION
The DataHub slack community is the best place to learn more about DataHub. This adds a link to the Slack community from Quickstart so new users can have the best experience onboarding to DataHub.

![image](https://user-images.githubusercontent.com/2455694/128546562-0fc7f912-3376-4df9-85bf-9c6e974d1948.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
