### PR TITLE
fix(policies): Only ingest bootstrap policies on clean start

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManager.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManager.java
@@ -22,7 +22,7 @@ public class BootstrapManager {
     // Once the application has been set up, apply boot steps.
     log.info("Starting Bootstrap Process...");
     for (int i = 0; i < _bootSteps.size(); i++) {
-      log.info(String.format("Executing Bootstrap Step %s/%s...", i, _bootSteps.size()));
+      log.info(String.format("Executing Bootstrap Step %s/%s...", i+1, _bootSteps.size()));
       final BootstrapStep step = _bootSteps.get(i);
       try {
         step.execute();

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManager.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManager.java
@@ -22,12 +22,12 @@ public class BootstrapManager {
     // Once the application has been set up, apply boot steps.
     log.info("Starting Bootstrap Process...");
     for (int i = 0; i < _bootSteps.size(); i++) {
-      log.info(String.format("Executing Bootstrap Step %s/%s...", i+1, _bootSteps.size()));
       final BootstrapStep step = _bootSteps.get(i);
+      log.info(String.format("Executing bootstrap step %s/%s with name %s...", i + 1, _bootSteps.size(), step.name()));
       try {
         step.execute();
       } catch (Exception e) {
-        log.error(String.format("Caught exception while executing bootstrao step %s. Exiting...", step.name()), e);
+        log.error(String.format("Caught exception while executing bootstrap step %s. Exiting...", step.name()), e);
         System.exit(1);
       }
     }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestPoliciesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestPoliciesStep.java
@@ -92,7 +92,8 @@ public class IngestPoliciesStep implements BootstrapStep {
   }
 
   private boolean hasDefaultPolicies() throws URISyntaxException {
-    // If there are already default policies, denoted by presence of policy 0, don't ingest bootstrap policies. This will retain any changes made to policies.
+    // If there are already default policies, denoted by presence of policy 0, don't ingest bootstrap policies.
+    // This will retain any changes made to policies after initial bootstrap.
     final Urn defaultPolicyUrn = Urn.createFromString("urn:li:dataHubPolicy:0");
     RecordTemplate aspect = _entityService.getAspect(defaultPolicyUrn, POLICY_INFO_ASPECT_NAME, 0);
     return aspect != null;

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestPoliciesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestPoliciesStep.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.boot.BootstrapStep;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.dao.utils.RecordUtils;
@@ -17,9 +18,11 @@ import com.linkedin.policy.DataHubPolicyInfo;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Iterator;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.ClassPathResource;
 
 
+@Slf4j
 public class IngestPoliciesStep implements BootstrapStep {
 
   private static final String POLICY_ENTITY_NAME = "dataHubPolicy";
@@ -41,45 +44,57 @@ public class IngestPoliciesStep implements BootstrapStep {
 
     final ObjectMapper mapper = new ObjectMapper();
 
-    // 1. Read from the file into JSON.
-    final JsonNode policiesObj = mapper.readTree(new ClassPathResource("./boot/policies.json").getFile());
+    // 0. Execute preflight check to see whether we need to ingest policies
+    if (!hasDefaultPolicies()) {
 
-    if (!policiesObj.isArray()) {
-      throw new RuntimeException(String.format("Found malformed policies file, expected an Array but found %s", policiesObj.getNodeType()));
+      log.info("Ingesting default access policies...");
+
+      // 1. Read from the file into JSON.
+      final JsonNode policiesObj = mapper.readTree(new ClassPathResource("./boot/policies.json").getFile());
+
+      if (!policiesObj.isArray()) {
+        throw new RuntimeException(String.format("Found malformed policies file, expected an Array but found %s", policiesObj.getNodeType()));
+      }
+
+      // 2. For each JSON object, cast into a DataHub Policy Info object.
+      for (Iterator<JsonNode> it = policiesObj.iterator(); it.hasNext(); ) {
+        final JsonNode policyObj = it.next();
+        final DataHubPolicyInfo info = RecordUtils.toRecordTemplate(DataHubPolicyInfo.class, policyObj.get("info").toString());
+        final Urn urn = Urn.createFromString(policyObj.get("urn").asText());
+
+        // 3. Write key & aspect
+        final MetadataChangeProposal keyAspectProposal = new MetadataChangeProposal();
+        final AspectSpec keyAspectSpec = _entityService.getKeyAspectSpec(urn);
+        GenericAspect aspect = GenericAspectUtils.serializeAspect(EntityKeyUtils.convertUrnToEntityKey(urn, keyAspectSpec.getPegasusSchema()));
+        keyAspectProposal.setAspect(aspect);
+        keyAspectProposal.setAspectName(keyAspectSpec.getName());
+        keyAspectProposal.setEntityType(POLICY_ENTITY_NAME);
+        keyAspectProposal.setChangeType(ChangeType.UPSERT);
+        keyAspectProposal.setEntityUrn(urn);
+
+        _entityService.ingestProposal(keyAspectProposal,
+            new AuditStamp().setActor(Urn.createFromString("urn:li:corpuser:system")).setTime(System.currentTimeMillis()));
+
+        final MetadataChangeProposal proposal = new MetadataChangeProposal();
+        proposal.setEntityUrn(urn);
+        proposal.setEntityType(POLICY_ENTITY_NAME);
+        proposal.setAspectName(POLICY_INFO_ASPECT_NAME);
+        proposal.setAspect(GenericAspectUtils.serializeAspect(info));
+        proposal.setChangeType(ChangeType.UPSERT);
+
+        _entityService.ingestProposal(proposal,
+            new AuditStamp().setActor(Urn.createFromString("urn:li:corpuser:system")).setTime(System.currentTimeMillis()));
+        log.info("Successfully ingested default access policies.");
+      }
+    } else {
+      log.info("Skipping IngestPoliciesStep, default policies already exist.");
     }
+  }
 
-    // 2. For each JSON object, cast into a DataHub Policy Info object.
-    for (Iterator<JsonNode> it = policiesObj.iterator(); it.hasNext(); ) {
-      final JsonNode policyObj = it.next();
-      final DataHubPolicyInfo info = RecordUtils.toRecordTemplate(DataHubPolicyInfo.class, policyObj.get("info").toString());
-      final Urn urn = Urn.createFromString(policyObj.get("urn").asText());
-
-      // 3. Write key & aspect
-      final MetadataChangeProposal keyAspectProposal = new MetadataChangeProposal();
-      final AspectSpec keyAspectSpec = _entityService.getKeyAspectSpec(urn);
-      GenericAspect aspect = GenericAspectUtils.serializeAspect(
-          EntityKeyUtils.convertUrnToEntityKey(
-              urn, keyAspectSpec.getPegasusSchema()));
-      keyAspectProposal.setAspect(aspect);
-      keyAspectProposal.setAspectName(keyAspectSpec.getName());
-      keyAspectProposal.setEntityType(POLICY_ENTITY_NAME);
-      keyAspectProposal.setChangeType(ChangeType.UPSERT);
-      keyAspectProposal.setEntityUrn(urn);
-
-      _entityService.ingestProposal(keyAspectProposal, new AuditStamp()
-          .setActor(Urn.createFromString("urn:li:corpuser:system"))
-          .setTime(System.currentTimeMillis()));
-
-      final MetadataChangeProposal proposal = new MetadataChangeProposal();
-      proposal.setEntityUrn(urn);
-      proposal.setEntityType(POLICY_ENTITY_NAME);
-      proposal.setAspectName(POLICY_INFO_ASPECT_NAME);
-      proposal.setAspect(GenericAspectUtils.serializeAspect(info));
-      proposal.setChangeType(ChangeType.UPSERT);
-
-      _entityService.ingestProposal(proposal, new AuditStamp()
-          .setActor(Urn.createFromString("urn:li:corpuser:system"))
-          .setTime(System.currentTimeMillis()));
-    }
+  private boolean hasDefaultPolicies() throws URISyntaxException {
+    // If there are already default policies, denoted by presence of policy 0, don't ingest bootstrap policies. This will retain any changes made to policies.
+    final Urn defaultPolicyUrn = Urn.createFromString("urn:li:dataHubPolicy:0");
+    RecordTemplate aspect = _entityService.getAspect(defaultPolicyUrn, POLICY_INFO_ASPECT_NAME, 0);
+    return aspect != null;
   }
 }


### PR DESCRIPTION
This PR ensures that we only ingest bootstrap policies when a clean start occurs, or when no bootstrap policies have already been ingested.

Thanks to @aseembansal-gogo for reporting!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
