### PR TITLE
feat(ingestion): Bring your own SQL parser

### DIFF
--- a/metadata-ingestion/source_docs/lookml.md
+++ b/metadata-ingestion/source_docs/lookml.md
@@ -53,11 +53,13 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `view_pattern.ignoreCase`  |          | `True` | Whether to ignore case sensitivity during pattern matching.                                                                                                                                  |
 | `env`                                          |          | `"PROD"`   | Environment to use in namespace when constructing URNs.                 |
 | `parse_table_names_from_sql`                   |          | `False`    | See note below.                                                         |
+| `sql_parser`                                   |          | `datahub.utilities.sql_parser.DefaultSQLParser`    | See note below.                                                         |
 
-Note! The integration can use [`sql-metadata`](https://pypi.org/project/sql-metadata/) to try to parse the tables the
-views depends on. As these SQL's can be complicated, and the package doesn't official support all the SQL dialects that
-Looker supports, the result might not be correct. This parsing is disabled by default, but can be enabled by setting
-`parse_table_names_from_sql: True`.
+Note! The integration can use an SQL parser to try to parse the tables the views depends on. This parsing is disabled by default, 
+but can be enabled by setting `parse_table_names_from_sql: True`.  The default parser is based on the [`sql-metadata`](https://pypi.org/project/sql-metadata/) package. 
+As this package doesn't officially support all the SQL dialects that Looker supports, the result might not be correct. You can, however, implement a
+custom parser and take it into use by setting the `sql_parser` configuration value. A custom SQL parser must inherit from `datahub.utilities.sql_parser.SQLParser`
+and must be made available to Datahub by ,for example, installing it. The configuration then needs to be set to `module_name.ClassName` of the parser.
 
 ## Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -70,9 +70,9 @@ class LookMLSourceConfig(ConfigModel):
     parse_table_names_from_sql: bool = False
     # This source can be configured to use a custom SQL parser.
     # A custom SQL parser must inherit from datahub.utilities.sql_parser.SQLParser
-    # and must be made available to Datahub for example by installing or placing it in the
-    # same directory as your ingestion recipe. The configuration value below then needs
-    # to be set to module_name.ClassName of the parser.
+    # and must be made available to Datahub for example by installing it.
+    # The configuration value below then needs to be set to module_name.ClassName
+    # of the parser.
     sql_parser: str = "datahub.utilities.sql_parser.DefaultSQLParser"
 
 
@@ -261,7 +261,11 @@ class LookerView:
 
     @classmethod
     def _import_sql_parser_cls(cls, sql_parser_path: str) -> Type[SQLParser]:
+        assert "." in sql_parser_path, "sql_parser-path must contain a ."
         module_name, cls_name = sql_parser_path.rsplit(".", 1)
+        import sys
+
+        logger.info(sys.path)
         parser_cls = getattr(importlib.import_module(module_name), cls_name)
         if not issubclass(parser_cls, SQLParser):
             raise ValueError(f"must be derived from {SQLParser}; got {parser_cls}")

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -68,6 +68,11 @@ class LookMLSourceConfig(ConfigModel):
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     env: str = builder.DEFAULT_ENV
     parse_table_names_from_sql: bool = False
+    # This source can be configured to use a custom SQL parser.
+    # A custom SQL parser must inherit from datahub.utilities.sql_parser.SQLParser
+    # and must be made available to Datahub for example by installing or placing it in the
+    # same directory as your ingestion recipe. The configuration value below then needs
+    # to be set to module_name.ClassName of the parser.
     sql_parser: str = "datahub.utilities.sql_parser.DefaultSQLParser"
 
 
@@ -258,6 +263,8 @@ class LookerView:
     def _import_sql_parser_cls(cls, sql_parser_path: str) -> Type[SQLParser]:
         module_name, cls_name = sql_parser_path.rsplit(".", 1)
         parser_cls = getattr(importlib.import_module(module_name), cls_name)
+        if not issubclass(parser_cls, SQLParser):
+            raise ValueError(f"must be derived from {SQLParser}; got {parser_cls}")
 
         return parser_cls
 

--- a/metadata-ingestion/src/datahub/ingestion/source/lookml.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/lookml.py
@@ -68,11 +68,6 @@ class LookMLSourceConfig(ConfigModel):
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     env: str = builder.DEFAULT_ENV
     parse_table_names_from_sql: bool = False
-    # This source can be configured to use a custom SQL parser.
-    # A custom SQL parser must inherit from datahub.utilities.sql_parser.SQLParser
-    # and must be made available to Datahub for example by installing it.
-    # The configuration value below then needs to be set to module_name.ClassName
-    # of the parser.
     sql_parser: str = "datahub.utilities.sql_parser.DefaultSQLParser"
 
 

--- a/metadata-ingestion/src/datahub/utilities/sql_parser.py
+++ b/metadata-ingestion/src/datahub/utilities/sql_parser.py
@@ -1,0 +1,25 @@
+from abc import abstractmethod, ABCMeta
+
+from typing import List
+
+try:
+    from sql_metadata import Parser as MetadataSQLParser
+except ImportError:
+    pass
+
+
+class SQLParser(metaclass=ABCMeta):
+    def __init__(self, sql_query: str) -> None:
+        self._sql_query = sql_query
+
+    @abstractmethod
+    def get_tables(self) -> List[str]:
+        pass
+
+
+class DefaultSQLParser(SQLParser):
+    def __init__(self, sql_query: str) -> None:
+        self._parser = MetadataSQLParser(sql_query)
+
+    def get_tables(self) -> List[str]:
+        return self._parser.tables

--- a/metadata-ingestion/src/datahub/utilities/sql_parser.py
+++ b/metadata-ingestion/src/datahub/utilities/sql_parser.py
@@ -1,5 +1,4 @@
-from abc import abstractmethod, ABCMeta
-
+from abc import ABCMeta, abstractmethod
 from typing import List
 
 try:
@@ -19,6 +18,7 @@ class SQLParser(metaclass=ABCMeta):
 
 class DefaultSQLParser(SQLParser):
     def __init__(self, sql_query: str) -> None:
+        # handle module not found.
         self._parser = MetadataSQLParser(sql_query)
 
     def get_tables(self) -> List[str]:

--- a/metadata-ingestion/src/datahub/utilities/sql_parser.py
+++ b/metadata-ingestion/src/datahub/utilities/sql_parser.py
@@ -18,7 +18,6 @@ class SQLParser(metaclass=ABCMeta):
 
 class DefaultSQLParser(SQLParser):
     def __init__(self, sql_query: str) -> None:
-        # handle module not found.
         self._parser = MetadataSQLParser(sql_query)
 
     def get_tables(self) -> List[str]:

--- a/metadata-ingestion/tests/unit/test_utilities.py
+++ b/metadata-ingestion/tests/unit/test_utilities.py
@@ -1,5 +1,6 @@
 from datahub.utilities.delayed_iter import delayed_iter
 from datahub.utilities.groupby import groupby_unsorted
+from datahub.utilities.sql_parser import DefaultSQLParser
 
 
 def test_delayed_iter():
@@ -44,3 +45,11 @@ def test_groupby_unsorted():
         ("B", ["B"]),
         ("C", ["C", "C"]),
     ]
+
+
+def test_default_sql_parser():
+    sql_query = "SELECT foo.a, foo.b, bar.c FROM foo JOIN bar ON (foo.a == bar.b);"
+
+    tables_list = DefaultSQLParser(sql_query).get_tables()
+
+    assert tables_list == ["foo", "bar"]

--- a/metadata-ingestion/tests/unit/test_utilities.py
+++ b/metadata-ingestion/tests/unit/test_utilities.py
@@ -1,3 +1,5 @@
+import pytest
+
 from datahub.utilities.delayed_iter import delayed_iter
 from datahub.utilities.groupby import groupby_unsorted
 from datahub.utilities.sql_parser import DefaultSQLParser
@@ -47,6 +49,7 @@ def test_groupby_unsorted():
     ]
 
 
+@pytest.mark.integration
 def test_default_sql_parser():
     sql_query = "SELECT foo.a, foo.b, bar.c FROM foo JOIN bar ON (foo.a == bar.b);"
 

--- a/metadata-ingestion/tests/unit/test_utilities.py
+++ b/metadata-ingestion/tests/unit/test_utilities.py
@@ -1,5 +1,6 @@
-import pytest
 import sys
+
+import pytest
 
 from datahub.utilities.delayed_iter import delayed_iter
 from datahub.utilities.groupby import groupby_unsorted

--- a/metadata-ingestion/tests/unit/test_utilities.py
+++ b/metadata-ingestion/tests/unit/test_utilities.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 from datahub.utilities.delayed_iter import delayed_iter
 from datahub.utilities.groupby import groupby_unsorted
@@ -50,6 +51,9 @@ def test_groupby_unsorted():
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="The LookML source requires Python 3.7+"
+)
 def test_default_sql_parser():
     sql_query = "SELECT foo.a, foo.b, bar.c FROM foo JOIN bar ON (foo.a == bar.b);"
 


### PR DESCRIPTION
This PR makes it possible to configure the the SQL Parser used in the LookML-source. The rational is that Looker supports DB backends that common SQL parsers don't support (an example being Snowflake), and relying on the default SQL parser might fail or, even worse, produce erroneous results. After this change, users can define their own SQL parsers, which e.g. relying on EXPLAIN-queries to the database, producing more reliable results.  

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)