### PR TITLE
fix(ingest): ingest deleted looker dashboards

### DIFF
--- a/metadata-ingestion/source_docs/looker.md
+++ b/metadata-ingestion/source_docs/looker.md
@@ -53,6 +53,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `chart_pattern.allow`     |          |                         | List of regex patterns for charts to include in ingestion.                                                            |
 | `chart_pattern.deny`      |          |                         | List of regex patterns for charts to exclude from ingestion.                                                          |
 | `chart_pattern.ignoreCase`  |          | `True` | Whether to ignore case sensitivity during pattern matching.                                                                                                                                  |
+| `include_deleted`         |          | `False`                 | Whether to include deleted dashboards.                                                                       |
 | `env`                     |          | `"PROD"`                | Environment to use in namespace when constructing URNs.                                                      |
 
 ## Compatibility


### PR DESCRIPTION
[all_dashboards()](https://github.com/looker-open-source/sdk-codegen/blob/6f9c8b0065acebe0304b0db121ac0ccdfb1466d4/python/looker_sdk/sdk/api31/methods.py#L2027-L2034) does not return deleted dashboards (even says so in the comments).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
