### PR TITLE
fix(nested avro): fixing key / value schemas after adding version

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/schema/translateFieldPath.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/schema/translateFieldPath.test.tsx
@@ -1,4 +1,4 @@
-import translateFieldPath from '../schema/utils/translateFieldPath';
+import translateFieldPath from '../../schema/utils/translateFieldPath';
 
 describe('translateFieldPath', () => {
     it('translates qualified unions', () => {

--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/schema/translateFieldPathSegment.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/schema/translateFieldPathSegment.test.tsx
@@ -1,4 +1,4 @@
-import translateFieldPathSegment from '../schema/utils/translateFieldPathSegment';
+import translateFieldPathSegment from '../../schema/utils/translateFieldPathSegment';
 
 describe('translateFieldPathSegment', () => {
     it('translates unions', () => {

--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/schema/utils.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/schema/utils.test.tsx
@@ -1,0 +1,49 @@
+import { SchemaFieldDataType } from '../../../../../../types.generated';
+import { filterKeyFieldPath } from '../../schema/utils/utils';
+
+describe('utils', () => {
+    describe('filterKeyFieldPath', () => {
+        it('allows keys when looking for keys', () => {
+            expect(
+                filterKeyFieldPath(true, {
+                    fieldPath: '[version=2.0].[key=True].[type=long].field',
+                    nullable: false,
+                    type: SchemaFieldDataType.Number,
+                    recursive: false,
+                }),
+            ).toEqual(true);
+        });
+        it('blocks non-keys when looking for keys', () => {
+            expect(
+                filterKeyFieldPath(true, {
+                    fieldPath: '[version=2.0].[type=long].field',
+                    nullable: false,
+                    type: SchemaFieldDataType.Number,
+                    recursive: false,
+                }),
+            ).toEqual(false);
+        });
+
+        it('allows non-keys when looking for non-keys', () => {
+            expect(
+                filterKeyFieldPath(false, {
+                    fieldPath: '[version=2.0].[type=long].field',
+                    nullable: false,
+                    type: SchemaFieldDataType.Number,
+                    recursive: false,
+                }),
+            ).toEqual(true);
+        });
+
+        it('blocks keys when looking for non-keys', () => {
+            expect(
+                filterKeyFieldPath(false, {
+                    fieldPath: '[version=2.0].[key=True].[type=long].field',
+                    nullable: false,
+                    type: SchemaFieldDataType.Number,
+                    recursive: false,
+                }),
+            ).toEqual(false);
+        });
+    });
+});

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -64,7 +64,7 @@ export default function SchemaView({
     });
 
     const hasKeySchema = useMemo(
-        () => (schema?.fields?.findIndex((field) => field.fieldPath.startsWith(KEY_SCHEMA_PREFIX)) || -1) !== -1,
+        () => (schema?.fields?.findIndex((field) => field.fieldPath.indexOf(KEY_SCHEMA_PREFIX) > -1) || -1) !== -1,
         [schema],
     );
 

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/utils/utils.ts
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/utils/utils.ts
@@ -46,7 +46,7 @@ export function convertEditableSchemaMetadataForUpdate(
 }
 
 export function filterKeyFieldPath(showKeySchema: boolean, field: SchemaField) {
-    return field.fieldPath.startsWith(KEY_SCHEMA_PREFIX) ? showKeySchema : !showKeySchema;
+    return field.fieldPath.indexOf(KEY_SCHEMA_PREFIX) > -1 ? showKeySchema : !showKeySchema;
 }
 
 export function downgradeV2FieldPath(fieldPath?: string | null) {

--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -206,7 +206,7 @@
               },
               "fields": [
                 {
-                  "fieldPath": "field_foo_2",
+                  "fieldPath": "[version=2.0].[type=boolean].field_foo_2",
                   "jsonPath": null,
                   "nullable": false,
                   "description": {
@@ -224,11 +224,26 @@
                   "recursive": false
                 },
                 {
-                  "fieldPath": "field_bar",
+                  "fieldPath": "[version=2.0].[type=boolean].field_bar",
                   "jsonPath": null,
                   "nullable": false,
                   "description": {
                     "string": "Bar field description"
+                  },
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.BooleanType": {}
+                    }
+                  },
+                  "nativeDataType": "boolean",
+                  "recursive": false
+                },
+                {
+                  "fieldPath": "[version=2.0].[key=True].[type=int].id",
+                  "jsonPath": null,
+                  "nullable": false,
+                  "description": {
+                    "string": "Id specifying which partition the message should go to"
                   },
                   "type": {
                     "type": {


### PR DESCRIPTION
Key/Value schemas broke after adding the version prefix. This pr fixes that case, and also adds tests & sample data to prevent this from happening again so easily.

![image](https://user-images.githubusercontent.com/2455694/129286695-51d893c5-74d5-4a50-9817-a365b9cfbf0a.png)