### PR TITLE
Safely access caught Error properties

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -101,9 +101,9 @@ export default function DescriptionField({
             await onUpdate(desc || '');
             // message.destroy();
             // message.success({ content: 'Updated!', duration: 2 });
-        } catch (e) {
+        } catch (e: unknown) {
             message.destroy();
-            message.error({ content: `Update Failed! \n ${e.message || ''}`, duration: 2 });
+            if (e instanceof Error) message.error({ content: `Update Failed! \n ${e.message || ''}`, duration: 2 });
         }
         onCloseModal();
     };

--- a/datahub-web-react/src/app/entity/shared/components/legacy/UpdatableDescription.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/legacy/UpdatableDescription.tsx
@@ -47,9 +47,9 @@ export default function UpdatableDescription({
                 entityUrn: urn,
             });
             message.success({ content: 'Updated!', duration: 2 });
-        } catch (e) {
+        } catch (e: unknown) {
             message.destroy();
-            message.error({ content: `Update Failed! \n ${e.message || ''}`, duration: 2 });
+            if (e instanceof Error) message.error({ content: `Update Failed! \n ${e.message || ''}`, duration: 2 });
         }
         setShowAddDescModal(false);
     };

--- a/datahub-web-react/src/app/entity/shared/components/styled/AddLinkModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/AddLinkModal.tsx
@@ -47,9 +47,11 @@ export const AddLinkModal = ({ buttonProps }: { buttonProps?: Record<string, unk
                     variables: { input: { urn, institutionalMemory: { elements: newLinks } } },
                 });
                 message.success({ content: 'Link Added', duration: 2 });
-            } catch (e) {
+            } catch (e: unknown) {
                 message.destroy();
-                message.error({ content: `Failed to add link: \n ${e.message || ''}`, duration: 3 });
+                if (e instanceof Error) {
+                    message.error({ content: `Failed to add link: \n ${e.message || ''}`, duration: 3 });
+                }
             }
 
             handleClose();

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -32,9 +32,11 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
             });
             message.success({ content: 'Description Updated', duration: 2 });
             if (onComplete) onComplete();
-        } catch (e) {
+        } catch (e: unknown) {
             message.destroy();
-            message.error({ content: `Failed to update description: \n ${e.message || ''}`, duration: 2 });
+            if (e instanceof Error) {
+                message.error({ content: `Failed to update description: \n ${e.message || ''}`, duration: 2 });
+            }
         }
     };
 

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
@@ -55,7 +55,6 @@ export const LinkList = () => {
             message.success({ content: 'Link Deleted', duration: 2 });
         } catch (e: unknown) {
             message.destroy();
-            message.destroy();
             if (e instanceof Error) {
                 message.error({ content: `Error deleting link: \n ${e.message || ''}`, duration: 2 });
             }

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/LinkList.tsx
@@ -53,9 +53,12 @@ export const LinkList = () => {
                 variables: { input: { urn, institutionalMemory: { elements: newLinks } } },
             });
             message.success({ content: 'Link Deleted', duration: 2 });
-        } catch (e) {
+        } catch (e: unknown) {
             message.destroy();
-            message.error({ content: `Error deleting link: \n ${e.message || ''}`, duration: 2 });
+            message.destroy();
+            if (e instanceof Error) {
+                message.error({ content: `Error deleting link: \n ${e.message || ''}`, duration: 2 });
+            }
         }
     };
 


### PR DESCRIPTION
Update in a few places to safely access caught Error properties via typescript4 `unknown on catch Clause Bindings`  https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#unknown-on-catch-clause-bindings



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
