### PR TITLE
Adding GraphQL Explorer! (GraphiQL) 

### DIFF
--- a/metadata-service/auth/src/main/resources/graphiql/index.html
+++ b/metadata-service/auth/src/main/resources/graphiql/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+        body {
+            height: 100%;
+            margin: 0;
+            width: 100%;
+            overflow: hidden;
+        }
+
+        #graphiql {
+            height: 100vh;
+        }
+    </style>
+
+  <!--
+    You can host these files locally or include them directly in your resource bundler.
+  -->
+  <script
+      crossorigin
+      src="https://unpkg.com/react@16/umd/react.development.js"
+  ></script>
+  <script
+      crossorigin
+      src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"
+  ></script>
+
+  <!--
+    These two files can be found in the npm module, however you may wish to
+    copy them directly into your environment, or perhaps include them in your
+    favored resource bundler.
+   -->
+  <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+</head>
+
+<body>
+<div id="graphiql">Loading GraphiQL...</div>
+<script
+    src="https://unpkg.com/graphiql/graphiql.min.js"
+    type="application/javascript"
+></script>
+<script>
+    function graphQLFetcher(path) {
+        return graphQLParams => fetch(
+            `${location.protocol}//${location.host}/api/graphql`,
+            {
+                method: 'post',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(graphQLParams),
+                credentials: 'omit',
+            },
+        ).then(function (response) {
+            return response.json().catch(function () {
+                return response.text();
+            });
+        });
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const path = params.get("path") || "/api/graphql";
+    const gqlFetcher = graphQLFetcher(path);
+    ReactDOM.render(
+        React.createElement(GraphiQL, {
+            fetcher: gqlFetcher,
+            defaultVariableEditorOpen: true,
+        }),
+        document.getElementById('graphiql'),
+    );
+</script>
+</body>
+</html>

--- a/metadata-service/auth/src/main/resources/graphiql/index.html
+++ b/metadata-service/auth/src/main/resources/graphiql/index.html
@@ -51,7 +51,6 @@
                     'Content-Type': 'application/json',
                 },
                 body: JSON.stringify(graphQLParams),
-                credentials: 'omit',
             },
         ).then(function (response) {
             return response.json().catch(function () {

--- a/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLController.java
+++ b/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLController.java
@@ -21,11 +21,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.datahub.metadata.auth.AuthContext;
 
+
 @Slf4j
 @RestController
 public class GraphQLController {
-
-  public GraphQLController() { }
 
   @Inject
   GraphQLEngine _engine;
@@ -103,6 +102,6 @@ public class GraphQLController {
 
   @GetMapping("/graphql")
   void getGraphQL(HttpServletRequest request, HttpServletResponse response) {
-    System.out.println("GET am graphql!");
+    throw new UnsupportedOperationException("GraphQL gets not supported.");
   }
 }

--- a/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphiQLController.java
+++ b/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphiQLController.java
@@ -1,0 +1,40 @@
+package com.datahub.metadata.graphql;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import static java.nio.charset.StandardCharsets.*;
+
+
+@Slf4j
+@Controller
+public class GraphiQLController {
+
+  private final String graphiqlHtml;
+
+  public GraphiQLController() {
+    Resource graphiQLResource = new ClassPathResource("graphiql/index.html");
+    try (Reader reader = new InputStreamReader(graphiQLResource.getInputStream(), UTF_8)) {
+      this.graphiqlHtml = FileCopyUtils.copyToString(reader);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @GetMapping(value = "/graphiql", produces = MediaType.TEXT_HTML_VALUE)
+  @ResponseBody
+  CompletableFuture<String> graphiQL() {
+    return CompletableFuture.supplyAsync(() -> this.graphiqlHtml);
+  }
+}


### PR DESCRIPTION
This PR introduces a GraphQL Explorer accessible via the browser at the following locations:

- your-gms-domain/api/graphiql (example: `localhost:8080/api/graphiql`) 
- your-datahub-frontend-domain/api/graphiql (example: `localhost:9002/api/graphiql`) 

Enjoy exploring the Graph + documentation!


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
