### PR TITLE
fix(dbt): add use_identifiers option and avoid duplicate descriptions

### DIFF
--- a/metadata-ingestion/source_docs/dbt.md
+++ b/metadata-ingestion/source_docs/dbt.md
@@ -24,6 +24,8 @@ This plugin pulls metadata from dbt's artifact files:
   - [data platforms](https://github.com/linkedin/datahub/blob/master/gms/impl/src/main/resources/DataPlatformInfo.json)
 - load_schemas:
   - Load schemas from dbt catalog file, not necessary when the underlying data platform already has this data.
+- use_identifiers:
+  - Use model [identifier](https://docs.getdbt.com/reference/resource-properties/identifier) instead of model name if defined (if not, default to model name).
 - node_type_pattern:
   - Use this filter to exclude and include node types using allow or deny method
 
@@ -62,11 +64,10 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `env`                     |          | `"PROD"` | Environment to use in namespace when constructing URNs.                                                                                               |
 | `target_platform`         | ✅       |          | The platform that dbt is loading onto.                                                                                                                |
 | `load_schemas`            | ✅       |          | Whether to load database schemas. If set to `False`, table schema details (e.g. columns) will not be ingested.                                        |
+| `use_identifiers`         |         | `False`   | Whether to use model identifiers instead of names, if defined (if not, default to names)                                                             |
 | `node_type_pattern.allow` |          |          | List of regex patterns for dbt nodes to include in ingestion.                                                                                                  |
 | `node_type_pattern.deny`  |          |          | List of regex patterns for dbt nodes to exclude from ingestion.                                                                                                |
 | `node_type_pattern.ignoreCase`  |          | `True` | Whether to ignore case sensitivity during pattern matching.                                                                                                                                  |
-
-Note: when `load_schemas` is False, models that use [identifiers](https://docs.getdbt.com/reference/resource-properties/identifier) to reference their source tables are ingested using the model identifier as the model name to preserve the lineage.
 
 ## Compatibility
 


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

This PR adds an additional option `use_identifiers` to the dbt configuration to use nodes identifiers instead of names if those are defined, and default back to names if not.

Previously this was achieved by setting `load_schemas=False` however there are cases when we want to load schemas while using node identifiers instead of names (for ex. dbt does not write column descriptions to Snowflake on views* and those need to be ingested with `load_schemas=True`, while using identifiers to preserve the lineage).

*see https://github.com/dbt-labs/dbt/issues/3291

Also:
- renamed `load_catalog` to `load_schemas` in dbt.py for consistency with the config file
- fixed a case issue when reading columns from catalog vs manifest files (names are upper case in the catalog but lower case in the manifest...)
- added a check for node/column description and comment to be different if both are displayed