### PR TITLE
fix(admin): moving admin links to header

### DIFF
--- a/datahub-web-react/src/app/ProtectedRoutes.tsx
+++ b/datahub-web-react/src/app/ProtectedRoutes.tsx
@@ -10,7 +10,6 @@ import { SearchPage } from './search/SearchPage';
 import { AnalyticsPage } from './analyticsDashboard/components/AnalyticsPage';
 import { PoliciesPage } from './policy/PoliciesPage';
 import AppConfigProvider from '../AppConfigProvider';
-import { AdminConsole } from './AdminConsole';
 
 /**
  * Container for all views behind an authentication wall.
@@ -20,7 +19,6 @@ export const ProtectedRoutes = (): JSX.Element => {
     return (
         <AppConfigProvider>
             <Layout style={{ height: '100%', width: '100%' }}>
-                <AdminConsole />
                 <Layout>
                     <Switch>
                         <Route exact path="/" render={() => <HomePage />} />

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -12,6 +12,7 @@ import { GetSearchResultsQuery, useGetAutoCompleteAllResultsLazyQuery } from '..
 import { useGetAllEntitySearchResults } from '../../utils/customGraphQL/useGetAllEntitySearchResults';
 import { EntityType } from '../../types.generated';
 import analytics, { EventType } from '../analytics';
+import { AdminHeaderLinks } from '../shared/admin/AdminHeaderLinks';
 
 const Background = styled.div`
     width: 100%;
@@ -211,6 +212,7 @@ export const HomePageHeader = () => {
                     )}
                 </WelcomeText>
                 <NavGroup>
+                    <AdminHeaderLinks />
                     <ManageAccount
                         urn={user?.urn || ''}
                         pictureLink={user?.editableInfo?.pictureLink || ''}

--- a/datahub-web-react/src/app/search/SearchHeader.tsx
+++ b/datahub-web-react/src/app/search/SearchHeader.tsx
@@ -8,6 +8,7 @@ import { ManageAccount } from '../shared/ManageAccount';
 import { AutoCompleteResultForEntity, EntityType } from '../../types.generated';
 import EntityRegistry from '../entity/EntityRegistry';
 import { ANTD_GRAY } from '../entity/shared/constants';
+import { AdminHeaderLinks } from '../shared/admin/AdminHeaderLinks';
 
 const { Header } = Layout;
 
@@ -90,6 +91,7 @@ export const SearchHeader = ({
                 />
             </LogoSearchContainer>
             <NavGroup>
+                <AdminHeaderLinks />
                 <ManageAccount urn={authenticatedUserUrn} pictureLink={authenticatedUserPictureLink || ''} />
             </NavGroup>
         </Header>

--- a/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
+++ b/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+import * as React from 'react';
+import { BankOutlined, BarChartOutlined } from '@ant-design/icons';
+import { Link } from 'react-router-dom';
+
+import { ANTD_GRAY } from '../../entity/shared/constants';
+import { useAppConfig } from '../../useAppConfig';
+import { useGetAuthenticatedUser } from '../../useGetAuthenticatedUser';
+
+const AdminLink = styled.span`
+    a {
+        color: ${ANTD_GRAY[9]};
+    }
+    font-weight: 600;
+    padding-right: 16px;
+`;
+
+export function AdminHeaderLinks() {
+    const me = useGetAuthenticatedUser();
+    const { config } = useAppConfig();
+
+    const isAnalyticsEnabled = config?.analyticsConfig.enabled;
+    const isPoliciesEnabled = config?.policiesConfig.enabled;
+
+    const showAnalytics = (isAnalyticsEnabled && me && me.platformPrivileges.viewAnalytics) || false;
+    const showPolicyBuilder = (isPoliciesEnabled && me && me.platformPrivileges.managePolicies) || false;
+
+    return (
+        <>
+            {showAnalytics && (
+                <AdminLink>
+                    <Link to="/analytics">
+                        <BarChartOutlined /> Analytics
+                    </Link>
+                </AdminLink>
+            )}
+            {showPolicyBuilder && (
+                <AdminLink>
+                    <Link to="/policies">
+                        <BankOutlined /> Policies
+                    </Link>
+                </AdminLink>
+            )}
+        </>
+    );
+}

--- a/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
+++ b/datahub-web-react/src/app/shared/admin/AdminHeaderLinks.tsx
@@ -2,17 +2,13 @@ import styled from 'styled-components';
 import * as React from 'react';
 import { BankOutlined, BarChartOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
+import { Button } from 'antd';
 
-import { ANTD_GRAY } from '../../entity/shared/constants';
 import { useAppConfig } from '../../useAppConfig';
 import { useGetAuthenticatedUser } from '../../useGetAuthenticatedUser';
 
 const AdminLink = styled.span`
-    a {
-        color: ${ANTD_GRAY[9]};
-    }
-    font-weight: 600;
-    padding-right: 16px;
+    margin-right: 4px;
 `;
 
 export function AdminHeaderLinks() {
@@ -30,14 +26,18 @@ export function AdminHeaderLinks() {
             {showAnalytics && (
                 <AdminLink>
                     <Link to="/analytics">
-                        <BarChartOutlined /> Analytics
+                        <Button type="text">
+                            <BarChartOutlined /> Analytics
+                        </Button>
                     </Link>
                 </AdminLink>
             )}
             {showPolicyBuilder && (
                 <AdminLink>
                     <Link to="/policies">
-                        <BankOutlined /> Policies
+                        <Button type="text">
+                            <BankOutlined /> Policies
+                        </Button>
                     </Link>
                 </AdminLink>
             )}


### PR DESCRIPTION
The admin hamburger floater would sometimes overlap important information. Moving to header for now so it won't conflict with other content.
![image](https://user-images.githubusercontent.com/2455694/132427434-5b8547e8-bae3-4c7e-a8a5-5f9d6db5bf00.png)
![image](https://user-images.githubusercontent.com/2455694/132427453-6598109f-2abd-41e2-bc3f-432149748b3e.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
