### PR TITLE
feat(access control): Adding "authorizedActors" method to AuthorizationManager

### DIFF
--- a/metadata-service/auth/src/test/java/com/datahub/metadata/authorization/AuthorizationManagerTest.java
+++ b/metadata-service/auth/src/test/java/com/datahub/metadata/authorization/AuthorizationManagerTest.java
@@ -2,14 +2,22 @@ package com.datahub.metadata.authorization;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Owner;
+import com.linkedin.common.OwnerArray;
+import com.linkedin.common.Ownership;
+import com.linkedin.common.OwnershipType;
 import com.linkedin.common.UrnArray;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.Entity;
 import com.linkedin.entity.client.AspectClient;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.OwnershipClient;
+import com.linkedin.metadata.aspect.Aspect;
 import com.linkedin.metadata.aspect.DataHubPolicyAspect;
 import com.linkedin.metadata.aspect.DataHubPolicyAspectArray;
+import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.query.ListUrnsResult;
 import com.linkedin.metadata.snapshot.DataHubPolicySnapshot;
 import com.linkedin.metadata.snapshot.Snapshot;
@@ -75,9 +83,16 @@ public class AuthorizationManagerTest {
         )
     );
 
+    final List<Urn> userUrns = ImmutableList.of(Urn.createFromString("urn:li:corpuser:user3"), Urn.createFromString("urn:li:corpuser:user4"));
+    final List<Urn> groupUrns = ImmutableList.of(Urn.createFromString("urn:li:corpGroup:group3"), Urn.createFromString("urn:li:corpGroup:group4"));
+    final Ownership ownershipAspect = createOwnershipAspect(userUrns, groupUrns);
+    when(_aspectClient.getAspect(any(), eq(OWNERSHIP_ASPECT_NAME), eq(ASPECT_LATEST_VERSION), any())).thenReturn(
+        new VersionedAspect().setAspect(Aspect.create(ownershipAspect))
+    );
+
     _authorizationManager = new AuthorizationManager(
         _entityClient,
-        _aspectClient,
+        new OwnershipClient(_aspectClient),
         10,
         10,
         Authorizer.AuthorizationMode.DEFAULT
@@ -129,7 +144,7 @@ public class AuthorizationManagerTest {
         Optional.of(resourceSpec)
     );
 
-    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.DENY);
+    assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.ALLOW);
   }
 
   @Test
@@ -165,7 +180,33 @@ public class AuthorizationManagerTest {
     assertEquals(_authorizationManager.authorize(request).getType(), AuthorizationResult.Type.DENY);
   }
 
-  private DataHubPolicyInfo createDataHubPolicyInfo(boolean active, List<String> privileges) {
+  @Test
+  public void testAuthorizedActorsActivePolicy() throws Exception {
+
+    final AuthorizationManager.AuthorizedActors actors = _authorizationManager.authorizedActors(
+        "EDIT_ENTITY_TAGS", // Should be inside the active policy.
+        Optional.of(new ResourceSpec("dataset", "urn:li:dataset:1"))
+    );
+
+    assertTrue(actors.allUsers());
+    assertTrue(actors.allGroups());
+
+    assertEquals(actors.getUsers(), ImmutableList.of(
+        Urn.createFromString("urn:li:corpuser:user1"),
+        Urn.createFromString("urn:li:corpuser:user2"),
+        Urn.createFromString("urn:li:corpuser:user3"),
+        Urn.createFromString("urn:li:corpuser:user4")
+    ));
+
+    assertEquals(actors.getGroups(), ImmutableList.of(
+        Urn.createFromString("urn:li:corpGroup:group1"),
+        Urn.createFromString("urn:li:corpGroup:group2"),
+        Urn.createFromString("urn:li:corpGroup:group3"),
+        Urn.createFromString("urn:li:corpGroup:group4")
+    ));
+  }
+
+  private DataHubPolicyInfo createDataHubPolicyInfo(boolean active, List<String> privileges) throws Exception {
     final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
     dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
     dataHubPolicyInfo.setState(active ? ACTIVE_POLICY_STATE : INACTIVE_POLICY_STATE);
@@ -174,10 +215,15 @@ public class AuthorizationManagerTest {
     dataHubPolicyInfo.setDescription("My test display!");
     dataHubPolicyInfo.setEditable(true);
 
+    List<Urn> users = ImmutableList.of(Urn.createFromString("urn:li:corpuser:user1"), Urn.createFromString("urn:li:corpuser:user2"));
+    List<Urn> groups = ImmutableList.of(Urn.createFromString("urn:li:corpGroup:group1"), Urn.createFromString("urn:li:corpGroup:group2"));
+
     final DataHubActorFilter actorFilter = new DataHubActorFilter();
     actorFilter.setResourceOwners(true);
     actorFilter.setAllUsers(true);
     actorFilter.setAllGroups(true);
+    actorFilter.setUsers(new UrnArray(users));
+    actorFilter.setGroups(new UrnArray(groups));
     dataHubPolicyInfo.setActors(actorFilter);
 
     final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
@@ -185,5 +231,33 @@ public class AuthorizationManagerTest {
     resourceFilter.setType("dataset");
     dataHubPolicyInfo.setResources(resourceFilter);
     return dataHubPolicyInfo;
+  }
+
+  private Ownership createOwnershipAspect(final List<Urn> userOwners, final List<Urn> groupOwners) throws Exception {
+    final Ownership ownershipAspect = new Ownership();
+    final OwnerArray owners = new OwnerArray();
+
+    if (userOwners != null) {
+      userOwners.forEach(userUrn -> {
+          final Owner userOwner = new Owner();
+          userOwner.setOwner(userUrn);
+          userOwner.setType(OwnershipType.DATAOWNER);
+          owners.add(userOwner);
+        }
+      );
+    }
+
+    if (groupOwners != null) {
+      groupOwners.forEach(groupUrn -> {
+        final Owner groupOwner = new Owner();
+        groupOwner.setOwner(groupUrn);
+        groupOwner.setType(OwnershipType.DATAOWNER);
+        owners.add(groupOwner);
+      });
+    }
+
+    ownershipAspect.setOwners(owners);
+    ownershipAspect.setLastModified(new AuditStamp().setTime(0).setActor(Urn.createFromString("urn:li:corpuser:foo")));
+    return ownershipAspect;
   }
 }

--- a/metadata-service/auth/src/test/java/com/datahub/metadata/authorization/PolicyEngineTest.java
+++ b/metadata-service/auth/src/test/java/com/datahub/metadata/authorization/PolicyEngineTest.java
@@ -12,6 +12,7 @@ import com.linkedin.data.template.StringArray;
 import com.linkedin.entity.Entity;
 import com.linkedin.entity.client.AspectClient;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.OwnershipClient;
 import com.linkedin.identity.CorpUserInfo;
 import com.linkedin.identity.GroupMembership;
 import com.linkedin.metadata.aspect.Aspect;
@@ -52,7 +53,7 @@ public class PolicyEngineTest {
   public void setupTest() throws Exception {
     _entityClient = Mockito.mock(EntityClient.class);
     _aspectClient = Mockito.mock(AspectClient.class);
-    _policyEngine = new PolicyEngine(_entityClient, _aspectClient);
+    _policyEngine = new PolicyEngine(_entityClient, new OwnershipClient(_aspectClient));
 
     // Init mocks.
     final CorpUserSnapshot authorizedUser = createDataHubSnapshot();

--- a/metadata-service/auth/src/test/java/com/datahub/metadata/authorization/PolicyEngineTest.java
+++ b/metadata-service/auth/src/test/java/com/datahub/metadata/authorization/PolicyEngineTest.java
@@ -1,5 +1,6 @@
 package com.datahub.metadata.authorization;
 
+import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.Owner;
 import com.linkedin.common.OwnerArray;
@@ -24,6 +25,7 @@ import com.linkedin.metadata.snapshot.Snapshot;
 import com.linkedin.policy.DataHubActorFilter;
 import com.linkedin.policy.DataHubPolicyInfo;
 import com.linkedin.policy.DataHubResourceFilter;
+import java.util.Collections;
 import java.util.Optional;
 import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
@@ -729,6 +731,126 @@ public class PolicyEngineTest {
         ))
     );
     assertFalse(result.isGranted());
+
+    // Verify no network calls
+    verify(_aspectClient, times(0)).getAspect(any(), any(), any(), any());
+    verify(_entityClient, times(0)).get(eq(Urn.createFromString(AUTHORIZED_PRINCIPAL)), any());
+  }
+
+  @Test
+  public void testGetMatchingActorsResourceMatch() throws Exception {
+
+    final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
+    dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
+    dataHubPolicyInfo.setState(ACTIVE_POLICY_STATE);
+    dataHubPolicyInfo.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    dataHubPolicyInfo.setDisplayName("My Test Display");
+    dataHubPolicyInfo.setDescription("My test display!");
+    dataHubPolicyInfo.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    actorFilter.setResourceOwners(true);
+    actorFilter.setAllUsers(true);
+    actorFilter.setAllGroups(true);
+    actorFilter.setUsers(new UrnArray(
+        ImmutableList.of(
+            Urn.createFromString("urn:li:corpuser:user1"),
+            Urn.createFromString("urn:li:corpuser:user2")
+        )
+    ));
+    actorFilter.setGroups(new UrnArray(
+        ImmutableList.of(
+            Urn.createFromString("urn:li:corpGroup:group1"),
+            Urn.createFromString("urn:li:corpGroup:group2")
+        )
+    ));
+    dataHubPolicyInfo.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setAllResources(false);
+    resourceFilter.setType("dataset");
+    StringArray resourceUrns = new StringArray();
+    resourceUrns.add(RESOURCE_URN); // Filter applies to specific resource.
+    resourceFilter.setResources(resourceUrns);
+    dataHubPolicyInfo.setResources(resourceFilter);
+
+    PolicyEngine.PolicyActors actors = _policyEngine.getMatchingActors(
+        dataHubPolicyInfo,
+        Optional.of(new ResourceSpec(
+            "dataset",
+            RESOURCE_URN // A resource covered by the policy.
+        ))
+    );
+
+    assertTrue(actors.allUsers());
+    assertTrue(actors.allGroups());
+
+    assertEquals(actors.getUsers(), ImmutableList.of(
+        Urn.createFromString("urn:li:corpuser:user1"),
+        Urn.createFromString("urn:li:corpuser:user2"),
+        Urn.createFromString(AUTHORIZED_PRINCIPAL) // Resource Owner
+    ));
+
+    assertEquals(actors.getGroups(), ImmutableList.of(
+        Urn.createFromString("urn:li:corpGroup:group1"),
+        Urn.createFromString("urn:li:corpGroup:group2"),
+        Urn.createFromString(AUTHORIZED_GROUP) // Resource Owner
+    ));
+
+    // Verify aspect client called, entity client not called.
+    verify(_aspectClient, times(1)).getAspect(any(), any(), any(), any());
+    verify(_entityClient, times(0)).get(eq(Urn.createFromString(AUTHORIZED_PRINCIPAL)), any());
+  }
+
+  @Test
+  public void testGetMatchingActorsNoResourceMatch() throws Exception {
+
+    final DataHubPolicyInfo dataHubPolicyInfo = new DataHubPolicyInfo();
+    dataHubPolicyInfo.setType(METADATA_POLICY_TYPE);
+    dataHubPolicyInfo.setState(ACTIVE_POLICY_STATE);
+    dataHubPolicyInfo.setPrivileges(new StringArray("EDIT_ENTITY_TAGS"));
+    dataHubPolicyInfo.setDisplayName("My Test Display");
+    dataHubPolicyInfo.setDescription("My test display!");
+    dataHubPolicyInfo.setEditable(true);
+
+    final DataHubActorFilter actorFilter = new DataHubActorFilter();
+    actorFilter.setResourceOwners(true);
+    actorFilter.setAllUsers(true);
+    actorFilter.setAllGroups(true);
+    actorFilter.setUsers(new UrnArray(
+        ImmutableList.of(
+            Urn.createFromString("urn:li:corpuser:user1"),
+            Urn.createFromString("urn:li:corpuser:user2")
+        )
+    ));
+    actorFilter.setGroups(new UrnArray(
+        ImmutableList.of(
+            Urn.createFromString("urn:li:corpGroup:group1"),
+            Urn.createFromString("urn:li:corpGroup:group2")
+        )
+    ));
+    dataHubPolicyInfo.setActors(actorFilter);
+
+    final DataHubResourceFilter resourceFilter = new DataHubResourceFilter();
+    resourceFilter.setAllResources(false);
+    resourceFilter.setType("dataset");
+    StringArray resourceUrns = new StringArray();
+    resourceUrns.add(RESOURCE_URN);
+    resourceFilter.setResources(resourceUrns);
+    dataHubPolicyInfo.setResources(resourceFilter);
+
+    PolicyEngine.PolicyActors actors = _policyEngine.getMatchingActors(
+        dataHubPolicyInfo,
+        Optional.of(new ResourceSpec(
+            "dataset",
+            "urn:li:dataset:random" // A resource not covered by the policy.
+        ))
+    );
+
+    assertFalse(actors.allUsers());
+    assertFalse(actors.allGroups());
+    assertEquals(actors.getUsers(), Collections.emptyList());
+    assertEquals(actors.getGroups(), Collections.emptyList());
 
     // Verify no network calls
     verify(_aspectClient, times(0)).getAspect(any(), any(), any(), any());

--- a/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/AuthorizationManagerFactory.java
+++ b/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/AuthorizationManagerFactory.java
@@ -3,6 +3,7 @@ package com.datahub.metadata.graphql;
 import com.datahub.metadata.authorization.AuthorizationManager;
 import com.linkedin.entity.client.AspectClient;
 import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.OwnershipClient;
 import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,6 +42,8 @@ public class AuthorizationManagerFactory {
         ? AuthorizationManager.AuthorizationMode.DEFAULT
         : AuthorizationManager.AuthorizationMode.ALLOW_ALL;
 
-    return new AuthorizationManager(entityClient, aspectClient, 10, policyCacheRefreshIntervalSeconds, mode);
+    final OwnershipClient ownershipClient = new OwnershipClient(aspectClient);
+
+    return new AuthorizationManager(entityClient, ownershipClient, 10, policyCacheRefreshIntervalSeconds, mode);
   }
 }

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/OwnershipClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/OwnershipClient.java
@@ -1,0 +1,50 @@
+package com.linkedin.entity.client;
+
+import com.linkedin.common.Ownership;
+import com.linkedin.metadata.aspect.VersionedAspect;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.RestLiServiceException;
+import javax.annotation.Nullable;
+
+import static com.linkedin.metadata.Constants.*;
+
+
+/**
+ * Basic client that fetches {@link Ownership} aspects from the Metadata Service.
+ */
+public class OwnershipClient {
+
+  private final AspectClient _aspectClient;
+
+  public OwnershipClient(final AspectClient aspectClient) {
+    _aspectClient = aspectClient;
+  }
+
+  /**
+   * Retrieve the latest version of the standard {@link Ownership} aspect from the Metadata Service,
+   * using a raw {@link AspectClient}.
+   *
+   * @param urn stringified urn associated with the entity to fetch Ownership for.
+   * @return an instance of {@link Ownership} if one is found, or null if one is not found.
+   * @throws RemoteInvocationException if Rest.li throws an unexpected exception (aside from 404 not found)
+   */
+  @Nullable
+  public Ownership getLatestOwnership(final String urn) throws RemoteInvocationException {
+    // Fetch the latest version of "ownership" aspect for the resource.
+    try {
+      final VersionedAspect aspect = _aspectClient.getAspect(
+          urn,
+          OWNERSHIP_ASPECT_NAME,
+          ASPECT_LATEST_VERSION,
+          SYSTEM_ACTOR);
+      return aspect.getAspect().getOwnership();
+    } catch (RestLiServiceException e) {
+      if (HttpStatus.S_404_NOT_FOUND.equals(e.getStatus())) {
+        // No aspect exists.
+        return null;
+      }
+      throw e;
+    }
+  }
+}

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -9,6 +9,17 @@ public class Constants {
   public static final String SYSTEM_ACTOR = "urn:li:principal:datahub"; // DataHub internal service principal.
   public static final String UNKNOWN_ACTOR = "urn:li:principal:UNKNOWN"; // Unknown principal.
   public static final Long ASPECT_LATEST_VERSION = 0L;
+
+  /**
+   * Entities
+   */
+  public static final String CORP_USER_ENTITY_NAME = "corpuser";
+  public static final String CORP_GROUP_ENTITY_NAME = "corpGroup";
+
+  /**
+   * Aspects
+   */
   public static final String OWNERSHIP_ASPECT_NAME = "ownership";
+
   private Constants() { }
 }


### PR DESCRIPTION
2 changes:

1. Fixing issue where "ALLOW_ALL" mode was not being honored (misconfigured test)
2. Adding an "authorizedActors" method to AuthorizationManager to allow asking the question: "Who is authorized for this privilege against this resource?" 
3. Introducing a thin wrapper called OwnershipClient to make fetching the standard Ownership aspect easier. 
4. Unit tests 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
