### PR TITLE
add optional config for ownership type in ownership transforms

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -10,6 +10,7 @@ from datahub.metadata.schema_classes import (
     DatasetLineageTypeClass,
     DatasetSnapshotClass,
     MetadataChangeEventClass,
+    OwnershipTypeClass,
     UpstreamClass,
     UpstreamLineageClass,
 )
@@ -110,6 +111,29 @@ def make_ml_model_group_urn(platform: str, group_name: str, env: str) -> str:
     return (
         f"urn:li:mlModelGroup:({make_data_platform_urn(platform)},{group_name},{env})"
     )
+
+
+_ownership_types = {
+    "DEVELOPER": OwnershipTypeClass.DEVELOPER,
+    "DATAOWNER": OwnershipTypeClass.DATAOWNER,
+    "DELEGATE": OwnershipTypeClass.DELEGATE,
+    "PRODUCER": OwnershipTypeClass.PRODUCER,
+    "CONSUMER": OwnershipTypeClass.CONSUMER,
+    "STAKEHOLDER": OwnershipTypeClass.STAKEHOLDER,
+}
+
+
+def _check_ownership_type(ownership_type: str) -> None:
+    if ownership_type not in _ownership_types:
+        logger.error(f"invalid ownership type value: {ownership_type}")
+
+
+def make_ownership_type(
+    ownership_type: Optional[str], fallback: OwnershipTypeClass
+) -> OwnershipTypeClass:
+    if ownership_type:
+        _check_ownership_type(ownership_type)
+    return _ownership_types.get(ownership_type, fallback)
 
 
 def make_lineage_mce(

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -1,7 +1,7 @@
 """Convenience functions for creating MCEs"""
 import logging
 import time
-from typing import List, Optional, Type, TypeVar, get_type_hints
+from typing import List, Optional, Type, TypeVar, cast, get_type_hints
 
 import typing_inspect
 from avrogen.dict_wrapper import DictWrapper
@@ -113,19 +113,22 @@ def make_ml_model_group_urn(platform: str, group_name: str, env: str) -> str:
     )
 
 
-def check_ownership_type(ownership_type: Optional[str]) -> str:
-    if ownership_type in [
+def is_valid_ownership_type(ownership_type: Optional[str]) -> bool:
+    return ownership_type is not None and ownership_type in [
         OwnershipTypeClass.DEVELOPER,
         OwnershipTypeClass.DATAOWNER,
         OwnershipTypeClass.DELEGATE,
         OwnershipTypeClass.PRODUCER,
         OwnershipTypeClass.CONSUMER,
         OwnershipTypeClass.STAKEHOLDER,
-    ]:
-        return ownership_type
+    ]
+
+
+def validate_ownership_type(ownership_type: Optional[str]) -> str:
+    if is_valid_ownership_type(ownership_type):
+        return cast(str, ownership_type)
     else:
-        logger.warning(f"invalid ownership type value: {ownership_type}")
-        return OwnershipTypeClass.DATAOWNER
+        raise ValueError(f"Unexpected ownership type: {ownership_type}")
 
 
 def make_lineage_mce(

--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -113,27 +113,19 @@ def make_ml_model_group_urn(platform: str, group_name: str, env: str) -> str:
     )
 
 
-_ownership_types = {
-    "DEVELOPER": OwnershipTypeClass.DEVELOPER,
-    "DATAOWNER": OwnershipTypeClass.DATAOWNER,
-    "DELEGATE": OwnershipTypeClass.DELEGATE,
-    "PRODUCER": OwnershipTypeClass.PRODUCER,
-    "CONSUMER": OwnershipTypeClass.CONSUMER,
-    "STAKEHOLDER": OwnershipTypeClass.STAKEHOLDER,
-}
-
-
-def _check_ownership_type(ownership_type: str) -> None:
-    if ownership_type not in _ownership_types:
-        logger.error(f"invalid ownership type value: {ownership_type}")
-
-
-def make_ownership_type(
-    ownership_type: Optional[str], fallback: OwnershipTypeClass
-) -> OwnershipTypeClass:
-    if ownership_type:
-        _check_ownership_type(ownership_type)
-    return _ownership_types.get(ownership_type, fallback)
+def check_ownership_type(ownership_type: Optional[str]) -> str:
+    if ownership_type in [
+        OwnershipTypeClass.DEVELOPER,
+        OwnershipTypeClass.DATAOWNER,
+        OwnershipTypeClass.DELEGATE,
+        OwnershipTypeClass.PRODUCER,
+        OwnershipTypeClass.CONSUMER,
+        OwnershipTypeClass.STAKEHOLDER,
+    ]:
+        return ownership_type
+    else:
+        logger.warning(f"invalid ownership type value: {ownership_type}")
+        return OwnershipTypeClass.DATAOWNER
 
 
 def make_lineage_mce(

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_ownership.py
@@ -10,7 +10,6 @@ from datahub.metadata.schema_classes import (
     MetadataChangeEventClass,
     OwnerClass,
     OwnershipClass,
-    OwnershipTypeClass,
 )
 
 
@@ -70,9 +69,7 @@ class SimpleAddDatasetOwnership(AddDatasetOwnership):
         owners = [
             OwnerClass(
                 owner=owner,
-                type=builder.make_ownership_type(
-                    config.ownership_type, OwnershipTypeClass.DATAOWNER
-                ),
+                type=builder.check_ownership_type(config.ownership_type),
             )
             for owner in config.owner_urns
         ]
@@ -100,13 +97,16 @@ class PatternDatasetOwnershipConfig(ConfigModel):
 class PatternAddDatasetOwnership(AddDatasetOwnership):
     """Transformer that adds a specified set of owners to each dataset."""
 
-    def getOwners(self, key, owner_pattern, ownership_type: Optional[str] = None):
+    def getOwners(
+        self,
+        key: str,
+        owner_pattern: KeyValuePattern,
+        ownership_type: Optional[str] = None,
+    ) -> List[OwnerClass]:
         owners = [
             OwnerClass(
                 owner=owner,
-                type=builder.make_ownership_type(
-                    ownership_type, OwnershipTypeClass.DATAOWNER
-                ),
+                type=builder.check_ownership_type(ownership_type),
             )
             for owner in owner_pattern.value(key)
         ]
@@ -118,9 +118,7 @@ class PatternAddDatasetOwnership(AddDatasetOwnership):
             get_owners_to_add=lambda _: [
                 OwnerClass(
                     owner=owner,
-                    type=builder.make_ownership_type(
-                        config.ownership_type, OwnershipTypeClass.DATAOWNER
-                    ),
+                    type=builder.check_ownership_type(config.ownership_type),
                 )
                 for owner in owner_pattern.value(_.urn)
             ],

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -1,3 +1,5 @@
+import pytest
+
 import datahub.emitter.mce_builder as builder
 import datahub.metadata.schema_classes as models
 from datahub.ingestion.api.common import PipelineContext, RecordEnvelope
@@ -143,6 +145,19 @@ def test_simple_dataset_ownership_with_type_transformation(mock_time):
     assert ownership_aspect
     assert len(ownership_aspect.owners) == 1
     assert ownership_aspect.owners[0].type == models.OwnershipTypeClass.PRODUCER
+
+
+def test_simple_dataset_ownership_with_invalid_type_transformation(mock_time):
+    with pytest.raises(ValueError):
+        SimpleAddDatasetOwnership.create(
+            {
+                "owner_urns": [
+                    builder.make_user_urn("person1"),
+                ],
+                "ownership_type": "INVALID_TYPE",
+            },
+            PipelineContext(run_id="test"),
+        )
 
 
 def test_simple_remove_dataset_ownership():
@@ -386,3 +401,18 @@ def test_pattern_dataset_ownership_with_type_transformation(mock_time):
     assert ownership_aspect
     assert len(ownership_aspect.owners) == 1
     assert ownership_aspect.owners[0].type == models.OwnershipTypeClass.PRODUCER
+
+
+def test_pattern_dataset_ownership_with_invalid_type_transformation(mock_time):
+    with pytest.raises(ValueError):
+        PatternAddDatasetOwnership.create(
+            {
+                "owner_pattern": {
+                    "rules": {
+                        ".*example1.*": [builder.make_user_urn("person1")],
+                    }
+                },
+                "ownership_type": "INVALID_TYPE",
+            },
+            PipelineContext(run_id="test"),
+        )

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -50,7 +50,7 @@ def make_dataset_with_owner():
     )
 
 
-def test_simple_dataset_ownership_tranformation(mock_time):
+def test_simple_dataset_ownership_transformation(mock_time):
     no_owner_aspect = make_generic_dataset()
 
     with_owner_aspect = make_dataset_with_owner()
@@ -96,6 +96,12 @@ def test_simple_dataset_ownership_tranformation(mock_time):
     )
     assert first_ownership_aspect
     assert len(first_ownership_aspect.owners) == 2
+    assert all(
+        [
+            owner.type == models.OwnershipTypeClass.DATAOWNER
+            for owner in first_ownership_aspect.owners
+        ]
+    )
 
     # Check the second entry.
     second_ownership_aspect = builder.get_aspect_if_available(
@@ -103,9 +109,40 @@ def test_simple_dataset_ownership_tranformation(mock_time):
     )
     assert second_ownership_aspect
     assert len(second_ownership_aspect.owners) == 3
+    assert all(
+        [
+            owner.type == models.OwnershipTypeClass.DATAOWNER
+            for owner in first_ownership_aspect.owners
+        ]
+    )
 
     # Verify that the third entry is unchanged.
     assert inputs[2] == outputs[2].record
+
+
+def test_simple_dataset_ownership_with_type_transformation(mock_time):
+    input = make_generic_dataset()
+
+    transformer = SimpleAddDatasetOwnership.create(
+        {
+            "owner_urns": [
+                builder.make_user_urn("person1"),
+            ],
+            "ownership_type": "PRODUCER",
+        },
+        PipelineContext(run_id="test"),
+    )
+
+    output = list(transformer.transform([RecordEnvelope(input, metadata={})]))
+
+    assert len(output) == 1
+
+    ownership_aspect = builder.get_aspect_if_available(
+        output[0].record, models.OwnershipClass
+    )
+    assert ownership_aspect
+    assert len(ownership_aspect.owners) == 1
+    assert ownership_aspect.owners[0].type == models.OwnershipTypeClass.PRODUCER
 
 
 def test_simple_remove_dataset_ownership():
@@ -235,7 +272,7 @@ def test_import_resolver():
     assert output
 
 
-def test_pattern_dataset_ownership_tranformation(mock_time):
+def test_pattern_dataset_ownership_transformation(mock_time):
     no_owner_aspect = make_generic_dataset()
 
     with_owner_aspect = models.MetadataChangeEventClass(
@@ -300,6 +337,12 @@ def test_pattern_dataset_ownership_tranformation(mock_time):
     )
     assert first_ownership_aspect
     assert len(first_ownership_aspect.owners) == 1
+    assert all(
+        [
+            owner.type == models.OwnershipTypeClass.DATAOWNER
+            for owner in first_ownership_aspect.owners
+        ]
+    )
 
     # Check the second entry.
     second_ownership_aspect = builder.get_aspect_if_available(
@@ -307,6 +350,39 @@ def test_pattern_dataset_ownership_tranformation(mock_time):
     )
     assert second_ownership_aspect
     assert len(second_ownership_aspect.owners) == 2
+    assert all(
+        [
+            owner.type == models.OwnershipTypeClass.DATAOWNER
+            for owner in first_ownership_aspect.owners
+        ]
+    )
 
     # Verify that the third entry is unchanged.
     assert inputs[2] == outputs[2].record
+
+
+def test_pattern_dataset_ownership_with_type_transformation(mock_time):
+    input = make_generic_dataset()
+
+    transformer = PatternAddDatasetOwnership.create(
+        {
+            "owner_pattern": {
+                "rules": {
+                    ".*example1.*": [builder.make_user_urn("person1")],
+                }
+            },
+            "ownership_type": "PRODUCER",
+        },
+        PipelineContext(run_id="test"),
+    )
+
+    output = list(transformer.transform([RecordEnvelope(input, metadata={})]))
+
+    assert len(output) == 1
+
+    ownership_aspect = builder.get_aspect_if_available(
+        output[0].record, models.OwnershipClass
+    )
+    assert ownership_aspect
+    assert len(ownership_aspect.owners) == 1
+    assert ownership_aspect.owners[0].type == models.OwnershipTypeClass.PRODUCER

--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -57,7 +57,11 @@ transformers:
         - "urn:li:corpuser:username1"
         - "urn:li:corpuser:username2"
         - "urn:li:corpGroup:groupname"
+      ownership_type: "PRODUCER"
 ```
+
+Note `ownership_type` is an optional field with `DATAOWNER` as default value.
+
 ### Setting ownership by dataset urn pattern
 
 Let’s suppose we’d like to append a series of users who we know to own different dataset from a data source but aren't detected during normal ingestion. To do so, we can use the `pattern_add_dataset_ownership` module that’s included in the ingestion framework. it match pattern with `urn` of dataset and assign the respective owners
@@ -72,7 +76,10 @@ transformers:
         rules:
           ".*example1.*": ["urn:li:corpuser:username1"]
           ".*example2.*": ["urn:li:corpuser:username2"]
+      ownership_type: "DEVELOPER"
 ```
+
+Note `ownership_type` is an optional field with `DATAOWNER` as default value.
 
 If you'd like to add more complex logic for assigning ownership, you can use the more generic `add_dataset_ownership` transformer, which calls a user-provided function to determine the ownership of each dataset.
 


### PR DESCRIPTION
This is adding the ability to specify the ownership type in the ownership transformations. `DATAOWNER` is the default value if not given or if an unexpected value is given.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
