### PR TITLE
fix(homepage): fix homepage jitter

### DIFF
--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -74,6 +74,10 @@ const NavGroup = styled.div`
     justify-content: center;
 `;
 
+const SuggestionsContainer = styled.div`
+    height: 140px;
+`;
+
 function getSuggestionFieldsFromResult(result: GetSearchResultsQuery | undefined): string[] {
     return (
         (result?.search?.searchResults
@@ -209,37 +213,41 @@ export const HomePageHeader = () => {
                     autoCompleteStyle={styles.searchBox}
                     entityRegistry={entityRegistry}
                 />
-                {suggestionsToShow.length === 0 && !suggestionsLoading && (
-                    <SubHeaderTextNoResults>{themeConfig.content.homepage.homepageMessage}</SubHeaderTextNoResults>
-                )}
-                {suggestionsToShow.length > 0 && !suggestionsLoading && (
-                    <Typography.Text style={styles.subHeaderLabel}>Try searching for...</Typography.Text>
-                )}
             </HeaderContainer>
-            {suggestionsToShow.length > 0 && !suggestionsLoading && (
-                <CarouselContainer>
-                    <Carousel autoplay effect="fade">
-                        {suggestionsToShow.length > 0 &&
-                            suggestionsToShow.slice(0, 3).map((suggestion) => (
-                                <CarouselElement key={suggestion}>
-                                    <Button
-                                        type="text"
-                                        onClick={() =>
-                                            navigateToSearchUrl({
-                                                type: undefined,
-                                                query: suggestion,
-                                                history,
-                                                entityRegistry,
-                                            })
-                                        }
-                                    >
-                                        <SubHeaderText>{truncate(suggestion, 40)}</SubHeaderText>
-                                    </Button>
-                                </CarouselElement>
-                            ))}
-                    </Carousel>
-                </CarouselContainer>
-            )}
+            <SuggestionsContainer>
+                <HeaderContainer>
+                    {suggestionsToShow.length === 0 && !suggestionsLoading && (
+                        <SubHeaderTextNoResults>{themeConfig.content.homepage.homepageMessage}</SubHeaderTextNoResults>
+                    )}
+                    {suggestionsToShow.length > 0 && !suggestionsLoading && (
+                        <Typography.Text style={styles.subHeaderLabel}>Try searching for...</Typography.Text>
+                    )}
+                </HeaderContainer>
+                {suggestionsToShow.length > 0 && !suggestionsLoading && (
+                    <CarouselContainer>
+                        <Carousel autoplay effect="fade">
+                            {suggestionsToShow.length > 0 &&
+                                suggestionsToShow.slice(0, 3).map((suggestion) => (
+                                    <CarouselElement key={suggestion}>
+                                        <Button
+                                            type="text"
+                                            onClick={() =>
+                                                navigateToSearchUrl({
+                                                    type: undefined,
+                                                    query: suggestion,
+                                                    history,
+                                                    entityRegistry,
+                                                })
+                                            }
+                                        >
+                                            <SubHeaderText>{truncate(suggestion, 40)}</SubHeaderText>
+                                        </Button>
+                                    </CarouselElement>
+                                ))}
+                        </Carousel>
+                    </CarouselContainer>
+                )}
+            </SuggestionsContainer>
         </Background>
     );
 };


### PR DESCRIPTION
Setting the container of the homepage elements to a fixed height so it doesn't jitter on load.

![image](https://user-images.githubusercontent.com/2455694/128577572-7f4ff6e6-bcef-4070-a708-8bbe937d465d.png)

![image](https://user-images.githubusercontent.com/2455694/128577575-daf44152-76f8-43ad-a53c-7645a4fc4747.png)

(review suggestion: selecting hide widespace changes makes the diff much simper)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
