### PR TITLE
fix(kafka key schema): Refactoring hasKeySchema computation 

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -63,10 +63,15 @@ export default function SchemaView({
         fetchPolicy: 'no-cache',
     });
 
-    const hasKeySchema = useMemo(
-        () => (schema?.fields?.findIndex((field) => field.fieldPath.indexOf(KEY_SCHEMA_PREFIX) > -1) || -1) !== -1,
-        [schema],
-    );
+    // Recipe for disaster.
+    const hasKeySchema = useMemo(() => {
+        const keySchemaIndex = schema?.fields?.findIndex((field) => field.fieldPath.indexOf(KEY_SCHEMA_PREFIX) > -1);
+        if (keySchemaIndex !== undefined && keySchemaIndex > -1) {
+            // We found a key schema.
+            return true;
+        }
+        return false;
+    }, [schema]);
 
     const [showKeySchema, setShowKeySchema] = useState(false);
 

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/Schema.tsx
@@ -63,7 +63,6 @@ export default function SchemaView({
         fetchPolicy: 'no-cache',
     });
 
-    // Recipe for disaster.
     const hasKeySchema = useMemo(() => {
         const keySchemaIndex = schema?.fields?.findIndex((field) => field.fieldPath.indexOf(KEY_SCHEMA_PREFIX) > -1);
         if (keySchemaIndex !== undefined && keySchemaIndex > -1) {


### PR DESCRIPTION
Currently hasKeySchema flag is mis-computed in cases where the index of the key field is 0, due to how Javascript handles 0 values (falsey). 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
