### PR TITLE
fix(schema version): temporarily hide schema version tab

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaHeader.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaHeader.tsx
@@ -8,9 +8,11 @@ const SchemaHeaderContainer = styled.div<{ edit?: string }>`
     ${(props) => (props.edit ? 'justify-content: flex-end; padding-bottom: 16px;' : 'justify-content: space-between;')}
 `;
 
+// TODO(Gabe): undo display: none when dbt/bigquery flickering has been resolved
 const ShowVersionButton = styled(Button)`
     display: inline-block;
     margin-right: 10px;
+    display: none;
 `;
 
 const KeyButton = styled(Button)`


### PR DESCRIPTION
Schema version in its current form has caused some confusion for users, hiding it until we can iterate a bit more.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
