### PR TITLE
fix(ingest): increasing default ingestion REST timeout to 30 seconds

### DIFF
--- a/metadata-ingestion/sink_docs/datahub.md
+++ b/metadata-ingestion/sink_docs/datahub.md
@@ -35,7 +35,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | Field    | Required | Default | Description                  |
 | -------- | -------- | ------- | ---------------------------- |
 | `server` | ✅       |         | URL of DataHub GMS endpoint. |
-| `timeout_sec` |     | 2       | Per-HTTP request timeout.    |
+| `timeout_sec` |     | 30      | Per-HTTP request timeout.    |
 
 ## DataHub Kafka
 

--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -39,9 +39,9 @@ def _make_curl_command(
 
 
 class DatahubRestEmitter:
-    DEFAULT_CONNECT_TIMEOUT_SEC = 10  # 10 seconds should be plenty to connect
+    DEFAULT_CONNECT_TIMEOUT_SEC = 30  # 30 seconds should be plenty to connect
     DEFAULT_READ_TIMEOUT_SEC = (
-        2  # Any ingest call taking longer than 2 seconds should be abandoned
+        30  # Any ingest call taking longer than 30 seconds should be abandoned
     )
 
     _gms_server: str


### PR DESCRIPTION
After the latest release, there are numerous reports that ingestion is timing out for folks due to latencies in environments. 
Increasing the default timeout to 30 seconds to avoid unnecessary failures, while still being robust to complete outages. 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
