### PR TITLE
fix(tags): fix tag name overwrite

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/tag/mappers/TagSnapshotMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/tag/mappers/TagSnapshotMapper.java
@@ -37,7 +37,6 @@ public class TagSnapshotMapper implements ModelMapper<TagSnapshot, Tag> {
                 if (TagProperties.class.cast(aspect).hasDescription()) {
                     result.setDescription(TagProperties.class.cast(aspect).getDescription());
                 }
-                result.setName(TagProperties.class.cast(aspect).getName());
             } else if (aspect instanceof Ownership) {
                 result.setOwnership(OwnershipMapper.map((Ownership) aspect));
             }


### PR DESCRIPTION
Removing the 2nd place that tag name is set in tag mapper- this caused issues when TagProperties were set but name was not set equal to name in the urn.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
