### PR TITLE
fix(frontend): fix utf-8 encoding bug

### DIFF
--- a/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLController.java
+++ b/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLController.java
@@ -29,7 +29,7 @@ public class GraphQLController {
   @Inject
   GraphQLEngine _engine;
 
-  @PostMapping("/graphql")
+  @PostMapping(value = "/graphql", produces = "application/json;charset=utf-8")
   CompletableFuture<ResponseEntity<String>> postGraphQL(HttpEntity<String> httpEntity) {
 
     String jsonStr = httpEntity.getBody();


### PR DESCRIPTION
When merging the graphql server into GMS an encoding bug was introduced. This change propagates the correct encoding header to the client.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
