### PR TITLE
ci: Upload test reports

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,6 +29,11 @@ jobs:
           python-version: "3.6"
       - name: Gradle build (and test)
         run: ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Test Results
+          path: "**/build/reports/tests/test/**"
       - name: Ensure codegen is updated
         run: |
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then


### PR DESCRIPTION
This uploads the test reports to GitHub so that they can be investigated when test fails:

![grafik](https://user-images.githubusercontent.com/44700269/132093465-09b2f146-db66-42d7-b4bd-9387810c0d79.png)