### PR TITLE
fix(frontend): Add additional sasl config for kafka producer in datahub-frontend

### DIFF
--- a/datahub-frontend/app/controllers/TrackingController.java
+++ b/datahub-frontend/app/controllers/TrackingController.java
@@ -127,6 +127,7 @@ public class TrackingController extends Controller {
                 setConfig(props, SaslConfigs.SASL_MECHANISM, "analytics.kafka.sasl.mechanism");
                 setConfig(props, SaslConfigs.SASL_JAAS_CONFIG, "analytics.kafka.sasl.jaas.config");
                 setConfig(props, SaslConfigs.SASL_KERBEROS_SERVICE_NAME, "analytics.kafka.sasl.kerberos.service.name");
+                setConfig(props, SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS, "analytics.kafka.sasl.login.callback.handler.class");
             }
         }
 

--- a/datahub-frontend/conf/application.conf
+++ b/datahub-frontend/conf/application.conf
@@ -166,6 +166,7 @@ analytics.kafka.ssl.endpoint.identification.algorithm = ${?KAFKA_PROPERTIES_SSL_
 analytics.kafka.sasl.mechanism = ${?KAFKA_PROPERTIES_SASL_MECHANISM}
 analytics.kafka.sasl.jaas.config = ${?KAFKA_PROPERTIES_SASL_JAAS_CONFIG}
 analytics.kafka.sasl.kerberos.service.name = ${?KAFKA_PROPERTIES_SASL_KERBEROS_SERVICE_NAME}
+analytics.kafka.sasl.login.callback.handler.class = ${?KAFKA_PROPERTIES_SASL_LOGIN_CALLBACK_HANDLER_CLASS}
 
 # Required Elastic Client Configuration
 analytics.elastic.host =  ${ELASTIC_CLIENT_HOST}


### PR DESCRIPTION
Requested config: analytics.kafka.sasl.login.callback.handler.class

This should be resolved once we move Tracking module to GMS. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
