### PR TITLE
fix(local-development): fix proxy for login route

### DIFF
--- a/datahub-web-react/src/setupProxy.js
+++ b/datahub-web-react/src/setupProxy.js
@@ -1,3 +1,7 @@
+const logInFilter = function (pathname, req) {
+  return pathname.match('^/logIn') && req.method === 'POST';
+};
+
 if (process.env.REACT_APP_MOCK === 'true' || process.env.REACT_APP_MOCK === 'cy') {
     // no proxy needed, MirageJS will intercept all http requests
     module.exports = function () {};
@@ -8,7 +12,7 @@ if (process.env.REACT_APP_MOCK === 'true' || process.env.REACT_APP_MOCK === 'cy'
     module.exports = function (app) {
         app.use(
             '/logIn',
-            createProxyMiddleware({
+            createProxyMiddleware(logInFilter, {
                 target: 'http://localhost:9002',
                 changeOrigin: true,
             }),


### PR DESCRIPTION
Logging in while developing on the react app caused some proxy issues. This only occurred while loading the react app in development mode while not logged in.

The issue was that the login page was proxied to the frontend server and served from there. It in turn had references to the frontend server's generated bundles. However, the bundle fetching was not proxied. Since the generated bundle ids are randomly created, the development react server would not find the frontend server's bundle ids.

This fix stops the login page from being proxied to the frontend server so the correct bundle ids are included in the page.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
