### PR TITLE
test: No need to run tests in smoke test again

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         run: ./metadata-ingestion/scripts/install_deps.sh
       - name: Gradle build
-        run: ./gradlew build -x check -x docs-website:build
+        run: ./gradlew build -x check -x test -x datahub-web-react:yarnTest -x docs-website:build
       - name: Smoke test
         run: ./smoke-test/smoke.sh
       - name: Slack failure notification


### PR DESCRIPTION
Tests are run in `build` job and `smoke-test` job again. The `build` job will make the CI pipeline fail anyway, no need to run the tests in smoke test again.