### PR TITLE
fix(dataset redesign): show ingested description

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/__tests__/SchemaDescriptionField.test.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/__tests__/SchemaDescriptionField.test.tsx
@@ -35,4 +35,45 @@ describe('SchemaDescriptionField', () => {
         fireEvent.click(getByText('Cancel'));
         await waitFor(() => expect(queryByText('Update description')).not.toBeInTheDocument());
     });
+
+    it('renders short messages without show more / show less', () => {
+        const { getByText, queryByText } = render(
+            <SchemaDescriptionField description="short description" onUpdate={() => Promise.resolve()} />,
+        );
+        expect(getByText('short description')).toBeInTheDocument();
+        expect(queryByText('Read Less')).not.toBeInTheDocument();
+        expect(queryByText('Read More')).not.toBeInTheDocument();
+    });
+
+    it('renders longer messages with show more / show less', () => {
+        const longDescription =
+            'really long description over 80 characters, really long description over 80 characters, really long description over 80 characters, really long description over 80 characters, really long description over 80 characters';
+        const { getByText, queryByText } = render(
+            <SchemaDescriptionField description={longDescription} onUpdate={() => Promise.resolve()} />,
+        );
+        expect(getByText('Read More')).toBeInTheDocument();
+        expect(queryByText(longDescription)).not.toBeInTheDocument();
+
+        fireEvent(
+            getByText('Read More'),
+            new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            }),
+        );
+
+        expect(getByText(longDescription)).toBeInTheDocument();
+        expect(getByText('Read Less')).toBeInTheDocument();
+
+        fireEvent(
+            getByText('Read Less'),
+            new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            }),
+        );
+
+        expect(getByText('Read More')).toBeInTheDocument();
+        expect(queryByText(longDescription)).not.toBeInTheDocument();
+    });
 });

--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -6,18 +6,21 @@ import { FetchResult } from '@apollo/client';
 
 import { UpdateDatasetMutation } from '../../../../../../graphql/dataset.generated';
 import UpdateDescriptionModal from '../../../../shared/components/legacy/DescriptionModal';
-import StripMarkdownText from '../../../../shared/components/styled/StripMarkdownText';
+import StripMarkdownText, { removeMarkdown } from '../../../../shared/components/styled/StripMarkdownText';
 import MarkdownViewer from '../../../../shared/components/legacy/MarkdownViewer';
 
 const EditIcon = styled(EditOutlined)`
     cursor: pointer;
     display: none;
-    margin-left: 4px;
 `;
 
 const AddNewDescription = styled(Tag)`
     cursor: pointer;
     display: none;
+`;
+
+const ExpandedActions = styled.div`
+    height: 10px;
 `;
 
 const DescriptionContainer = styled.div`
@@ -63,6 +66,10 @@ const EditedLabel = styled(Typography.Text)`
     font-style: italic;
 `;
 
+const ReadLessText = styled(Typography.Link)`
+    margin-right: 4px;
+`;
+
 type Props = {
     description: string;
     original?: string | null;
@@ -73,6 +80,8 @@ type Props = {
     isEdited?: boolean;
 };
 
+const ABBREVIATED_LIMIT = 80;
+
 export default function DescriptionField({
     description,
     onUpdate,
@@ -81,7 +90,8 @@ export default function DescriptionField({
     original,
 }: Props) {
     const [showAddModal, setShowAddModal] = useState(false);
-    const [expanded, setExpanded] = useState(false);
+    const overLimit = removeMarkdown(description).length > 80;
+    const [expanded, setExpanded] = useState(!overLimit);
 
     const onCloseModal = () => setShowAddModal(false);
 
@@ -112,21 +122,23 @@ export default function DescriptionField({
             {expanded ? (
                 <>
                     <DescriptionText source={description} />
-                    <div>
-                        <Typography.Link
-                            onClick={() => {
-                                setExpanded(false);
-                            }}
-                        >
-                            Read Less
-                        </Typography.Link>
+                    <ExpandedActions>
+                        {overLimit && (
+                            <ReadLessText
+                                onClick={() => {
+                                    setExpanded(false);
+                                }}
+                            >
+                                Read Less
+                            </ReadLessText>
+                        )}
                         {EditButton}
-                    </div>
+                    </ExpandedActions>
                 </>
             ) : (
                 <>
                     <StripMarkdownText
-                        limit={80}
+                        limit={ABBREVIATED_LIMIT}
                         readMore={
                             <>
                                 <Typography.Link

--- a/datahub-web-react/src/app/entity/shared/components/styled/StripMarkdownText.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/StripMarkdownText.tsx
@@ -17,14 +17,18 @@ export type Props = {
     limit?: number;
 };
 
-export default function NoMarkdownViewer({ children, readMore, suffix, limit }: Props) {
-    let plainText = removeMd(children || '', {
+export const removeMarkdown = (text: string) => {
+    return removeMd(text, {
         stripListLeaders: true,
         gfm: true,
         useImgAltText: true,
     })
         .replace(/\n*\n/g, ' • ') // replace linebreaks with •
         .replace(/^•/, ''); // remove first •
+};
+
+export default function NoMarkdownViewer({ children, readMore, suffix, limit }: Props) {
+    let plainText = removeMarkdown(children || '');
 
     if (limit) {
         let abridgedPlainText = plainText.substring(0, limit);

--- a/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfile.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfile.test.tsx
@@ -89,6 +89,9 @@ describe('EntityProfile', () => {
         );
 
         await waitFor(() => expect(getByText('Yet Another Dataset')).toBeInTheDocument());
+        await waitFor(() =>
+            expect(getByText('This and here we have yet another Dataset (YAN). Are there more?')).toBeInTheDocument(),
+        );
     });
 
     it('renders tab content', async () => {

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
@@ -40,7 +40,7 @@ export const SidebarAboutSection = () => {
     const { entityData } = useEntityData();
     const routeToTab = useRouteToTab();
 
-    const description = entityData?.editableProperties?.description;
+    const description = entityData?.editableProperties?.description || entityData?.description;
     const links = entityData?.institutionalMemory?.elements || [];
 
     const isUntouched = !description && !(links?.length > 0);

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -23,7 +23,7 @@ const DocumentationContainer = styled.div`
 
 export const DocumentationTab = () => {
     const { entityData } = useEntityData();
-    const description = entityData?.editableProperties?.description || '';
+    const description = entityData?.editableProperties?.description || entityData?.description || '';
     const links = entityData?.institutionalMemory?.elements || [];
 
     const routeToTab = useRouteToTab();

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
@@ -1,0 +1,62 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { getByText, render } from '@testing-library/react';
+import React from 'react';
+import { mocks } from '../../../../../../Mocks';
+import { EntityType } from '../../../../../../types.generated';
+import TestPageContainer from '../../../../../../utils/test-utils/TestPageContainer';
+import EntityContext from '../../../EntityContext';
+import { DocumentationTab } from '../DocumentationTab';
+
+describe('SchemaDescriptionField', () => {
+    it('renders original description', async () => {
+        const { getByText } = render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/dataset/urn:li:dataset:3']}>
+                    <EntityContext.Provider
+                        value={{
+                            urn: 'urn:li:dataset:123',
+                            entityType: EntityType.Dataset,
+                            entityData: {
+                                description: 'This is a description',
+                            },
+                            baseEntity: {},
+                            updateEntity: jest.fn(),
+                            routeToTab: jest.fn(),
+                        }}
+                    >
+                        <DocumentationTab />
+                    </EntityContext.Provider>
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+        expect(getByText('This is a description')).toBeInTheDocument();
+    });
+
+    it('if editable is present, renders edited description', async () => {
+        const { getByText, queryByText } = render(
+            <MockedProvider mocks={mocks} addTypename={false}>
+                <TestPageContainer initialEntries={['/dataset/urn:li:dataset:3']}>
+                    <EntityContext.Provider
+                        value={{
+                            urn: 'urn:li:dataset:123',
+                            entityType: EntityType.Dataset,
+                            entityData: {
+                                description: 'This is a description',
+                                editableProperties: {
+                                    description: 'Edited description',
+                                },
+                            },
+                            baseEntity: {},
+                            updateEntity: jest.fn(),
+                            routeToTab: jest.fn(),
+                        }}
+                    >
+                        <DocumentationTab />
+                    </EntityContext.Provider>
+                </TestPageContainer>
+            </MockedProvider>,
+        );
+        expect(getByText('Edited description')).toBeInTheDocument();
+        expect(queryByText('This is a description')).not.toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from '@apollo/client/testing';
-import { getByText, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { mocks } from '../../../../../../Mocks';
 import { EntityType } from '../../../../../../types.generated';

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -14,7 +14,7 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
     const { urn, entityType, entityData } = useEntityData();
     const updateEntity = useEntityUpdate<GenericEntityUpdate>();
 
-    const description = entityData?.editableProperties?.description || '';
+    const description = entityData?.editableProperties?.description || entityData?.description || '';
     const [updatedDescription, setUpdatedDescription] = useState(description);
 
     const handleSaveDescription = async () => {

--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -600,6 +600,16 @@
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,logging_events,PROD)",
         "aspects": [
           {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "table where each row represents a single log event",
+              "uri": null,
+              "tags": [],
+              "customProperties": {
+                "encoding": "utf-8"
+              }
+            }
+          },
+          {
             "com.linkedin.pegasus2avro.common.Ownership": {
               "owners": [
                 {
@@ -737,6 +747,16 @@
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_created,PROD)",
         "aspects": [
           {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "table containing all the users created on a single day",
+              "uri": null,
+              "tags": [],
+              "customProperties": {
+                "encoding": "utf-8"
+              }
+            }
+          },
+          {
             "com.linkedin.pegasus2avro.common.Ownership": {
               "owners": [
                 {
@@ -858,6 +878,16 @@
       "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
         "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,fct_users_deleted,PROD)",
         "aspects": [
+          {
+            "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+              "description": "table containing all the users deleted on a single day",
+              "uri": null,
+              "tags": [],
+              "customProperties": {
+                "encoding": "utf-8"
+              }
+            }
+          },
           {
             "com.linkedin.pegasus2avro.common.Ownership": {
               "owners": [


### PR DESCRIPTION
A bug was introduced in the redesign that hid the ingested description, even if no edited description was present. This PR:

1) fixes that issue
2) adds a test to check for this
3) adds default description to some tables in our sample data (none existed before)

Also fixes the issue where short descriptions were not rendered as markdown.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
