### PR TITLE
test(metadata-io): Improve speed of ElasticSearch tests

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/ElasticSearchTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/ElasticSearchTestUtils.java
@@ -4,16 +4,39 @@ import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.flush.FlushResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.testng.TestException;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 public class ElasticSearchTestUtils {
 
     private ElasticSearchTestUtils() {
     }
 
-    public static void syncAfterWrite(RestHighLevelClient searchClient) throws Exception {
-        // flush changes in ES to disk
+    public static void syncAfterWrite(RestHighLevelClient client) throws Exception {
+        syncAfterWrite(client, "test-sync-flag");
+    }
+
+    public static void syncAfterWrite(RestHighLevelClient searchClient, String indexName) throws Exception {
+        // we add some more data (a sync flag) and wait for it to appear
+        // we pick a random flag so that this can be used concurrently
+        String syncFlag = UUID.randomUUID().toString();
+
+        // add the flag and wait for it to appear, preferably to the indexed modified outside
+        addSyncFlag(searchClient, syncFlag, indexName);
+        waitForSyncFlag(searchClient, syncFlag, indexName, true);
+
+        // flush changes for all indices in ES to disk
         FlushResponse fResponse = searchClient.indices().flush(new FlushRequest(), RequestOptions.DEFAULT);
         if (fResponse.getFailedShards() > 0) {
             throw new RuntimeException("Failed to flush " + fResponse.getFailedShards() + " of " + fResponse.getTotalShards() + " shards");
@@ -24,6 +47,38 @@ public class ElasticSearchTestUtils {
         if (rResponse.getFailedShards() > 0) {
             throw new RuntimeException("Failed to refresh " + rResponse.getFailedShards() + " of " + rResponse.getTotalShards() + " shards");
         }
+
+        // remove the flag again and wait for it to disappear
+        removeSyncFlag(searchClient, syncFlag, indexName);
+        waitForSyncFlag(searchClient, syncFlag, indexName, false);
+    }
+
+    private static void addSyncFlag(RestHighLevelClient searchClient, String docId, String indexName) throws IOException {
+        String document = "{ }";
+        final IndexRequest indexRequest = new IndexRequest(indexName).id(docId).source(document, XContentType.JSON);
+        final UpdateRequest updateRequest = new UpdateRequest(indexName, docId).doc(document, XContentType.JSON)
+                .detectNoop(false)
+                .upsert(indexRequest);
+        searchClient.update(updateRequest, RequestOptions.DEFAULT);
+    }
+
+    private static void removeSyncFlag(RestHighLevelClient searchClient, String docId, String indexName) throws IOException {
+        final DeleteRequest deleteRequest = new DeleteRequest(indexName).id(docId);
+        searchClient.delete(deleteRequest, RequestOptions.DEFAULT);
+    }
+
+    private static void waitForSyncFlag(RestHighLevelClient searchClient, String docId, String indexName, boolean toExist)
+            throws IOException, InterruptedException {
+        GetRequest request = new GetRequest(indexName).id(docId);
+        long timeout = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(10, TimeUnit.SECONDS);
+        while (System.currentTimeMillis() < timeout) {
+            GetResponse response = searchClient.get(request, RequestOptions.DEFAULT);
+            if (response.isExists() == toExist) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(50);
+        }
+        throw new TestException("Waiting for sync timed out");
     }
 
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/ElasticSearchTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/ElasticSearchTestUtils.java
@@ -1,0 +1,29 @@
+package com.linkedin.metadata;
+
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushResponse;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+
+public class ElasticSearchTestUtils {
+
+    private ElasticSearchTestUtils() {
+    }
+
+    public static void syncAfterWrite(RestHighLevelClient searchClient) throws Exception {
+        // flush changes in ES to disk
+        FlushResponse fResponse = searchClient.indices().flush(new FlushRequest(), RequestOptions.DEFAULT);
+        if (fResponse.getFailedShards() > 0) {
+            throw new RuntimeException("Failed to flush " + fResponse.getFailedShards() + " of " + fResponse.getTotalShards() + " shards");
+        }
+
+        // wait for all indices to be refreshed
+        RefreshResponse rResponse = searchClient.indices().refresh(new RefreshRequest(), RequestOptions.DEFAULT);
+        if (rResponse.getFailedShards() > 0) {
+            throw new RuntimeException("Failed to refresh " + rResponse.getFailedShards() + " of " + rResponse.getTotalShards() + " shards");
+        }
+    }
+
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -18,11 +18,14 @@ import org.testng.annotations.BeforeTest;
 
 import javax.annotation.Nonnull;
 
+import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.INDEX_NAME;
+
 public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   private ElasticsearchContainer _elasticsearchContainer;
   private RestHighLevelClient _searchClient;
-  private IndexConvention _indexConvention;
+  private final IndexConvention _indexConvention = new IndexConventionImpl(null);
+  private final String _indexName = _indexConvention.getIndexName(INDEX_NAME);
   private ElasticSearchGraphService _client;
 
   private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
@@ -36,7 +39,6 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   @BeforeTest
   public void setup() {
-    _indexConvention = new IndexConventionImpl(null);
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
@@ -76,6 +78,7 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   @Override
   protected void syncAfterWrite() throws Exception {
-    ElasticSearchTestUtils.syncAfterWrite(_searchClient);
+    ElasticSearchTestUtils.syncAfterWrite(_searchClient, _indexName);
   }
+
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.graph;
 
+import com.linkedin.metadata.ElasticSearchTestUtils;
 import com.linkedin.metadata.graph.elastic.ESGraphQueryDAO;
 import com.linkedin.metadata.graph.elastic.ESGraphWriteDAO;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
@@ -7,11 +8,6 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import org.apache.http.HttpHost;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.elasticsearch.action.admin.indices.flush.FlushRequest;
-import org.elasticsearch.action.admin.indices.flush.FlushResponse;
-import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -80,16 +76,6 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
   @Override
   protected void syncAfterWrite() throws Exception {
-    // flush changes in ES to disk
-    FlushResponse fResponse = _searchClient.indices().flush(new FlushRequest(), RequestOptions.DEFAULT);
-    if (fResponse.getFailedShards() > 0) {
-      throw new RuntimeException("Failed to flush " + fResponse.getFailedShards() + " of " + fResponse.getTotalShards() + " shards");
-    }
-
-    // wait for all indices to be refreshed
-    RefreshResponse rResponse = _searchClient.indices().refresh(new RefreshRequest(), RequestOptions.DEFAULT);
-    if (rResponse.getFailedShards() > 0) {
-      throw new RuntimeException("Failed to refresh " + rResponse.getFailedShards() + " of " + rResponse.getTotalShards() + " shards");
-    }
+    ElasticSearchTestUtils.syncAfterWrite(_searchClient);
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchServiceTest.java
@@ -17,7 +17,6 @@ import com.linkedin.metadata.search.elasticsearch.update.ESWriteDAO;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import org.apache.http.HttpHost;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
@@ -108,7 +107,6 @@ public class ElasticSearchServiceTest {
     document.set("browsePaths", JsonNodeFactory.instance.textNode("/a/b/c"));
     _elasticSearchService.upsertDocument(ENTITY_NAME, document.toString(), urn.toString());
     syncAfterWrite(_searchClient);
-    TimeUnit.SECONDS.sleep(2);  // for some reason we still need to wait here though we 'syncAfterWrite'
 
     searchResult = _elasticSearchService.search(ENTITY_NAME, "test", null, null, 0, 10);
     assertEquals(searchResult.getNumEntities().intValue(), 1);

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
@@ -19,13 +19,15 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
+import static com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService.INDEX_NAME;
 import static org.testng.Assert.*;
 
 public class ElasticSearchSystemMetadataServiceTest {
 
   private ElasticsearchContainer _elasticsearchContainer;
   private RestHighLevelClient _searchClient;
-  private IndexConvention _indexConvention;
+  private final IndexConvention _indexConvention = new IndexConventionImpl(null);
+  private final String _indexName = _indexConvention.getIndexName(INDEX_NAME);
   private ElasticSearchSystemMetadataService _client;
 
   private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
@@ -33,7 +35,6 @@ public class ElasticSearchSystemMetadataServiceTest {
 
   @BeforeTest
   public void setup() {
-    _indexConvention = new IndexConventionImpl(null);
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
@@ -44,7 +45,7 @@ public class ElasticSearchSystemMetadataServiceTest {
   @BeforeMethod
   public void wipe() throws Exception {
     _client.clear();
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
   }
 
   @Nonnull
@@ -88,7 +89,7 @@ public class ElasticSearchSystemMetadataServiceTest {
     _client.insert(metadata2, "urn:li:chart:2", "chartKey");
     _client.insert(metadata2, "urn:li:chart:2", "Ownership");
 
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
 
     List<IngestionRunSummary> runs = _client.listRuns(0, 20);
 
@@ -117,7 +118,7 @@ public class ElasticSearchSystemMetadataServiceTest {
     _client.insert(metadata2, "urn:li:chart:2", "chartKey");
     _client.insert(metadata2, "urn:li:chart:2", "Ownership");
 
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
 
     List<IngestionRunSummary> runs = _client.listRuns(0, 20);
 
@@ -146,7 +147,7 @@ public class ElasticSearchSystemMetadataServiceTest {
     _client.insert(metadata2, "urn:li:chart:2", "chartKey");
     _client.insert(metadata2, "urn:li:chart:2", "Ownership");
 
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
 
     List<AspectRowSummary> rows = _client.findByRunId("abc-456");
 
@@ -174,11 +175,11 @@ public class ElasticSearchSystemMetadataServiceTest {
     _client.insert(metadata2, "urn:li:chart:2", "chartKey");
     _client.insert(metadata2, "urn:li:chart:2", "Ownership");
 
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
 
     _client.deleteUrn("urn:li:chart:1");
 
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
 
     List<AspectRowSummary> rows = _client.findByRunId("abc-456");
 
@@ -190,7 +191,7 @@ public class ElasticSearchSystemMetadataServiceTest {
   public void testInsertNullData() throws Exception {
     _client.insert(null, "urn:li:chart:1", "chartKey");
 
-    syncAfterWrite(_searchClient);
+    syncAfterWrite(_searchClient, _indexName);
 
     List<IngestionRunSummary> runs = _client.listRuns(0, 20);
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
@@ -18,7 +18,6 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -35,6 +34,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
+import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
 
 public class ElasticSearchTimeseriesAspectServiceTest {
 
@@ -122,7 +122,7 @@ public class ElasticSearchTimeseriesAspectServiceTest {
   }
 
   @Test(groups = "upsert")
-  public void testUpsertProfiles() throws InterruptedException {
+  public void testUpsertProfiles() throws Exception {
     // Create the testEntity profiles that we would like to use for testing.
     _startTime = Calendar.getInstance().getTimeInMillis();
 
@@ -146,7 +146,7 @@ public class ElasticSearchTimeseriesAspectServiceTest {
       }
     });
 
-    TimeUnit.SECONDS.sleep(5);
+    syncAfterWrite(_searchClient);
   }
 
   @Test(groups = "query", dependsOnGroups = "upsert")


### PR DESCRIPTION
This improves `syncAfterWrite` for ElasticSearch GraphService tests, which reduces test time to the possible minimum (0,08s per test, not waiting 5s per test any more). This fixes #3124.

The logic of `syncAfterWrite` is used by all ElasticSearch tests in metadata-io now, speeding up those tests as well.