### PR TITLE
fix(graphql): Allow explicit JSON null in GraphQL endpoint 

### DIFF
--- a/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLController.java
+++ b/metadata-service/graphql-api/src/main/java/com/datahub/metadata/graphql/GraphQLController.java
@@ -64,11 +64,11 @@ public class GraphQLController {
      * Extract "variables" map
      */
     JsonNode variablesJson = bodyJson.get("variables");
-    final Map<String, Object> variables = variablesJson != null
+    final Map<String, Object> variables = (variablesJson != null && !variablesJson.isNull())
       ? new ObjectMapper().convertValue(variablesJson, new TypeReference<Map<String, Object>>() { })
       : Collections.emptyMap();
 
-    log.debug(String.format("Executing graphQL query: %s, variables: %s", queryJson, variablesJson));
+    log.debug(String.format("Executing graphQL query: %s, variables: %s", queryJson, variables));
 
     /*
      * Init QueryContext


### PR DESCRIPTION
Title says it. GraphiQL passes an explicit null value when variables are not present. Supporting this case. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
