### PR TITLE
fix(gms): actually load keys from keystore for elastic connections

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticsearchSSLContextFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticsearchSSLContextFactory.java
@@ -45,6 +45,9 @@ public class ElasticsearchSSLContextFactory {
     @Value("${ELASTICSEARCH_SSL_KEYSTORE_PASSWORD:#{null}}")
     private String sslKeyStorePassword;
 
+    @Value("${ELASTICSEARCH_SSL_KEYSTORE_KEY_PASSWORD:#{null}}")
+    private String sslKeyStoreKeyPassword;
+
     @Bean(name = "elasticSearchSSLContext")
     public SSLContext createInstance() {
         final SSLContextBuilder sslContextBuilder = new SSLContextBuilder();
@@ -56,8 +59,8 @@ public class ElasticsearchSSLContextFactory {
             loadTrustStore(sslContextBuilder, sslTrustStoreFile, sslTrustStoreType, sslTrustStorePassword);
         }
 
-        if (sslKeyStoreFile != null && sslKeyStoreType != null && sslKeyStorePassword != null) {
-            loadKeyStore(sslContextBuilder, sslKeyStoreFile, sslKeyStoreType, sslKeyStorePassword);
+        if (sslKeyStoreFile != null && sslKeyStoreType != null && sslKeyStorePassword != null && sslKeyStoreKeyPassword != null) {
+            loadKeyStore(sslContextBuilder, sslKeyStoreFile, sslKeyStoreType, sslKeyStorePassword, sslKeyStoreKeyPassword);
         }
 
         final SSLContext sslContext;
@@ -73,11 +76,11 @@ public class ElasticsearchSSLContextFactory {
     }
 
     private void loadKeyStore(@Nonnull SSLContextBuilder sslContextBuilder, @Nonnull String path,
-                                     @Nonnull String type, @Nonnull String password) {
+                              @Nonnull String type, @Nonnull String password, @Nonnull String sslKeyStoreKeyPassword) {
         try (InputStream identityFile = new FileInputStream(path)) {
             final KeyStore keystore = KeyStore.getInstance(type);
             keystore.load(identityFile, password.toCharArray());
-            sslContextBuilder.loadKeyMaterial(keystore, null);
+            sslContextBuilder.loadKeyMaterial(keystore, sslKeyStoreKeyPassword.toCharArray());
         } catch (IOException | CertificateException | NoSuchAlgorithmException | KeyStoreException | UnrecoverableKeyException e) {
             throw new RuntimeException("Failed to load key store: " + path, e);
         }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticsearchSSLContextFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticsearchSSLContextFactory.java
@@ -45,8 +45,8 @@ public class ElasticsearchSSLContextFactory {
     @Value("${ELASTICSEARCH_SSL_KEYSTORE_PASSWORD:#{null}}")
     private String sslKeyStorePassword;
 
-    @Value("${ELASTICSEARCH_SSL_KEYSTORE_KEY_PASSWORD:#{null}}")
-    private String sslKeyStoreKeyPassword;
+    @Value("${ELASTICSEARCH_SSL_KEY_PASSWORD:#{null}}")
+    private String sslKeyPassword;
 
     @Bean(name = "elasticSearchSSLContext")
     public SSLContext createInstance() {
@@ -59,8 +59,8 @@ public class ElasticsearchSSLContextFactory {
             loadTrustStore(sslContextBuilder, sslTrustStoreFile, sslTrustStoreType, sslTrustStorePassword);
         }
 
-        if (sslKeyStoreFile != null && sslKeyStoreType != null && sslKeyStorePassword != null && sslKeyStoreKeyPassword != null) {
-            loadKeyStore(sslContextBuilder, sslKeyStoreFile, sslKeyStoreType, sslKeyStorePassword, sslKeyStoreKeyPassword);
+        if (sslKeyStoreFile != null && sslKeyStoreType != null && sslKeyStorePassword != null && sslKeyPassword != null) {
+            loadKeyStore(sslContextBuilder, sslKeyStoreFile, sslKeyStoreType, sslKeyStorePassword, sslKeyPassword);
         }
 
         final SSLContext sslContext;
@@ -76,11 +76,11 @@ public class ElasticsearchSSLContextFactory {
     }
 
     private void loadKeyStore(@Nonnull SSLContextBuilder sslContextBuilder, @Nonnull String path,
-                              @Nonnull String type, @Nonnull String password, @Nonnull String sslKeyStoreKeyPassword) {
+                              @Nonnull String type, @Nonnull String password, @Nonnull String keyPassword) {
         try (InputStream identityFile = new FileInputStream(path)) {
             final KeyStore keystore = KeyStore.getInstance(type);
             keystore.load(identityFile, password.toCharArray());
-            sslContextBuilder.loadKeyMaterial(keystore, sslKeyStoreKeyPassword.toCharArray());
+            sslContextBuilder.loadKeyMaterial(keystore, keyPassword.toCharArray());
         } catch (IOException | CertificateException | NoSuchAlgorithmException | KeyStoreException | UnrecoverableKeyException e) {
             throw new RuntimeException("Failed to load key store: " + path, e);
         }


### PR DESCRIPTION
Looks like the `ElasticsearchSSLContextFactory` wasn't loading keys from the keystore, just certs.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
