### PR TITLE
fix(ingest): allow ingestion of glossary terms without nodes

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
@@ -62,7 +62,8 @@ class BusinessGlossarySourceConfig(ConfigModel):
 
 class BusinessGlossaryConfig(DefaultConfig):
     version: str
-    nodes: List[GlossaryNodeConfig]
+    nodes: Optional[List[GlossaryNodeConfig]]
+    terms: Optional[List[GlossaryTermConfig]]
 
     @validator("version")
     def version_must_be_1(cls, v):
@@ -106,14 +107,26 @@ def get_mces(
     path: List[str] = []
     root_owners = get_owners(glossary.owners)
 
-    for node in glossary.nodes:
-        events += get_mces_from_node(
-            node,
-            path + [node.name],
-            parentNode=None,
-            parentOwners=root_owners,
-            defaults=glossary,
-        )
+    if glossary.nodes:
+        for node in glossary.nodes:
+            events += get_mces_from_node(
+                node,
+                path + [node.name],
+                parentNode=None,
+                parentOwners=root_owners,
+                defaults=glossary,
+            )
+
+    if glossary.terms:
+        for term in glossary.terms:
+            events += get_mces_from_term(
+                term,
+                path + [term.name],
+                parentNode=None,
+                parentOwnership=root_owners,
+                defaults=glossary,
+            )
+
     return events
 
 
@@ -171,7 +184,7 @@ def get_mces_from_node(
 def get_mces_from_term(
     glossaryTerm: GlossaryTermConfig,
     path: List[str],
-    parentNode: str,
+    parentNode: Optional[str],
     parentOwnership: models.OwnershipClass,
     defaults: DefaultConfig,
 ) -> List[models.MetadataChangeEventClass]:


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

This PR allows ingesting Business Glossary terms defined at the root level (without nodes).

Tested locally with DataHub v0.8.13.