### PR TITLE
feat(glossary): splitting apart tags & terms into their own visual sections

### DIFF
--- a/datahub-web-react/src/app/entity/shared/constants.ts
+++ b/datahub-web-react/src/app/entity/shared/constants.ts
@@ -26,6 +26,10 @@ export const EMPTY_MESSAGES = {
         title: 'No tags added yet',
         description: 'Tag entities to help make them more discoverable and call out their most important attributes.',
     },
+    terms: {
+        title: 'No terms added yet',
+        description: 'Apply glossary terms to entities to classify their data.',
+    },
     owners: {
         title: 'No owners added yet',
         description:

--- a/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfile.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfile.test.tsx
@@ -316,7 +316,7 @@ describe('EntityProfile', () => {
         );
 
         // find the tags
-        await waitFor(() => expect(getByText('Tags')).toBeInTheDocument());
+        await waitFor(() => expect(getByText('Tags & Terms')).toBeInTheDocument());
         await waitFor(() => expect(getByText('abc-sample-tag')).toBeInTheDocument());
     });
 });

--- a/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfile.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/__tests__/EntityProfile.test.tsx
@@ -316,7 +316,7 @@ describe('EntityProfile', () => {
         );
 
         // find the tags
-        await waitFor(() => expect(getByText('Tags & Terms')).toBeInTheDocument());
+        await waitFor(() => expect(getByText('Tags')).toBeInTheDocument());
         await waitFor(() => expect(getByText('abc-sample-tag')).toBeInTheDocument());
     });
 });

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
@@ -15,35 +15,31 @@ export const SidebarTagsSection = ({ properties }: { properties?: any }) => {
 
     const { urn, entityType, entityData } = useEntityData();
 
-    const showTermGroup = (entityData?.glossaryTerms?.terms?.length || 0) > 0;
     const refetch = useRefetch();
     return (
         <div>
-            <SidebarHeader title={showTermGroup ? 'Tags' : 'Tags & Terms'} />
+            <SidebarHeader title="Tags" />
             <TagTermGroup
                 editableTags={entityData?.globalTags}
                 canAddTag={canAddTag}
-                canAddTerm={!showTermGroup}
                 canRemove
                 showEmptyMessage
                 entityUrn={urn}
                 entityType={entityType}
                 refetch={refetch}
             />
-            {showTermGroup && (
-                <TermSection>
-                    <SidebarHeader title="Glossary Terms" />
-                    <TagTermGroup
-                        editableGlossaryTerms={entityData?.glossaryTerms}
-                        canAddTerm={canAddTerm}
-                        canRemove
-                        showEmptyMessage
-                        entityUrn={urn}
-                        entityType={entityType}
-                        refetch={refetch}
-                    />
-                </TermSection>
-            )}
+            <TermSection>
+                <SidebarHeader title="Glossary Terms" />
+                <TagTermGroup
+                    editableGlossaryTerms={entityData?.glossaryTerms}
+                    canAddTerm={canAddTerm}
+                    canRemove
+                    showEmptyMessage
+                    entityUrn={urn}
+                    entityType={entityType}
+                    refetch={refetch}
+                />
+            </TermSection>
         </div>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarTagsSection.tsx
@@ -1,28 +1,49 @@
 import React from 'react';
+import styled from 'styled-components';
+
 import TagTermGroup from '../../../../../shared/tags/TagTermGroup';
 import { SidebarHeader } from './SidebarHeader';
 import { useEntityData, useRefetch } from '../../../EntityContext';
+
+const TermSection = styled.div`
+    margin-top: 20px;
+`;
 
 export const SidebarTagsSection = ({ properties }: { properties?: any }) => {
     const canAddTag = properties?.hasTags;
     const canAddTerm = properties?.hasTerms;
 
     const { urn, entityType, entityData } = useEntityData();
+
+    const showTermGroup = (entityData?.glossaryTerms?.terms?.length || 0) > 0;
     const refetch = useRefetch();
     return (
         <div>
-            <SidebarHeader title="Tags" />
+            <SidebarHeader title={showTermGroup ? 'Tags' : 'Tags & Terms'} />
             <TagTermGroup
                 editableTags={entityData?.globalTags}
-                editableGlossaryTerms={entityData?.glossaryTerms}
                 canAddTag={canAddTag}
-                canAddTerm={canAddTerm}
+                canAddTerm={!showTermGroup}
                 canRemove
                 showEmptyMessage
                 entityUrn={urn}
                 entityType={entityType}
                 refetch={refetch}
             />
+            {showTermGroup && (
+                <TermSection>
+                    <SidebarHeader title="Glossary Terms" />
+                    <TagTermGroup
+                        editableGlossaryTerms={entityData?.glossaryTerms}
+                        canAddTerm={canAddTerm}
+                        canRemove
+                        showEmptyMessage
+                        entityUrn={urn}
+                        entityType={entityType}
+                        refetch={refetch}
+                    />
+                </TermSection>
+            )}
         </div>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/SchemaTable.tsx
@@ -60,20 +60,9 @@ export default function SchemaTable({
     const hasUsageStats = useMemo(() => (usageStats?.aggregations?.fields?.length || 0) > 0, [usageStats]);
 
     const [tagHoveredIndex, setTagHoveredIndex] = useState<string | undefined>(undefined);
-    const hasTerms =
-        rows.filter((row) => !!row.glossaryTerms?.terms?.length).length > 0 ||
-        (editableSchemaMetadata?.editableSchemaFieldInfo.filter((row) => !!row.glossaryTerms?.terms?.length).length ||
-            0) > 0;
 
     const descriptionRender = useDescriptionRenderer(editableSchemaMetadata, onUpdateDescription);
     const usageStatsRenderer = useUsageStatsRenderer(usageStats);
-    const tagAndTermRender = useTagsAndTermsRenderer(
-        editableSchemaMetadata,
-        onUpdateTags,
-        tagHoveredIndex,
-        setTagHoveredIndex,
-        { showTags: true, showTerms: true },
-    );
     const tagRenderer = useTagsAndTermsRenderer(
         editableSchemaMetadata,
         onUpdateTags,
@@ -102,17 +91,8 @@ export default function SchemaTable({
         },
     });
 
-    const tagAndTermColumn = {
-        width: 150,
-        title: 'Tags & Terms',
-        dataIndex: 'globalTags',
-        key: 'tag',
-        render: tagAndTermRender,
-        onCell: onTagTermCell,
-    };
-
     const tagColumn = {
-        width: 100,
+        width: 125,
         title: 'Tags',
         dataIndex: 'globalTags',
         key: 'tag',
@@ -121,7 +101,7 @@ export default function SchemaTable({
     };
 
     const termColumn = {
-        width: 100,
+        width: 125,
         title: 'Terms',
         dataIndex: 'globalTags',
         key: 'tag',
@@ -144,12 +124,7 @@ export default function SchemaTable({
         width: 300,
     };
 
-    let allColumns: ColumnsType<ExtendedSchemaFields> = [];
-    if (hasTerms) {
-        allColumns = [...defaultColumns, descriptionColumn, tagColumn, termColumn];
-    } else {
-        allColumns = [...defaultColumns, descriptionColumn, tagAndTermColumn];
-    }
+    let allColumns: ColumnsType<ExtendedSchemaFields> = [...defaultColumns, descriptionColumn, tagColumn, termColumn];
 
     if (hasUsageStats) {
         allColumns = [...allColumns, usageColumn];

--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Schema/utils/useTagsAndTermsRenderer.tsx
@@ -16,6 +16,7 @@ export default function useTagsAndTermsRenderer(
     onUpdateTags: (update: GlobalTagsUpdate, record?: EditableSchemaFieldInfo) => Promise<any>,
     tagHoveredIndex: string | undefined,
     setTagHoveredIndex: (index: string | undefined) => void,
+    options: { showTags: boolean; showTerms: boolean },
 ) {
     const { urn } = useEntityData();
     const refetch = useRefetch();
@@ -27,14 +28,14 @@ export default function useTagsAndTermsRenderer(
 
         return (
             <TagTermGroup
-                uneditableTags={tags}
-                editableTags={relevantEditableFieldInfo?.globalTags}
-                uneditableGlossaryTerms={record.glossaryTerms}
-                editableGlossaryTerms={relevantEditableFieldInfo?.glossaryTerms}
+                uneditableTags={options.showTags ? tags : null}
+                editableTags={options.showTags ? relevantEditableFieldInfo?.globalTags : null}
+                uneditableGlossaryTerms={options.showTerms ? record.glossaryTerms : null}
+                editableGlossaryTerms={options.showTerms ? relevantEditableFieldInfo?.glossaryTerms : null}
                 canRemove
                 buttonProps={{ size: 'small' }}
-                canAddTag={tagHoveredIndex === `${record.fieldPath}-${rowIndex}`}
-                canAddTerm={tagHoveredIndex === `${record.fieldPath}-${rowIndex}`}
+                canAddTag={tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTags}
+                canAddTerm={tagHoveredIndex === `${record.fieldPath}-${rowIndex}` && options.showTerms}
                 onOpenModal={() => setTagHoveredIndex(undefined)}
                 entityUrn={urn}
                 entityType={EntityType.Dataset}

--- a/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
@@ -64,7 +64,11 @@ export default function TagTermGroup({
     const entityRegistry = useEntityRegistry();
     const [showAddModal, setShowAddModal] = useState(false);
     const [addModalType, setAddModalType] = useState(EntityType.Tag);
-    const tagsEmpty = !editableTags?.tags?.length;
+    const tagsEmpty =
+        !editableTags?.tags?.length &&
+        !uneditableTags?.tags?.length &&
+        !editableGlossaryTerms?.terms?.length &&
+        !uneditableGlossaryTerms?.terms?.length;
     const [removeTagMutation] = useRemoveTagMutation();
     const [removeTermMutation] = useRemoveTermMutation();
 
@@ -203,7 +207,7 @@ export default function TagTermGroup({
                     </TagLink>
                 );
             })}
-            {showEmptyMessage && (canAddTag || canAddTerm) && tagsEmpty && (
+            {showEmptyMessage && canAddTag && tagsEmpty && (
                 <Typography.Paragraph type="secondary">
                     {EMPTY_MESSAGES.tags.title}. {EMPTY_MESSAGES.tags.description}
                 </Typography.Paragraph>

--- a/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
+++ b/datahub-web-react/src/app/shared/tags/TagTermGroup.tsx
@@ -212,6 +212,11 @@ export default function TagTermGroup({
                     {EMPTY_MESSAGES.tags.title}. {EMPTY_MESSAGES.tags.description}
                 </Typography.Paragraph>
             )}
+            {showEmptyMessage && canAddTerm && tagsEmpty && (
+                <Typography.Paragraph type="secondary">
+                    {EMPTY_MESSAGES.terms.title}. {EMPTY_MESSAGES.terms.description}
+                </Typography.Paragraph>
+            )}
             {canAddTag && (uneditableTags?.tags?.length || 0) + (editableTags?.tags?.length || 0) < 10 && (
                 <NoElementButton
                     type={showEmptyMessage && tagsEmpty ? 'default' : 'text'}


### PR DESCRIPTION
Render tags and terms in separate sections.

Terms present:
![image](https://user-images.githubusercontent.com/2455694/133659105-bcb2f922-62a2-419a-9a86-2132c0cc7e3e.png)

Empty state:
![image](https://user-images.githubusercontent.com/2455694/133663025-5b509447-fe6c-4aaa-ac3f-ae5e42d6dbdb.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
