### PR TITLE
fix(UI): fix jitter on schema when adding description

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -1,4 +1,4 @@
-import { Typography, message, Tag } from 'antd';
+import { Typography, message, Button } from 'antd';
 import { EditOutlined } from '@ant-design/icons';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -14,9 +14,10 @@ const EditIcon = styled(EditOutlined)`
     display: none;
 `;
 
-const AddNewDescription = styled(Tag)`
-    cursor: pointer;
+const AddNewDescription = styled(Button)`
     display: none;
+    margin: -4px;
+    width: 140px;
 `;
 
 const ExpandedActions = styled.div`
@@ -112,6 +113,8 @@ export default function DescriptionField({
         (editable && description && <EditIcon twoToneColor="#52c41a" onClick={() => setShowAddModal(true)} />) ||
         undefined;
 
+    const showAddDescription = editable && !description;
+
     return (
         <DescriptionContainer
             onClick={(e) => {
@@ -121,19 +124,21 @@ export default function DescriptionField({
         >
             {expanded ? (
                 <>
-                    <DescriptionText source={description} />
-                    <ExpandedActions>
-                        {overLimit && (
-                            <ReadLessText
-                                onClick={() => {
-                                    setExpanded(false);
-                                }}
-                            >
-                                Read Less
-                            </ReadLessText>
-                        )}
-                        {EditButton}
-                    </ExpandedActions>
+                    {!!description && <DescriptionText source={description} />}
+                    {!!description && (
+                        <ExpandedActions>
+                            {overLimit && (
+                                <ReadLessText
+                                    onClick={() => {
+                                        setExpanded(false);
+                                    }}
+                                >
+                                    Read Less
+                                </ReadLessText>
+                            )}
+                            {EditButton}
+                        </ExpandedActions>
+                    )}
                 </>
             ) : (
                 <>
@@ -169,8 +174,8 @@ export default function DescriptionField({
                     />
                 </div>
             )}
-            {editable && !description && (
-                <AddNewDescription color="success" onClick={() => setShowAddModal(true)}>
+            {showAddDescription && (
+                <AddNewDescription type="text" onClick={() => setShowAddModal(true)}>
                     + Add Description
                 </AddNewDescription>
             )}

--- a/metadata-ingestion/examples/mce_files/bootstrap_mce.json
+++ b/metadata-ingestion/examples/mce_files/bootstrap_mce.json
@@ -745,6 +745,18 @@
                   },
                   "nativeDataType": "boolean",
                   "recursive": false
+                },
+                {
+                  "fieldPath": "browser",
+                  "jsonPath": null,
+                  "nullable": false,
+                  "type": {
+                    "type": {
+                      "com.linkedin.pegasus2avro.schema.StringType": {}
+                    }
+                  },
+                  "nativeDataType": "string",
+                  "recursive": false
                 }
               ],
               "primaryKeys": null,


### PR DESCRIPTION
Refresh add description button and remove jitter when hovering over it

![image](https://user-images.githubusercontent.com/2455694/133140063-7b21e713-298b-48fb-a4ac-adf4552116ff.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
