### PR TITLE
feat(ingest): Add custom browse paths for kafka sources and remove browse lowercase filter

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/aws/glue.py
@@ -429,31 +429,27 @@ class GlueSource(Source):
         return all_tables
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-
         tables = self.get_all_tables()
-
         for table in tables:
             database_name = table["DatabaseName"]
             table_name = table["Name"]
             full_table_name = f"{database_name}.{table_name}"
             self.report.report_table_scanned()
-            if not self.source_config.database_pattern.allowed(
-                database_name
-            ) or not self.source_config.table_pattern.allowed(full_table_name):
+            if self.source_config.database_pattern.allowed(database_name):
+                if self.source_config.table_pattern.allowed(table_name):
+                    mce = self._extract_record(table, full_table_name)
+                    workunit = MetadataWorkUnit(full_table_name, mce=mce)
+                    self.report.report_workunit(workunit)
+                    yield workunit
+            else:
                 self.report.report_table_dropped(full_table_name)
                 continue
-
-            mce = self._extract_record(table, full_table_name)
-            workunit = MetadataWorkUnit(full_table_name, mce=mce)
-            self.report.report_workunit(workunit)
-            yield workunit
 
         if self.extract_transforms:
 
             dags = {}
 
             for job in self.get_all_jobs():
-
                 flow_urn = mce_builder.make_data_flow_urn(
                     self.get_underlying_platform(), job["Name"], self.env
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -24,6 +24,7 @@ from datahub.metadata.com.linkedin.pegasus2avro.schema import (
     SchemaField,
     SchemaMetadata,
 )
+from datahub.metadata.schema_classes import BrowsePathsClass
 
 logger = logging.getLogger(__name__)
 
@@ -156,6 +157,11 @@ class KafkaSource(Source):
                 fields=key_fields + fields,
             )
             dataset_snapshot.aspects.append(schema_metadata)
+
+        browse_path = BrowsePathsClass(
+            [f"/{self.source_config.env.lower()}/{platform}/{topic}"]
+        )
+        dataset_snapshot.aspects.append(browse_path)
 
         metadata_record = MetadataChangeEvent(proposedSnapshot=dataset_snapshot)
         return metadata_record

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/IndexBuilder.java
@@ -2,12 +2,18 @@ package com.linkedin.metadata.search.elasticsearch.indexbuilder;
 
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -15,13 +21,9 @@ import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.ReindexRequest;
-
-import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 
 @Slf4j
@@ -55,13 +57,25 @@ public class IndexBuilder {
         .getSourceAsMap();
 
     MapDifference<String, Object> mappingsDiff = Maps.difference(mappings, oldMappings);
+
+    Settings oldSettings = searchClient.indices()
+        .getSettings(new GetSettingsRequest().indices(indexName), RequestOptions.DEFAULT)
+        .getIndexToSettings()
+        .valuesIt()
+        .next();
+
     // If there are no updates to mappings, return
-    if (mappingsDiff.areEqual()) {
+    if (mappingsDiff.areEqual() && equals(settings, oldSettings)) {
       log.info("No updates to index {}", indexName);
       return;
     }
 
-    log.info("There's diff between new mappings (left) and old mappings (right): {}", mappingsDiff.toString());
+    if (!mappingsDiff.areEqual()) {
+      log.info("There's diff between new mappings (left) and old mappings (right): {}", mappingsDiff.toString());
+    } else {
+      log.info("There's an update to settings");
+    }
+
     String tempIndexName = indexName + "_" + System.currentTimeMillis();
     createIndex(tempIndexName, mappings, settings);
     try {
@@ -101,8 +115,8 @@ public class IndexBuilder {
     log.info("Reindex from {} to {} succeeded", indexName, tempIndexName);
     String indexNamePattern = indexName + "_*";
     // Check if the original index is aliased or not
-    GetAliasesResponse aliasesResponse =
-        searchClient.indices().getAlias(new GetAliasesRequest(indexName).indices(indexNamePattern), RequestOptions.DEFAULT);
+    GetAliasesResponse aliasesResponse = searchClient.indices()
+        .getAlias(new GetAliasesRequest(indexName).indices(indexNamePattern), RequestOptions.DEFAULT);
     // If not aliased, delete the original index
     if (aliasesResponse.getAliases().isEmpty()) {
       searchClient.indices().delete(new DeleteIndexRequest().indices(indexName), RequestOptions.DEFAULT);
@@ -134,5 +148,39 @@ public class IndexBuilder {
     createIndexRequest.settings(settings);
     searchClient.indices().create(createIndexRequest, RequestOptions.DEFAULT);
     log.info("Created index {}", indexName);
+  }
+
+  private boolean equals(Map<String, Object> newSettings, Settings oldSettings) {
+    if (!newSettings.containsKey("index") || !((Map<String, Object>) newSettings.get("index")).containsKey(
+        "analysis")) {
+      return true;
+    }
+    Map<String, Object> newAnalysis =
+        (Map<String, Object>) ((Map<String, Object>) newSettings.get("index")).get("analysis");
+    Settings oldAnalysis = oldSettings.getByPrefix("index.analysis.");
+    return equalsGroup(newAnalysis, oldAnalysis);
+  }
+
+  private boolean equalsGroup(Map<String, Object> newSettings, Settings oldSettings) {
+    if (!newSettings.keySet().equals(oldSettings.names())) {
+      return false;
+    }
+
+    for (String key : newSettings.keySet()) {
+      if (newSettings.get(key) instanceof Map) {
+        if (!equalsGroup((Map<String, Object>) newSettings.get(key), oldSettings.getByPrefix(key + "."))) {
+          return false;
+        }
+      } else if (newSettings.get(key) instanceof List) {
+        if (!newSettings.get(key).equals(oldSettings.getAsList(key))) {
+          return false;
+        }
+      } else {
+        if (!newSettings.get(key).toString().equals(oldSettings.get(key))) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
@@ -98,7 +98,6 @@ public class SettingsBuilder {
 
     // Analyzer for matching browse path
     analyzers.put("browse_path_hierarchy", ImmutableMap.<String, Object>builder().put("tokenizer", "path_hierarchy")
-        .put("filter", ImmutableList.of("lowercase"))
         .build());
 
     // Analyzer for case-insensitive exact matching - Only used when building queries


### PR DESCRIPTION
Add custom browse paths for kafka sources, so it does not separate on dots. 

Also removed the lowercase filter for browse, and added a way to reindex all indices on settings change. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
