### PR TITLE
fix(ui): fix lineage button color

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/nav/ProfileNavBrowsePath.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/nav/ProfileNavBrowsePath.tsx
@@ -3,7 +3,7 @@ import { Link, useHistory, useLocation } from 'react-router-dom';
 import { Badge, Breadcrumb, Row } from 'antd';
 import styled from 'styled-components';
 import { InfoCircleOutlined, PartitionOutlined } from '@ant-design/icons';
-import { blue, grey } from '@ant-design/colors';
+import { grey, blue } from '@ant-design/colors';
 import { EntityType } from '../../../../../../types.generated';
 import { useEntityRegistry } from '../../../../../useEntityRegistry';
 import { PageRoutes } from '../../../../../../conf/Global';
@@ -43,10 +43,10 @@ const IconGroup = styled.div<{ isSelected: boolean; disabled: boolean }>`
         if (props.disabled) {
             return grey[2];
         }
-        return props.isSelected ? 'black' : grey[2];
+        return !props.isSelected ? 'black' : props.theme.styles['primary-color'] || blue[4];
     }};
     &:hover {
-        color: ${(props) => !props.disabled && (props.isSelected ? 'black' : blue[4])};
+        color: ${(props) => (props.disabled ? grey[2] : props.theme.styles['primary-color'] || blue[4])};
         cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
     }
 `;
@@ -122,7 +122,11 @@ export const ProfileNavBrowsePath = ({ type, path, upstreams, downstreams }: Pro
                     <IconGroup
                         disabled={!hasLineage}
                         isSelected={!isLineageMode}
-                        onClick={() => navigateToLineageUrl({ location, history, isLineageMode: false })}
+                        onClick={() => {
+                            if (hasLineage) {
+                                navigateToLineageUrl({ location, history, isLineageMode: false });
+                            }
+                        }}
                     >
                         <DetailIcon />
                         Details
@@ -130,7 +134,11 @@ export const ProfileNavBrowsePath = ({ type, path, upstreams, downstreams }: Pro
                     <IconGroup
                         disabled={!hasLineage}
                         isSelected={isLineageMode}
-                        onClick={() => navigateToLineageUrl({ location, history, isLineageMode: true })}
+                        onClick={() => {
+                            if (hasLineage) {
+                                navigateToLineageUrl({ location, history, isLineageMode: true });
+                            }
+                        }}
                     >
                         <LineageIcon />
                         Lineage

--- a/datahub-web-react/src/conf/theme/theme_dark.config.json
+++ b/datahub-web-react/src/conf/theme/theme_dark.config.json
@@ -1,5 +1,6 @@
 {
     "styles": {
+        "primary-color": "#1890ff",
         "layout-header-background": "#333E4C",
         "layout-header-color": "white",
         "layout-body-background": "#333E4C",

--- a/datahub-web-react/src/conf/theme/theme_light.config.json
+++ b/datahub-web-react/src/conf/theme/theme_light.config.json
@@ -1,5 +1,6 @@
 {
     "styles": {
+        "primary-color": "#1890ff",
         "layout-header-background": "white",
         "layout-header-color": "#434343",
         "layout-body-background": "white",

--- a/datahub-web-react/src/conf/theme/types.ts
+++ b/datahub-web-react/src/conf/theme/types.ts
@@ -1,5 +1,6 @@
 export type Theme = {
     styles: {
+        'primary-color'?: string;
         'layout-header-background': string;
         'layout-header-color': string;
         'layout-body-background': string;


### PR DESCRIPTION
The button group would previously indicate that lineage was unavailable thru grey text on the Lineage button. This fixes it!

![image](https://user-images.githubusercontent.com/2455694/132916750-e668f789-d7b7-4511-806c-c9b2946ad041.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
