### PR TITLE
Remove the `datahub-frontend.graphql`

### DIFF
--- a/datahub-web-react/src/graphql-mock/schema.ts
+++ b/datahub-web-react/src/graphql-mock/schema.ts
@@ -4,11 +4,9 @@ import gql from 'graphql-tag';
 import { buildASTSchema } from 'graphql';
 
 const gmsSchema = loader('../../../datahub-graphql-core/src/main/resources/gms.graphql');
-const feSchema = loader('../../../datahub-frontend/conf/datahub-frontend.graphql');
 
 const graphQLSchemaAST = gql`
     ${gmsSchema}
-    ${feSchema}
 `;
 
 export const graphQLSchema = buildASTSchema(graphQLSchemaAST);


### PR DESCRIPTION
Remove the `datahub-frontend.graphql` from the mock server, the schema definition is already covered in the `gms.graphql`.  And the original file (`'../../../datahub-frontend/conf/datahub-frontend.graphql'`) is been removed. 



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
