### PR TITLE
feat(ingest): Minor Kafka Connect source improvements

### DIFF
--- a/metadata-ingestion/source_docs/kafka-connect.md
+++ b/metadata-ingestion/source_docs/kafka-connect.md
@@ -50,6 +50,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `username`                 |          |                            | Kafka Connect username.                                 |
 | `password`                 |          |                            | Kafka Connect password.                                 |
 | `cluster_name`             |          | `"connect-cluster"`        | Cluster to ingest from.                                 |
+| `construct_lineage_workunits`    |    | `True`                     | Whether to create the input and output Dataset entities |
 | `connector_patterns.deny`  |          |                            | List of regex patterns for connectors to include in ingestion.   |
 | `connector_patterns.allow` |          |                            | List of regex patterns for connectors to exclude from ingestion. |
 | `connector_pattern.ignoreCase`  |     | `True`      | Whether to ignore case sensitivity during pattern matching.            |

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -41,6 +41,18 @@ class KafkaConnectSourceReport(SourceReport):
 
 
 @dataclass
+class DebeziumParser:
+    source_platform: str
+    server_name: Optional[str]
+    database_name: Optional[str]
+
+
+@dataclass
+class JdbcParser:
+    db_connection_url: Optional[str]
+
+
+@dataclass
 class KafkaConnectLineage:
     """Class to store Kafka Connect lineage mapping"""
 
@@ -59,71 +71,71 @@ class ConnectorManifest(BaseModel):
     url: Optional[str]
 
 
-def get_jdbc_source_connector_parser(connector_manifest):
+def get_jdbc_source_connector_parser(connector_manifest) -> JdbcParser:
+    return JdbcParser(connector_manifest.config.get("connection.url"))
+
+
+def get_debezium_source_connector_parser(connector_manifest) -> DebeziumParser:
     connector_class = connector_manifest.config.get("connector.class", "")
-    parser = {
-        # https://docs.confluent.io/kafka-connect-jdbc/current/source-connector/source_config_options.html
-        "io.confluent.connect.jdbc.JdbcSourceConnector": {
-            "db_connection_url": connector_manifest.config.get("connection.url"),
-        }
-    }
-
-    return parser.get(connector_class)
-
-
-def get_debezium_source_connector_parser(connector_manifest):
-    connector_class = connector_manifest.config.get("connector.class", "")
-    parser = {
+    if connector_class == "io.debezium.connector.mysql.MySqlConnector":
         # https://debezium.io/documentation/reference/connectors/mysql.html#mysql-topic-names
-        "io.debezium.connector.mysql.MySqlConnector": {
-            "source_platform": "mysql",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": None,
-        },
-        "MySqlConnector": {
-            "source_platform": "mysql",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": None,
-        },
+        parser = DebeziumParser(
+            source_platform="mysql",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=None,
+        )
+    elif connector_class == "MySqlConnector":
+        parser = DebeziumParser(
+            source_platform="mysql",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=None,
+        )
+    elif connector_class == "io.debezium.connector.mongodb.MongoDbConnector":
         # https://debezium.io/documentation/reference/connectors/mongodb.html#mongodb-topic-names
-        "io.debezium.connector.mongodb.MongoDbConnector": {
-            "source_platform": "mongodb",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": None,
-        },
+        parser = DebeziumParser(
+            source_platform="mongodb",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=None,
+        )
+    elif connector_class == "io.debezium.connector.postgresql.PostgresConnector":
         # https://debezium.io/documentation/reference/connectors/postgresql.html#postgresql-topic-names
-        "io.debezium.connector.postgresql.PostgresConnector": {
-            "source_platform": "postgres",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": connector_manifest.config.get("database.dbname"),
-        },
+        parser = DebeziumParser(
+            source_platform="postgres",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=connector_manifest.config.get("database.dbname"),
+        )
+    elif connector_class == "io.debezium.connector.oracle.OracleConnector":
         # https://debezium.io/documentation/reference/connectors/oracle.html#oracle-topic-names
-        "io.debezium.connector.oracle.OracleConnector": {
-            "source_platform": "oracle",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": connector_manifest.config.get("database.dbname"),
-        },
+        parser = DebeziumParser(
+            source_platform="oracle",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=connector_manifest.config.get("database.dbname"),
+        )
+    elif connector_class == "io.debezium.connector.sqlserver.SqlServerConnector":
         # https://debezium.io/documentation/reference/connectors/sqlserver.html#sqlserver-topic-names
-        "io.debezium.connector.sqlserver.SqlServerConnector": {
-            "source_platform": "mssql",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": connector_manifest.config.get("database.dbname"),
-        },
+        parser = DebeziumParser(
+            source_platform="mssql",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=connector_manifest.config.get("database.dbname"),
+        )
+    elif connector_class == "io.debezium.connector.db2.Db2Connector":
         # https://debezium.io/documentation/reference/connectors/db2.html#db2-topic-names
-        "io.debezium.connector.db2.Db2Connector": {
-            "source_platform": "db2",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": connector_manifest.config.get("database.dbname"),
-        },
+        parser = DebeziumParser(
+            source_platform="db2",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=connector_manifest.config.get("database.dbname"),
+        )
+    elif connector_class == "io.debezium.connector.vitess.VitessConnector":
         # https://debezium.io/documentation/reference/connectors/vitess.html#vitess-topic-names
-        "io.debezium.connector.vitess.VitessConnector": {
-            "source_platform": "vitess",
-            "server_name": connector_manifest.config.get("database.server.name"),
-            "database_name": connector_manifest.config.get("vitess.keyspace"),
-        },
-    }
+        parser = DebeziumParser(
+            source_platform="vitess",
+            server_name=connector_manifest.config.get("database.server.name"),
+            database_name=connector_manifest.config.get("vitess.keyspace"),
+        )
+    else:
+        raise ValueError(f"Connector class '{connector_class}' is unknown.")
 
-    return parser.get(connector_class)
+    return parser
 
 
 def remove_prefix(text: str, prefix: str) -> str:
@@ -140,7 +152,7 @@ class JDBCSourceConnectorLineages:
     def get_lineages(self):
         lineages: List[KafkaConnectLineage] = list()
         parser = get_jdbc_source_connector_parser(self.connector_manifest)
-        db_connection_url = parser.get("db_connection_url")
+        db_connection_url = parser.db_connection_url
         url = remove_prefix(str(db_connection_url), "jdbc:")
         url_instance = make_url(url)
         source_platform = url_instance.drivername
@@ -191,12 +203,12 @@ class JDBCSourceConnectorLineages:
 class DebeziumSourceConnectorLineages:
     connector_manifest: ConnectorManifest
 
-    def get_lineages(self):
+    def get_lineages(self) -> List[KafkaConnectLineage]:
         lineages: List[KafkaConnectLineage] = list()
         parser = get_debezium_source_connector_parser(self.connector_manifest)
-        source_platform = parser.get("source_platform")
-        server_name = parser.get("server_name")
-        database_name = parser.get("database_name")
+        source_platform = parser.source_platform
+        server_name = parser.server_name
+        database_name = parser.database_name
         topic_naming_pattern = r"({0})\.(\w+\.\w+)".format(server_name)
 
         if not self.connector_manifest.topic_names:
@@ -254,11 +266,11 @@ class KafkaConnectSource(Source):
         logger.info(f"Connection to {self.config.connect_uri} is ok")
 
     @classmethod
-    def create(cls, config_dict, ctx):
+    def create(cls, config_dict, ctx) -> Source:
         config = KafkaConnectSourceConfig.parse_obj(config_dict)
         return cls(config, ctx)
 
-    def get_connectors_manifest(self):
+    def get_connectors_manifest(self) -> List[ConnectorManifest]:
         """Get Kafka Connect connectors manifest using REST API.
 
         Enrich with lineages metadata.
@@ -302,12 +314,19 @@ class KafkaConnectSource(Source):
                     )
                 else:
                     # Debezium Source Connector lineages
-                    debezium_source_lineages = DebeziumSourceConnectorLineages(
-                        connector_manifest=connector_manifest
-                    )
-                    connector_manifest.lineages.extend(
-                        debezium_source_lineages.get_lineages()
-                    )
+                    try:
+                        debezium_source_lineages = DebeziumSourceConnectorLineages(
+                            connector_manifest=connector_manifest
+                        )
+                        connector_manifest.lineages.extend(
+                            debezium_source_lineages.get_lineages()
+                        )
+                    except ValueError as err:
+                        logger.warning(
+                            f"Skipping connector {connector_manifest.name} due to error: {err}"
+                        )
+                        self.report.report_failure(connector_manifest.name, str(err))
+                        continue
 
             if connector_manifest.type == "sink":
                 # TODO: Sink Connector not yet implemented

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -72,11 +72,15 @@ class ConnectorManifest(BaseModel):
     url: Optional[str]
 
 
-def get_jdbc_source_connector_parser(connector_manifest) -> JdbcParser:
+def get_jdbc_source_connector_parser(
+    connector_manifest: ConnectorManifest,
+) -> JdbcParser:
     return JdbcParser(connector_manifest.config.get("connection.url"))
 
 
-def get_debezium_source_connector_parser(connector_manifest) -> DebeziumParser:
+def get_debezium_source_connector_parser(
+    connector_manifest: ConnectorManifest,
+) -> DebeziumParser:
     connector_class = connector_manifest.config.get("connector.class", "")
     if connector_class == "io.debezium.connector.mysql.MySqlConnector":
         # https://debezium.io/documentation/reference/connectors/mysql.html#mysql-topic-names
@@ -267,7 +271,7 @@ class KafkaConnectSource(Source):
         logger.info(f"Connection to {self.config.connect_uri} is ok")
 
     @classmethod
-    def create(cls, config_dict, ctx) -> Source:
+    def create(cls, config_dict: dict, ctx: PipelineContext) -> Source:
         config = KafkaConnectSourceConfig.parse_obj(config_dict)
         return cls(config, ctx)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -25,6 +25,7 @@ class KafkaConnectSourceConfig(ConfigModel):
     password: Optional[str] = None
     cluster_name: Optional[str] = "connect-cluster"
     env: str = builder.DEFAULT_ENV
+    construct_lineage_workunits: bool = True
     connector_patterns: AllowDenyPattern = AllowDenyPattern(allow=[".*"], deny=["^_.*"])
 
 
@@ -466,7 +467,8 @@ class KafkaConnectSource(Source):
             if self.config.connector_patterns.allowed(name):
                 yield from self.construct_flow_workunit(connector)
                 yield from self.construct_job_workunits(connector)
-                yield from self.construct_lineage_workunits(connector)
+                if self.config.construct_lineage_workunits:
+                    yield from self.construct_lineage_workunits(connector)
 
                 self.report.report_connector_scanned(name)
 


### PR DESCRIPTION
This PR improves the Kafka connect source:
* Unknown connector classes are reported as failures, and does not crash the ingestion anymore. 
* Clarifies some typing and fixes some bugs due to accessing `NoneType`
* Makes it optional to construct the lineage dataset entities (input database table and output Kafka topic).