### PR TITLE
fix(quickstart): Remove mem_limit for datahub containers

### DIFF
--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -38,7 +38,6 @@ services:
     - ELASTIC_CLIENT_PORT=9200
     hostname: datahub-frontend-react
     image: linkedin/datahub-frontend-react:${DATAHUB_VERSION:-head}
-    mem_limit: 512m
     ports:
     - 9002:9002
   datahub-gms:
@@ -63,7 +62,6 @@ services:
     - MCE_CONSUMER_ENABLED=true
     hostname: datahub-gms
     image: linkedin/datahub-gms:${DATAHUB_VERSION:-head}
-    mem_limit: 512m
     ports:
     - 8080:8080
   elasticsearch:

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -38,7 +38,6 @@ services:
     - ELASTIC_CLIENT_PORT=9200
     hostname: datahub-frontend-react
     image: linkedin/datahub-frontend-react:${DATAHUB_VERSION:-head}
-    mem_limit: 512m
     ports:
     - 9002:9002
   datahub-gms:
@@ -67,7 +66,6 @@ services:
     - MCE_CONSUMER_ENABLED=true
     hostname: datahub-gms
     image: linkedin/datahub-gms:${DATAHUB_VERSION:-head}
-    mem_limit: 512m
     ports:
     - 8080:8080
   elasticsearch:

--- a/docker/quickstart/generate_docker_quickstart.py
+++ b/docker/quickstart/generate_docker_quickstart.py
@@ -17,8 +17,6 @@ omitted_services = [
 # Note that these are upper bounds on memory usage. Once exceeded, the container is killed.
 # Each service will be configured to use much less Java heap space than allocated here.
 mem_limits = {
-    "datahub-gms": "512m",
-    "datahub-frontend-react": "512m",
     "elasticsearch": "1g",
 }
 


### PR DESCRIPTION
Remove mem_limit for datahub containers. Instead rely on JAVA_OPTS

```
051e80257213   datahub-frontend-react   1.78%     295.1MiB / 3.844GiB   7.50%     3.04kB / 555B   5.07MB / 0B       25
4deef6cf82ec   schema-registry          1.10%     182.4MiB / 3.844GiB   4.63%     364kB / 352kB   58.2MB / 8.19kB   34
b7ea3a0c4d62   datahub-gms              50.27%    840.5MiB / 3.844GiB   21.35%    679kB / 749kB   209MB / 0B        93
fb96b242a938   broker                   10.59%    299.7MiB / 3.844GiB   7.61%     948kB / 749kB   26.7MB / 537kB    73
fc47d4917b17   mysql                    3.01%     170.3MiB / 3.844GiB   4.33%     315kB / 241kB   40.8MB / 347MB    31
5af639f9b884   neo4j                    1.53%     393.1MiB / 3.844GiB   9.98%     11kB / 6.78kB   172MB / 119MB     44
75f0b5e36084   elasticsearch            44.34%    470.4MiB / 1GiB       45.94%    164kB / 84kB    140MB / 4.23MB    62
89886cee01f2   zookeeper                0.23%     78.34MiB / 3.844GiB   1.99%     275kB / 453kB   34MB / 831kB      39
```

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
