### PR TITLE
feat(datahub-cli): datahub init & docs for it

### DIFF
--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -2,6 +2,17 @@
 
 There are a two ways to delete data from DataHub.
 
+
+## Configuring DataHub CLI
+
+By default, the CLI will point to localhost DataHub. To point to a different instance, 
+you'll need to configure your CLI by running
+
+```aidl
+datahub init
+```
+
+
 ## Delete By Urn
 
 To delete all the data related to a single entity, run

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -13,6 +13,7 @@ datahub init
 
 will allow you to customize the datahub instance you are communicating with.
 
+_Note: Provide your GMS instance's host when the prompt asks you for the DataHub host._
 
 ## Delete By Urn
 

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -5,12 +5,13 @@ There are a two ways to delete data from DataHub.
 
 ## Configuring DataHub CLI
 
-By default, the CLI will point to localhost DataHub. To point to a different instance, 
-you'll need to configure your CLI by running
+The CLI will point to localhost DataHub by default. Running
 
 ```aidl
 datahub init
 ```
+
+will allow you to customize the datahub instance you are communicating with.
 
 
 ## Delete By Urn

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -7,7 +7,7 @@ There are a two ways to delete data from DataHub.
 
 The CLI will point to localhost DataHub by default. Running
 
-```aidl
+```
 datahub init
 ```
 
@@ -18,7 +18,7 @@ will allow you to customize the datahub instance you are communicating with.
 
 To delete all the data related to a single entity, run
 
-```aidl
+```
 datahub delete --urn "<my urn>"
 ```
 
@@ -30,13 +30,13 @@ Whenever you run `datahub ingest -c ...`, all the metadata ingested with that ru
 
 To view the ids of the most recent set of ingestion batches, execute
 
-```aidl
+```
 datahub ingest list-runs
 ```
 
 That will print out a table of all the runs. Once you have an idea of which run you want to roll back, run
 
-```aidl
+```
 datahub ingest show --run-id <run-id>
 ```
 
@@ -44,7 +44,7 @@ to see more info of the run.
 
 Finally, run
 
-```aidl
+```
 datahub ingest rollback --run-id <run-id>
 ```
 

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -23,7 +23,7 @@ class DatahubConfig(BaseModel):
     gms: GmsConfig
 
 
-def write_datahub_config(host: str, token: Optional[str]):
+def write_datahub_config(host: str, token: Optional[str]) -> None:
     config = {
         "gms": {
             "server": host,
@@ -32,6 +32,7 @@ def write_datahub_config(host: str, token: Optional[str]):
     }
     with open(DATAHUB_CONFIG_PATH, "w+") as outfile:
         yaml.dump(config, outfile, default_flow_style=False)
+    return None
 
 
 def get_session_and_host():
@@ -72,7 +73,9 @@ def get_session_and_host():
         }
     )
     if isinstance(gms_token, str) and len(gms_token) > 0:
-        session.headers.update({"Authorization": f"Bearer {gms_token}"})
+        session.headers.update(
+            {"Authorization": f"Bearer {gms_token.format(**os.environ)}"}
+        )
 
     return session, gms_host
 
@@ -97,8 +100,8 @@ def parse_run_restli_response(response):
 
 
 def post_rollback_endpoint(
-        payload_obj: dict,
-        path: str,
+    payload_obj: dict,
+    path: str,
 ) -> typing.Tuple[typing.List[typing.List[str]], int, int]:
     session, gms_host = get_session_and_host()
     url = gms_host + path
@@ -130,8 +133,8 @@ def post_rollback_endpoint(
 
 
 def post_delete_endpoint(
-        payload_obj: dict,
-        path: str,
+    payload_obj: dict,
+    path: str,
 ) -> typing.Tuple[str, int]:
     session, gms_host = get_session_and_host()
     url = gms_host + path

--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -13,13 +13,6 @@ from pydantic import BaseModel, ValidationError
 CONDENSED_DATAHUB_CONFIG_PATH = "~/.datahubenv"
 DATAHUB_CONFIG_PATH = os.path.expanduser(CONDENSED_DATAHUB_CONFIG_PATH)
 
-DEFAULT_DATAHUB_CONFIG = {
-    "gms": {
-        "server": "http://localhost:8080",
-        "token": "",
-    }
-}
-
 
 class GmsConfig(BaseModel):
     server: str
@@ -28,6 +21,17 @@ class GmsConfig(BaseModel):
 
 class DatahubConfig(BaseModel):
     gms: GmsConfig
+
+
+def write_datahub_config(host: str, token: Optional[str]):
+    config = {
+        "gms": {
+            "server": host,
+            "token": token,
+        }
+    }
+    with open(DATAHUB_CONFIG_PATH, "w+") as outfile:
+        yaml.dump(config, outfile, default_flow_style=False)
 
 
 def get_session_and_host():
@@ -40,9 +44,7 @@ def get_session_and_host():
             f"No {CONDENSED_DATAHUB_CONFIG_PATH} file found, generating one for you...",
             bold=True,
         )
-
-        with open(DATAHUB_CONFIG_PATH, "w+") as outfile:
-            yaml.dump(DEFAULT_DATAHUB_CONFIG, outfile, default_flow_style=False)
+        write_datahub_config(gms_host, gms_token)
 
     with open(DATAHUB_CONFIG_PATH, "r") as stream:
         try:
@@ -95,8 +97,8 @@ def parse_run_restli_response(response):
 
 
 def post_rollback_endpoint(
-    payload_obj: dict,
-    path: str,
+        payload_obj: dict,
+        path: str,
 ) -> typing.Tuple[typing.List[typing.List[str]], int, int]:
     session, gms_host = get_session_and_host()
     url = gms_host + path
@@ -128,8 +130,8 @@ def post_rollback_endpoint(
 
 
 def post_delete_endpoint(
-    payload_obj: dict,
-    path: str,
+        payload_obj: dict,
+        path: str,
 ) -> typing.Tuple[str, int]:
     session, gms_host = get_session_and_host()
     url = gms_host + path

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -70,7 +70,9 @@ def init() -> None:
         "Enter your DataHub host", type=str, default="http://localhost:8080"
     )
     token = click.prompt(
-        "Enter your DataHub access token (Supports env vars via `{VAR_NAME}` syntax)", type=str, default=""
+        "Enter your DataHub access token (Supports env vars via `{VAR_NAME}` syntax)",
+        type=str,
+        default="",
     )
     write_datahub_config(host, token)
 

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -7,7 +7,7 @@ import stackprinter
 
 import datahub as datahub_package
 from datahub.cli.check_cli import check
-from datahub.cli.cli_utils import write_datahub_config, DATAHUB_CONFIG_PATH
+from datahub.cli.cli_utils import DATAHUB_CONFIG_PATH, write_datahub_config
 from datahub.cli.delete_cli import delete
 from datahub.cli.docker import docker
 from datahub.cli.ingest_cli import ingest
@@ -66,8 +66,12 @@ def init() -> None:
         click.confirm(f"{DATAHUB_CONFIG_PATH} already exists. Overwrite?", abort=True)
 
     click.echo("Configure which datahub instance to connect to")
-    host = click.prompt('Enter your DataHub host', type=str, default='http://localhost:8080')
-    token = click.prompt('(Optional) Enter your DataHub access token', type=str, default='')
+    host = click.prompt(
+        "Enter your DataHub host", type=str, default="http://localhost:8080"
+    )
+    token = click.prompt(
+        "Enter your DataHub access token (Supports env vars via `{VAR_NAME}` syntax)", type=str, default=""
+    )
     write_datahub_config(host, token)
 
     click.echo(f"Written to {DATAHUB_CONFIG_PATH}")

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -7,6 +7,7 @@ import stackprinter
 
 import datahub as datahub_package
 from datahub.cli.check_cli import check
+from datahub.cli.cli_utils import write_datahub_config, DATAHUB_CONFIG_PATH
 from datahub.cli.delete_cli import delete
 from datahub.cli.docker import docker
 from datahub.cli.ingest_cli import ingest
@@ -56,6 +57,20 @@ def version() -> None:
     """Print version number and exit."""
     click.echo(f"DataHub CLI version: {datahub_package.nice_version_name()}")
     click.echo(f"Python version: {sys.version}")
+
+
+@datahub.command()
+def init() -> None:
+    """Configure which datahub instance to connect to"""
+    if os.path.isfile(DATAHUB_CONFIG_PATH):
+        click.confirm(f"{DATAHUB_CONFIG_PATH} already exists. Overwrite?", abort=True)
+
+    click.echo("Configure which datahub instance to connect to")
+    host = click.prompt('Enter your DataHub host', type=str, default='http://localhost:8080')
+    token = click.prompt('(Optional) Enter your DataHub access token', type=str, default='')
+    write_datahub_config(host, token)
+
+    click.echo(f"Written to {DATAHUB_CONFIG_PATH}")
 
 
 datahub.add_command(check)


### PR DESCRIPTION
Add an easy way to configure datahub cli for remote instances.

```
(venv) ➜  datahub init
Configure which datahub instance to connect to
Enter your DataHub host [http://localhost:8080]: 
(Optional) Enter your DataHub access token []: 
Written to /Users/gabe/.datahubenv

(venv) ➜ datahub init
/Users/gabe/.datahubenv already exists. Overwrite? [y/N]: y
Configure which datahub instance to connect to
Enter your DataHub host [http://localhost:8080]: 
(Optional) Enter your DataHub access token []: 
Written to /Users/gabe/.datahubenv
```


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
