### PR TITLE
fix(bootstrap): Invoke BootstrapManage once

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManagerApplicationListener.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManagerApplicationListener.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
 
 
 /**
@@ -16,12 +17,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class BootstrapManagerApplicationListener implements ApplicationListener<ContextRefreshedEvent> {
 
+  private static final String ROOT_WEB_APPLICATION_CONTEXT_ID = String.format("%s:", WebApplicationContext.class.getName());
+
   @Autowired
   @Qualifier("bootstrapManager")
   private BootstrapManager _bootstrapManager;
 
   @Override
   public void onApplicationEvent(@Nonnull ContextRefreshedEvent event) {
-    _bootstrapManager.start();
+    if (ROOT_WEB_APPLICATION_CONTEXT_ID.equals(event.getApplicationContext().getId())) {
+      _bootstrapManager.start();
+    }
   }
 }


### PR DESCRIPTION
Currently, bootstrap manager invoked 2 times for each spring context: root context and that created by the API servlet dispatcherservlet. This PR ensures that we only run when the Root context is refreshed at boot time. 

Validated locally. 
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
