### PR TITLE
fix(nested avro): hide unqualifying schemas

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/translateFieldPath.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/translateFieldPath.test.tsx
@@ -30,4 +30,8 @@ describe('translateFieldPath', () => {
     it('leaves old fieldpaths as is', () => {
         expect(translateFieldPath('a.b.c')).toEqual('a.b.c');
     });
+
+    it('does not return struct names if there are no field names', () => {
+        expect(translateFieldPath('[type=ParentStruct].[type=ChildStruct]')).toEqual('');
+    });
 });

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/utils/translateFieldPathSegment.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/utils/translateFieldPathSegment.tsx
@@ -30,13 +30,13 @@ export default function translateFieldPathSegment(fieldPathSegment, i, fieldPath
     // we convert into union_field. (QualifiedStruct) qualified_struct_field
     if (fieldPathSegment.startsWith('[type=') && fieldPathSegment.endsWith(']')) {
         const typeName = fieldPathSegment.replace('[type=', '').replace(']', '');
-        // if the qualified struct is the last element, just show the qualified struct
-        if (i === fieldPathParts.length - 1) {
-            return ` ${typeName}`;
-        }
 
         // if the qualified struct is not the last element, surround with parens
         if (previousSegment === UNION_TOKEN) {
+            // if the qualified struct is the last element, just show the qualified struct
+            if (i === fieldPathParts.length - 1) {
+                return ` ${typeName}`;
+            }
             return `(${typeName}) `;
         }
 


### PR DESCRIPTION
If a struct is not qualifying a union, we don't want to show it in the field path

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
