### PR TITLE
feat(GraphService): Add Dgraph implementation of GraphService

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,14 +17,8 @@ on:
 
 jobs:
   build:
-    name: "build (#${{ matrix.high-digit}}${{ matrix.low-digit}})"
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        high-digit: [0, 1, 2]
-        low-digit: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -42,14 +36,13 @@ jobs:
           ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x datahub-web-react:yarnBuild -x datahub-frontend:unzipAssets
           ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
       - uses: actions/upload-artifact@v2
-        if: failure()
+        if: always()
         with:
-          name: "Test Results #${{ matrix.high-digit}}${{ matrix.low-digit}}"
+          name: Test Results (build)
           path: |
             **/build/reports/tests/test/**
             **/build/test-results/test/**
             **/junit.*.xml
-          retention-days: 5
       - name: Ensure codegen is updated
         run: |
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,8 +17,14 @@ on:
 
 jobs:
   build:
+    name: "build (#${{ matrix.high-digit}}${{ matrix.low-digit}})"
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        high-digit: [0, 1, 2]
+        low-digit: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -36,13 +42,14 @@ jobs:
           ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x datahub-web-react:yarnBuild -x datahub-frontend:unzipAssets
           ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: Test Results (build)
+          name: "Test Results #${{ matrix.high-digit}}${{ matrix.low-digit}}"
           path: |
             **/build/reports/tests/test/**
             **/build/test-results/test/**
             **/junit.*.xml
+          retention-days: 5
       - name: Ensure codegen is updated
         run: |
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ project.ext.externalDependency = [
     'commonsLang': 'commons-lang:commons-lang:2.6',
     'commonsCollections': 'commons-collections:commons-collections:3.2.2',
     'data' : 'com.linkedin.pegasus:data:' + pegasusVersion,
+    'dgraph4j' : 'io.dgraph:dgraph4j:21.03.1',
     'dropwizardMetricsCore': 'io.dropwizard.metrics:metrics-core:4.2.3',
     'dropwizardMetricsJmx': 'io.dropwizard.metrics:metrics-jmx:4.2.3',
     'ebean': 'io.ebean:ebean:11.33.3',

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -40,6 +40,7 @@ dependencies {
   testCompile externalDependency.testContainers
   testCompile externalDependency.testContainersJunit
   testCompile externalDependency.testContainersElasticsearch
+  testCompile externalDependency.lombok
   testCompile project(':test-models')
 
   testAnnotationProcessor externalDependency.lombok

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -15,6 +15,7 @@ dependencies {
   compile spec.product.pegasus.data
   compile spec.product.pegasus.generator
 
+  compile externalDependency.dgraph4j exclude group: 'com.google.guava', module: 'guava'
   compile externalDependency.lombok
   compile externalDependency.elasticSearchRest
   compile externalDependency.elasticSearchTransport

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   compile externalDependency.ebean
   enhance externalDependency.ebeanAgent
   compile externalDependency.opentelemetryAnnotations
+  compile externalDependency.resilience4j
   compile externalDependency.springContext
 
   annotationProcessor externalDependency.lombok

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
@@ -1,0 +1,65 @@
+package com.linkedin.metadata.graph;
+
+import io.dgraph.DgraphClient;
+import io.dgraph.TxnConflictException;
+import io.grpc.StatusRuntimeException;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+public class DgraphExecutor {
+    private final DgraphClient _client;
+
+    public DgraphExecutor(DgraphClient client) {
+        this._client = client;
+    }
+
+    public <T> T execute(Function<DgraphClient, T> func) {
+        int retry = 0;
+        while (true) {
+            try {
+                return func.apply(_client);
+            } catch (Exception e) {
+                Throwable t = e;
+
+                // unwrap RuntimeException and ExecutionException
+                while (true) {
+                    if ((t instanceof RuntimeException || t instanceof ExecutionException) && t.getCause() != null) {
+                        t = t.getCause();
+                        continue;
+                    }
+                    break;
+                }
+
+                if (t instanceof TxnConflictException
+                        || t instanceof StatusRuntimeException && (
+                        t.getMessage().contains("operation opIndexing is already running")
+                                || t.getMessage().contains("Please retry")
+                                || t.getMessage().contains("DEADLINE_EXCEEDED:")
+                )) {
+                    try {
+                        // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10.24s
+                        long time = (long) Math.pow(2, Math.min(retry, 10)) * 10;
+                        synchronized (System.out) {
+                            System.out.printf(System.currentTimeMillis() + ": retrying in %d ms due to %s%n", time, e.getMessage());
+                        }
+                        TimeUnit.MILLISECONDS.sleep(time);
+                        retry++;
+                    } catch (InterruptedException e2) {
+                        // ignore interruption
+                    }
+
+                    continue;
+                }
+
+                // throw unexpected exceptions
+                synchronized (System.out) {
+                    System.out.printf(System.currentTimeMillis() + ": un-retried exception: %s%n", e.getMessage());
+                }
+
+                throw e;
+            }
+        }
+    }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
@@ -6,12 +6,14 @@ import io.github.resilience4j.core.IntervalFunction;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import io.grpc.StatusRuntimeException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+@Slf4j
 public class DgraphExecutor {
 
     // requests are retried with an exponential randomized backoff
@@ -88,9 +90,7 @@ public class DgraphExecutor {
                         || t.getMessage().contains("context deadline exceeded")
                         || t.getMessage().contains("Only leader can decide to commit or abort")
         )) {
-            synchronized (System.out) {
-                System.out.printf(System.currentTimeMillis() + ": retrying %s%n", t.getMessage());
-            }
+            log.debug("retrying request due to {}", t.getMessage());
             return true;
         }
         return false;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
@@ -44,7 +44,7 @@ public class DgraphExecutor {
                         // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10.24s
                         long time = (long) Math.pow(2, Math.min(retry, 10)) * 10;
                         synchronized (System.out) {
-                            System.out.printf(System.currentTimeMillis() + ": retrying in %d ms due to %s%n", time, e.getMessage());
+                            System.out.printf(System.currentTimeMillis() + ": retrying in %d ms due to %s%n", time, t.getMessage());
                         }
                         TimeUnit.MILLISECONDS.sleep(time);
                         retry++;
@@ -57,7 +57,7 @@ public class DgraphExecutor {
 
                 // throw unexpected exceptions
                 synchronized (System.out) {
-                    System.out.printf(System.currentTimeMillis() + ": un-retried exception: %s%n", e.getMessage());
+                    System.out.printf(System.currentTimeMillis() + ": un-retried exception: %s%n", t.getMessage());
                 }
 
                 throw e;

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
@@ -2,66 +2,97 @@ package com.linkedin.metadata.graph;
 
 import io.dgraph.DgraphClient;
 import io.dgraph.TxnConflictException;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.retry.Retry;
+import io.github.resilience4j.retry.RetryConfig;
 import io.grpc.StatusRuntimeException;
 
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class DgraphExecutor {
-    private final DgraphClient _client;
 
-    public DgraphExecutor(DgraphClient client) {
+    // requests are retried with an exponential randomized backoff
+    // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10s, all ±50%
+    private static final Duration INITIAL_DURATION = Duration.ofMillis(10);
+    private static final Duration MAX_DURATION = Duration.ofSeconds(10);
+    private static final double BACKOFF_MULTIPLIER = 2.0;
+    private static final double RANDOMIZATION_FACTOR = 0.5;
+
+    private final DgraphClient _client;
+    private final Retry _retry;
+
+    public DgraphExecutor(DgraphClient client, int maxAttempts) {
         this._client = client;
+
+        RetryConfig config = RetryConfig.custom()
+                .intervalFunction(IntervalFunction.ofExponentialRandomBackoff(INITIAL_DURATION, BACKOFF_MULTIPLIER, RANDOMIZATION_FACTOR, MAX_DURATION))
+                .retryOnException(DgraphExecutor::isRetryableException)
+                .failAfterMaxAttempts(true)
+                .maxAttempts(maxAttempts)
+                .build();
+        this._retry = Retry.of("DgraphExecutor", config);
     }
 
-    public <T> T execute(Function<DgraphClient, T> func) {
-        int retry = 0;
+    /**
+     * Executes the given DgraphClient call and retries retry-able exceptions.
+     * Subsequent executions will experience an exponential randomized backoff.
+     *
+     * @param func call on the provided DgraphClient
+     * @param <T> return type of the function
+     * @return return value of the function
+     * @throws io.github.resilience4j.retry.MaxRetriesExceeded if max attempts exceeded
+     */
+    public <T> T executeFunction(Function<DgraphClient, T> func) {
+        return Retry.decorateFunction(this._retry, func).apply(_client);
+    }
+
+    /**
+     * Executes the given DgraphClient call and retries retry-able exceptions.
+     * Subsequent executions will experience an exponential randomized backoff.
+     *
+     * @param func call on the provided DgraphClient
+     * @throws io.github.resilience4j.retry.MaxRetriesExceeded if max attempts exceeded
+     */
+    public void executeConsumer(Consumer<DgraphClient> func) {
+        this._retry.executeSupplier(() -> {
+            func.accept(_client);
+            return null;
+        });
+    }
+
+    /**
+     * Defines which DgraphClient exceptions are being retried.
+     *
+     * @param t exception from DgraphClient
+     * @return true if this exception can be retried
+     */
+    private static boolean isRetryableException(Throwable t) {
+        // unwrap RuntimeException and ExecutionException
         while (true) {
-            try {
-                return func.apply(_client);
-            } catch (Exception e) {
-                Throwable t = e;
-
-                // unwrap RuntimeException and ExecutionException
-                while (true) {
-                    if ((t instanceof RuntimeException || t instanceof ExecutionException) && t.getCause() != null) {
-                        t = t.getCause();
-                        continue;
-                    }
-                    break;
-                }
-
-                if (t instanceof TxnConflictException
-                        || t instanceof StatusRuntimeException && (
-                        t.getMessage().contains("operation opIndexing is already running")
-                                || t.getMessage().contains("Please retry")
-                                || t.getMessage().contains("DEADLINE_EXCEEDED:")
-                                || t.getMessage().contains("context deadline exceeded")
-                                || t.getMessage().contains("Only leader can decide to commit or abort")
-                )) {
-                    try {
-                        // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10.24s
-                        long time = (long) Math.pow(2, Math.min(retry, 10)) * 10;
-                        synchronized (System.out) {
-                            System.out.printf(System.currentTimeMillis() + ": retrying in %d ms due to %s%n", time, t.getMessage());
-                        }
-                        TimeUnit.MILLISECONDS.sleep(time);
-                        retry++;
-                    } catch (InterruptedException e2) {
-                        // ignore interruption
-                    }
-
-                    continue;
-                }
-
-                // throw unexpected exceptions
-                synchronized (System.out) {
-                    System.out.printf(System.currentTimeMillis() + ": un-retried exception: %s%n", t.getMessage());
-                }
-
-                throw e;
+            if ((t instanceof RuntimeException || t instanceof ExecutionException) && t.getCause() != null) {
+                t = t.getCause();
+                continue;
             }
+            break;
         }
+
+        // retry-able exceptions
+        if (t instanceof TxnConflictException
+                || t instanceof StatusRuntimeException && (
+                t.getMessage().contains("operation opIndexing is already running")
+                        || t.getMessage().contains("Please retry")
+                        || t.getMessage().contains("DEADLINE_EXCEEDED:")
+                        || t.getMessage().contains("context deadline exceeded")
+                        || t.getMessage().contains("Only leader can decide to commit or abort")
+        )) {
+            synchronized (System.out) {
+                System.out.printf(System.currentTimeMillis() + ": retrying %s%n", t.getMessage());
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphExecutor.java
@@ -37,6 +37,8 @@ public class DgraphExecutor {
                         t.getMessage().contains("operation opIndexing is already running")
                                 || t.getMessage().contains("Please retry")
                                 || t.getMessage().contains("DEADLINE_EXCEEDED:")
+                                || t.getMessage().contains("context deadline exceeded")
+                                || t.getMessage().contains("Only leader can decide to commit or abort")
                 )) {
                     try {
                         // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10.24s

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -1,0 +1,392 @@
+package com.linkedin.metadata.graph;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.CriterionArray;
+import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.RelationshipFilter;
+import io.dgraph.DgraphClient;
+import io.dgraph.DgraphProto;
+import io.dgraph.DgraphProto.Value;
+import io.dgraph.DgraphProto.Mutation;
+import io.dgraph.DgraphProto.NQuad;
+import io.dgraph.DgraphProto.Operation;
+import io.dgraph.DgraphProto.Request;
+import io.dgraph.DgraphProto.Response;
+import io.dgraph.Helpers;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+@Slf4j
+public class DgraphGraphService implements GraphService {
+
+    private final DgraphClient _client;
+
+    public DgraphGraphService(@Nonnull DgraphClient client) {
+        this._client = client;
+        Operation setSchema = Operation.newBuilder()
+                .setSchema("" +
+                        "<urn>: string @index(hash) .\n" +
+                        "<type>: string @index(exact) .\n" +
+                        "<key>: string @index(hash) .\n"
+                )
+                .build();
+        this._client.alter(setSchema);
+    }
+
+    @Override
+    public void addEdge(Edge edge) {
+        log.debug(String.format("Adding Edge source: %s, destination: %s, type: %s",
+                edge.getSource(),
+                edge.getDestination(),
+                edge.getRelationshipType()));
+
+        // add the relationship type to the schema
+        // TODO: translate edge name to allowed dgraph uris
+        // TODO: cache the schema and only mutate if relationship is new
+        String schema = String.format("<%s>: [uid] @reverse .", edge.getRelationshipType());
+        log.debug("Adding to schema: " + schema);
+        Operation setSchema = Operation.newBuilder()
+                .setSchema(schema)
+                .build();
+        this._client.alter(setSchema);
+
+        // lookup the source and destination nodes
+        // TODO: add escape for string values
+        String query = String.format("query {\n" +
+                " src as var(func: eq(urn, \"%s\"))\n" +
+                " dst as var(func: eq(urn, \"%s\"))\n" +
+                "}", edge.getSource(), edge.getDestination());
+        // create source and destination nodes if they do not exist
+        // and create the new edge between them
+        // TODO: add escape for string values
+        // TODO: translate edge name to allowed dgraph uris
+        String mutations = String.format("" +
+                        "uid(src) <urn> \"%s\" .\n" +
+                        "uid(src) <type> \"%s\" .\n" +
+                        "uid(src) <key> \"%s\" .\n" +
+                        "uid(dst) <urn> \"%s\" .\n" +
+                        "uid(dst) <type> \"%s\" .\n" +
+                        "uid(dst) <key> \"%s\" .\n" +
+                        "uid(src) <%s> uid(dst) .",
+                edge.getSource(),
+                edge.getSource().getEntityType(),
+                edge.getSource().getEntityKey(),
+                edge.getDestination(),
+                edge.getDestination().getEntityType(),
+                edge.getDestination().getEntityKey(),
+                edge.getRelationshipType()
+        );
+
+        log.debug("Query: " + query);
+        log.debug("Mutations: " + mutations);
+
+        // construct the upsert
+        Mutation mutation = Mutation.newBuilder()
+                .setSetNquads(ByteString.copyFromUtf8(mutations))
+                .build();
+        Request request = Request.newBuilder()
+                .setQuery(query)
+                .addMutations(mutation)
+                .setCommitNow(true)
+                .build();
+
+        // run the request
+        this._client.newTransaction().doRequest(request);
+    }
+
+    protected static String getQueryForRelatedUrns(@Nullable String sourceType,
+                                                   @Nonnull Filter sourceEntityFilter,
+                                                   @Nullable String destinationType,
+                                                   @Nonnull Filter destinationEntityFilter,
+                                                   @Nonnull List<String> relationshipTypes,
+                                                   @Nonnull RelationshipFilter relationshipFilter,
+                                                   int offset,
+                                                   int count) {
+        // TODO: verify assumptions: criterions in filters are AND
+        // TODO: support destinationEntityFilter
+        // TODO: support relationshipFilter (direction)
+
+        List<String> filters = new ArrayList<>();
+
+        String bootstrapFilterName = null;
+        String sourceTypeFilterName = null;
+        String destinationTypeFilterName = null;
+        List<String> sourceFilterNames = new ArrayList<>();
+        List<String> destinationFilterNames = new ArrayList<>();
+        List<String> relationshipTypeFilterNames = new ArrayList<>();
+
+        if (sourceType != null && !sourceType.isEmpty()) {
+            sourceTypeFilterName = "sourceType";
+            // TODO: escape string value
+            filters.add(String.format("%s as var(func: eq(<type>, \"%s\"))", sourceTypeFilterName, sourceType));
+        }
+
+        if (destinationType != null && !destinationType.isEmpty()) {
+            destinationTypeFilterName = "destinationTypeType";
+            // TODO: escape string value
+            filters.add(String.format("%s as var(func: eq(<type>, \"%s\"))", destinationTypeFilterName, destinationType));
+        }
+
+        CriterionArray sourceCriteria = sourceEntityFilter.getCriteria();
+        IntStream.range(0, sourceCriteria.size())
+                .forEach(idx -> {
+                    String sourceFilterName = "sourceFilter" + (idx + 1);
+                    sourceFilterNames.add(sourceFilterName);
+                    Criterion criterion = sourceCriteria.get(idx);
+                    // TODO: escape field name and string value
+                    filters.add(String.format("%s as var(func: eq(<%s>, \"%s\"))", sourceFilterName, criterion.getField(), criterion.getValue()));
+                });
+        CriterionArray destinationCriteria = destinationEntityFilter.getCriteria();
+        IntStream.range(0, destinationCriteria.size())
+                .forEach(idx -> {
+                    String sourceFilterName = "destinationFilter" + (idx + 1);
+                    destinationFilterNames.add(sourceFilterName);
+                    Criterion criterion = destinationCriteria.get(idx);
+                    // TODO: escape field name and string value
+                    filters.add(String.format("%s as var(func: eq(<%s>, \"%s\"))", sourceFilterName, criterion.getField(), criterion.getValue()));
+                });
+
+        IntStream.range(0, relationshipTypes.size())
+                .forEach(idx -> {
+                    String relationshipTypeFilterName = "relationshipType" + (idx + 1);
+                    relationshipTypeFilterNames.add(relationshipTypeFilterName);
+                    // TODO: escape string value
+                    filters.add(String.format("%s as var(func: has(<%s>))", relationshipTypeFilterName, relationshipTypes.get(idx)));
+                });
+
+        // bootstrap filter is the first filter that is being applied
+        // should be most selective to improve performance
+        // TODO: we can only retrieve all relationships (non given) when we add all relationships to a node type
+        //       then we would also have to move the destination type filter to a different place in the query
+        //       better not support such a broad query
+        // TODO: throw exception when no relationship type given (test for that exception)
+        //       then, condition if (bootstrapFilterName == null) can be removed
+        if (!relationshipTypeFilterNames.isEmpty())
+            bootstrapFilterName = relationshipTypeFilterNames.get(0);
+        if (sourceTypeFilterName != null) bootstrapFilterName = sourceTypeFilterName;
+        if (!sourceFilterNames.isEmpty()) bootstrapFilterName = sourceFilterNames.get(0);
+        // if there is still no bootstrap filter, we filter for all nodes
+        if (bootstrapFilterName == null) {
+            bootstrapFilterName = "allNodes";
+            String bootstrapFilter = String.format("%s as var(func: has(<urn>))", bootstrapFilterName);
+            filters.add(bootstrapFilter);
+        }
+
+        String filterConditions = getFilterConditions(
+                sourceTypeFilterName, destinationTypeFilterName,
+                sourceFilterNames, destinationFilterNames,
+                relationshipTypeFilterNames, relationshipTypes
+        );
+
+        StringJoiner filterJoiner = new StringJoiner("\n  ");
+        filters.forEach(filterJoiner::add);
+        String filterExpressions = filterJoiner.toString();
+
+        StringJoiner relationshipJoiner = new StringJoiner("\n    ");
+        relationshipTypes.forEach(relationshipType -> relationshipJoiner.add(String.format("<%s> { uid <urn> <type> <key> }", relationshipType)));
+        String relationships = relationshipJoiner.toString();
+        return String.format("query {\n" +
+                        "  %s\n" +
+                        "\n" +
+                        "  result (func: uid(%s), first: %d, offset: %d) %s {\n" +
+                        "    uid\n" +
+                        "    <urn>\n" +
+                        "    <type>\n" +
+                        "    <key>\n" +
+                        "    %s\n" +
+                        "  }\n" +
+                        "}",
+                filterExpressions,
+                bootstrapFilterName,
+                count, offset,
+                filterConditions,
+                relationships);
+    }
+
+    @Nonnull
+    @Override
+    public List<String> findRelatedUrns(@Nullable String sourceType,
+                                        @Nonnull Filter sourceEntityFilter,
+                                        @Nullable String destinationType,
+                                        @Nonnull Filter destinationEntityFilter,
+                                        @Nonnull List<String> relationshipTypes,
+                                        @Nonnull RelationshipFilter relationshipFilter,
+                                        int offset,
+                                        int count) {
+        String query = getQueryForRelatedUrns(
+                sourceType, sourceEntityFilter,
+                destinationType, destinationEntityFilter,
+                relationshipTypes, relationshipFilter,
+                offset, count
+        );
+
+        log.debug("Query: " + query);
+
+        Request request = Request.newBuilder()
+                .setQuery(query)
+                .build();
+
+        Response response = this._client.newReadOnlyTransaction().doRequest(request);
+        String json = response.getJson().toStringUtf8();
+        Map<String, Object> data = getDataFromResponseJson(json);
+
+        return getDestinationUrnsFromResponseData(data, relationshipTypes);
+    }
+
+    protected static @Nonnull String getFilterConditions(String sourceTypeFilterName,
+                                                         String destinationTypeFilterName,
+                                                         @Nonnull List<String> sourceFilterNames,
+                                                         @Nonnull List<String> destinationFilterNames,
+                                                         @Nonnull List<String> relationshipTypeFilterNames,
+                                                         @Nonnull List<String> relationshipTypes) {
+        if (relationshipTypes.size() != relationshipTypeFilterNames.size())
+            throw new IllegalArgumentException("relationshipTypeFilterNames and relationshipTypes " +
+                    "must have same size: " + relationshipTypeFilterNames + " vs. " + relationshipTypes);
+
+        if (sourceTypeFilterName== null && destinationTypeFilterName == null &&
+                sourceFilterNames.isEmpty() && destinationFilterNames.isEmpty() &&
+                relationshipTypeFilterNames.isEmpty())
+            return "";
+
+        StringJoiner andJoiner = new StringJoiner(" AND\n    ");
+        if (sourceTypeFilterName != null) andJoiner.add(String.format("uid(%s)", sourceTypeFilterName));
+
+        sourceFilterNames.forEach(filter -> andJoiner.add(String.format("uid(%s)", filter)));
+
+        if (!relationshipTypes.isEmpty()) {
+            StringJoiner orJoiner = new StringJoiner(" OR\n      ");
+            IntStream.range(0, relationshipTypes.size()).forEach(idx -> orJoiner.add(getRelationshipCondition(
+                    relationshipTypes.get(idx), relationshipTypeFilterNames.get(idx),
+                    destinationTypeFilterName, destinationFilterNames
+            )));
+            String relationshipCondition = orJoiner.toString();
+            andJoiner.add(String.format("(\n      %s\n    )", relationshipCondition));
+        }
+
+        String conditions = andJoiner.toString();
+        return String.format("@filter(\n    %s\n  )", conditions);
+    }
+
+    protected static String getRelationshipCondition(@Nonnull String relationshipType,
+                                                     @Nonnull String relationshipTypeFilterName,
+                                                     String destinationTypeFilterName,
+                                                     @Nonnull List<String> destinationFilterNames) {
+        StringJoiner andJoiner = new StringJoiner(" AND ");
+        andJoiner.add(String.format("uid(%s)", relationshipTypeFilterName));
+        if (destinationTypeFilterName != null)
+            andJoiner.add(String.format("uid_in(<%s>, uid(%s))", relationshipType, destinationTypeFilterName));
+        destinationFilterNames.forEach(filter -> andJoiner.add(String.format("uid_in(<%s>, uid(%s))", relationshipType, filter)));
+        return andJoiner.toString();
+    }
+
+    protected static Map<String, Object> getDataFromResponseJson(String json) {
+        ObjectMapper mapper = new ObjectMapper();
+        TypeReference<HashMap<String, Object>> typeRef = new TypeReference<HashMap<String, Object>>() {};
+        try {
+            return mapper.readValue(json, typeRef);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse response json: " + json.substring(0, 1000), e);
+        }
+    }
+
+    protected static List<String> getDestinationUrnsFromResponseData(Map<String, Object> data, List<String> relationshipTypes) {
+        Object obj = data.get("result");
+        if (! (obj instanceof List<?>))
+            throw new IllegalArgumentException(
+                    "The result from Dgraph did not contain a 'result' field, or that field is not a List"
+            );
+
+        List<?> results = (List<?>)obj;
+        return results.stream().flatMap(sourceObj -> {
+            if (!(sourceObj instanceof Map))
+                return Stream.empty();
+
+            Map<?, ?> source = (Map<?, ?>) sourceObj;
+            return relationshipTypes.stream().flatMap(relationship -> {
+                Object destinationObjs = source.get(relationship);
+                if (!(destinationObjs instanceof List))
+                    return Stream.empty();
+
+                List<?> destinations = (List<?>)destinationObjs;
+                return destinations.stream().flatMap(destinationObj -> {
+                    if (!(destinationObj instanceof Map))
+                        return Stream.empty();
+
+                    Map<?, ?> destination = (Map<?, ?>) destinationObj;
+                    Object destinationUrnObj = destination.get("urn");
+                    if (!(destinationUrnObj instanceof String))
+                        return Stream.empty();
+
+                    return Stream.of((String) destinationUrnObj);
+                });
+            });
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    public void removeNode(@Nonnull Urn urn) {
+
+    }
+
+    @Override
+    public void removeEdgesFromNode(@Nonnull Urn urn,
+                                    @Nonnull List<String> relationshipTypes,
+                                    @Nonnull RelationshipFilter relationshipFilter) {
+        // TODO: implement reverse relationships
+        // TODO: add escape for string values
+        String query = String.format("query {\n" +
+                "  node as var(func: eq(<urn>, \"%s\"))\n" +
+                "}", urn.toString());
+
+        Value star = Value.newBuilder().setDefaultVal("_STAR_ALL").build();
+        List<NQuad> deletions = relationshipTypes.stream().map(relationshipType ->
+                NQuad.newBuilder()
+                        .setSubject("uid(node)")
+                        .setPredicate(relationshipType)
+                        .setObjectValue(star)
+                        .build()
+        ).collect(Collectors.toList());
+
+        Mutation mutation = Mutation.newBuilder()
+                .addAllDel(deletions)
+                .build();
+        Request request = Request.newBuilder()
+                .setQuery(query)
+                .addMutations(mutation)
+                .setCommitNow(true)
+                .build();
+
+        log.debug("Query: " + query);
+        log.debug("Deletions: " + deletions);
+
+        this._client.newTransaction().doRequest(request);
+    }
+
+    @Override
+    public void configure() {
+
+    }
+
+    @Override
+    public void clear() {
+        this._client.alter(Operation.newBuilder().setDropOp(Operation.DropOp.DATA).build());
+    }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -264,13 +264,13 @@ public class DgraphGraphService implements GraphService {
         List<String> destinationFilterNames = new ArrayList<>();
         List<String> relationshipTypeFilterNames = new ArrayList<>();
 
-        if (sourceType != null && !sourceType.isEmpty()) {
+        if (sourceType != null) {
             sourceTypeFilterName = "sourceType";
             // TODO: escape string value
             filters.add(String.format("%s as var(func: eq(<type>, \"%s\"))", sourceTypeFilterName, sourceType));
         }
 
-        if (destinationType != null && !destinationType.isEmpty()) {
+        if (destinationType != null) {
             destinationTypeFilterName = "destinationType";
             // TODO: escape string value
             filters.add(String.format("%s as var(func: eq(<type>, \"%s\"))", destinationTypeFilterName, destinationType));

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -303,6 +303,8 @@ public class DgraphGraphService implements GraphService {
                         || t instanceof StatusRuntimeException && (
                                 t.getMessage().contains("operation opIndexing is already running")
                                         || t.getMessage().contains("Please retry")
+                                        || t.getMessage().contains("DEADLINE_EXCEEDED:")
+                                        || t.getMessage().contains("context deadline exceeded")
                         )) {
                     try {
                         // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10.24s

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -270,7 +270,6 @@ public class DgraphGraphService implements GraphService {
                                         || t.getMessage().contains("Please retry")
                         )) {
                     try {
-                        System.err.println("retrying: " + t);
                         // wait 0.01s, 0.02s, 0.04s, 0.08s, ..., 10.24s
                         long time = (long) Math.pow(2, Math.min(retry, 10)) * 10;
                         TimeUnit.MILLISECONDS.sleep(time);
@@ -445,8 +444,6 @@ public class DgraphGraphService implements GraphService {
                 relationshipFilter,
                 offset, count
         );
-
-        System.out.println("Query: " + query);
 
         Request request = Request.newBuilder()
                 .setQuery(query)

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -449,6 +449,7 @@ public class DgraphGraphService implements GraphService {
                 .setQuery(query)
                 .build();
 
+        log.debug("Query: " + query);
         Response response = retry(() -> this._client.newReadOnlyTransaction().doRequest(request));
         String json = response.getJson().toStringUtf8();
         Map<String, Object> data = getDataFromResponseJson(json);
@@ -703,15 +704,19 @@ public class DgraphGraphService implements GraphService {
     }
 
     @Override
-    public void configure() {
-
-    }
+    public void configure() { }
 
     @Override
     public void clear() {
+        log.debug("dropping Dgraph data");
+
         Operation dropAll = Operation.newBuilder().setDropOp(Operation.DropOp.ALL).build();
         retry(() -> this._client.alter(dropAll));
+
+        // drop schema cache
         get_schema().clear();
+
+        // setup urn, type and key relationships
         getSchema(this._client);
     }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -150,7 +150,8 @@ public class DgraphGraphService implements GraphService {
 
         // add the relationship type to the schema
         // TODO: translate edge name to allowed dgraph uris
-        // TODO: cache the schema and only mutate if relationship is new
+        // TODO: move the schema modification into DgraphSchema and provide an atomic method
+        //       that adds the type and all fields if they do not exist
         String sourceEntityType = getDgraphType(edge.getSource());
         String relationshipType = edge.getRelationshipType();
         if (!get_schema().hasField(sourceEntityType, relationshipType)) {

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphGraphService.java
@@ -207,19 +207,7 @@ public class DgraphGraphService implements GraphService {
                 .build();
 
         // run the request
-        synchronized (System.out) {
-            System.out.printf(System.currentTimeMillis() + ": Adding Edge source: %s, destination: %s, type: %s%n",
-                    edge.getSource(),
-                    edge.getDestination(),
-                    edge.getRelationshipType());
-        }
         _dgraph.executeFunction(client -> client.newTransaction().doRequest(request));
-        synchronized (System.out) {
-            System.out.printf(System.currentTimeMillis() + ": Added  Edge source: %s, destination: %s, type: %s%n",
-                    edge.getSource(),
-                    edge.getDestination(),
-                    edge.getRelationshipType());
-        }
     }
 
     private static @Nonnull String getDgraphType(@Nonnull Urn urn) {
@@ -551,9 +539,7 @@ public class DgraphGraphService implements GraphService {
                 .setCommitNow(true)
                 .build();
 
-        System.out.printf(System.currentTimeMillis() + ": removing node %s%n", urn);
         _dgraph.executeConsumer(client -> client.newTransaction().doRequest(request));
-        System.out.printf(System.currentTimeMillis() + ": removed  node %s%n", urn);
     }
 
     @Override
@@ -603,9 +589,7 @@ public class DgraphGraphService implements GraphService {
                 .setCommitNow(true)
                 .build();
 
-        System.out.printf(System.currentTimeMillis() + ": removing outgoing edges from node %s%n", urn);
         _dgraph.executeConsumer(client -> client.newTransaction().doRequest(request));
-        System.out.printf(System.currentTimeMillis() + ": removed  outgoing edges from node %s%n", urn);
     }
 
     private void removeIncomingEdgesFromNode(@Nonnull Urn urn,
@@ -640,9 +624,7 @@ public class DgraphGraphService implements GraphService {
                 .setCommitNow(true)
                 .build();
 
-        System.out.printf(System.currentTimeMillis() + ": removing incoming edges from node %s%n", urn);
         _dgraph.executeConsumer(client -> client.newTransaction().doRequest(request));
-        System.out.printf(System.currentTimeMillis() + ": removed incoming edges from node %s%n", urn);
     }
 
     @Override

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
@@ -53,11 +53,16 @@ public class DgraphSchema {
         return types.getOrDefault(typeName, Collections.emptySet()).contains(fieldName);
     }
 
-    public void addField(String typeName, String fieldName) {
+    synchronized public void addField(String typeName, String fieldName) {
         if (!types.containsKey(typeName)) {
             types.put(typeName, new HashSet<>());
         }
         types.get(typeName).add(fieldName);
         fields.add(fieldName);
+    }
+
+    public void clear() {
+        types.clear();
+        fields.clear();
     }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
@@ -1,7 +1,10 @@
 package com.linkedin.metadata.graph;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DgraphSchema {
@@ -51,8 +54,9 @@ public class DgraphSchema {
     }
 
     public void addField(String typeName, String fieldName) {
-        if (!types.containsKey(typeName))
+        if (!types.containsKey(typeName)) {
             types.put(typeName, new HashSet<>());
+        }
         types.get(typeName).add(fieldName);
         fields.add(fieldName);
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
@@ -1,0 +1,59 @@
+package com.linkedin.metadata.graph;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class DgraphSchema {
+    private final @Nonnull Set<String> fields;
+    private final @Nonnull Map<String, Set<String>> types;
+
+    public DgraphSchema(@Nonnull Set<String> fields, @Nonnull Map<String, Set<String>> types) {
+        this.fields = fields;
+        this.types = types;
+    }
+
+    public boolean isEmpty() {
+        return fields.isEmpty();
+    }
+
+    public Set<String> getFields() {
+        // Make Set unmodifiable
+        return Collections.unmodifiableSet(fields);
+    }
+
+    public Set<String> getFields(String typeName) {
+        // Make Set unmodifiable
+        return Collections.unmodifiableSet(types.getOrDefault(typeName, Collections.emptySet()));
+    }
+
+    public Map<String, Set<String>> getTypes() {
+        // make Map and contained sets unmodifiable
+        return Collections.unmodifiableMap(
+                types.entrySet().stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> Collections.unmodifiableSet(e.getValue())
+                        ))
+        );
+    }
+
+    public boolean hasType(String typeName) {
+        return types.containsKey(typeName);
+    }
+
+    public boolean hasField(String fieldName) {
+        return fields.contains(fieldName);
+    }
+
+    public boolean hasField(String typeName, String fieldName) {
+        return types.getOrDefault(typeName, Collections.emptySet()).contains(fieldName);
+    }
+
+    public void addField(String typeName, String fieldName) {
+        if (!types.containsKey(typeName))
+            types.put(typeName, new HashSet<>());
+        types.get(typeName).add(fieldName);
+        fields.add(fieldName);
+    }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
@@ -102,15 +102,13 @@ public class DgraphSchema {
         allTypesFields.add(fieldName);
 
         if (dgraph != null) {
+            log.info("Adding predicate {} for type {} to schema", fieldName, typeName);
+
             StringJoiner type = new StringJoiner("\n  ");
             allTypesFields.stream().map(t -> "<" + t + ">").forEach(type::add);
             schema.add(String.format("type <%s> {\n  %s\n}", typeName, type));
             log.debug("Adding to schema: " + schema);
             DgraphProto.Operation setSchema = DgraphProto.Operation.newBuilder().setSchema(schema.toString()).setRunInBackground(true).build();
-            synchronized (System.out) {
-                System.out.printf(System.currentTimeMillis() + ": adding predicate %s to %s: %s%n", fieldName, typeName, schema);
-            }
-
             dgraph.executeConsumer(dgraphClient -> dgraphClient.alter(setSchema));
         }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
@@ -21,6 +21,10 @@ public class DgraphSchema {
     private final @Nonnull Map<String, Set<String>> types;
     private final DgraphExecutor dgraph;
 
+    public static DgraphSchema empty() {
+        return new DgraphSchema(Collections.emptySet(), Collections.emptyMap(), null);
+    }
+
     public DgraphSchema(@Nonnull Set<String> fields, @Nonnull Map<String, Set<String>> types) {
         this(fields, types, null);
     }
@@ -29,6 +33,17 @@ public class DgraphSchema {
         this.fields = fields;
         this.types = types;
         this.dgraph = dgraph;
+    }
+
+    /**
+     * Adds the given DgraphExecutor to this schema returning a new instance.
+     * Be aware this and the new instance share the underlying fields and types datastructures.
+     *
+     * @param dgraph dgraph executor to add
+     * @return new instance
+     */
+    public DgraphSchema withDgraph(DgraphExecutor dgraph) {
+        return new DgraphSchema(this.fields, this.types, dgraph);
     }
 
     synchronized public boolean isEmpty() {
@@ -96,10 +111,7 @@ public class DgraphSchema {
                 System.out.printf(System.currentTimeMillis() + ": adding predicate %s to %s: %s%n", fieldName, typeName, schema);
             }
 
-            dgraph.execute(dgraphClient -> {
-                dgraphClient.alter(setSchema);
-                return null;
-            });
+            dgraph.executeConsumer(dgraphClient -> dgraphClient.alter(setSchema));
         }
 
         // now that the schema has been updated on dgraph we can cache this new type / field

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/DgraphSchema.java
@@ -7,6 +7,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Provides a thread-safe Dgraph schema. Returned data structures are immutable.
+ */
 public class DgraphSchema {
     private final @Nonnull Set<String> fields;
     private final @Nonnull Map<String, Set<String>> types;
@@ -16,40 +19,40 @@ public class DgraphSchema {
         this.types = types;
     }
 
-    public boolean isEmpty() {
+    synchronized public boolean isEmpty() {
         return fields.isEmpty();
     }
 
-    public Set<String> getFields() {
-        // Make Set unmodifiable
-        return Collections.unmodifiableSet(fields);
+    synchronized public Set<String> getFields() {
+        // Provide an unmodifiable copy
+        return Collections.unmodifiableSet(new HashSet<>(fields));
     }
 
-    public Set<String> getFields(String typeName) {
-        // Make Set unmodifiable
-        return Collections.unmodifiableSet(types.getOrDefault(typeName, Collections.emptySet()));
+    synchronized public Set<String> getFields(String typeName) {
+        // Provide an unmodifiable copy
+        return Collections.unmodifiableSet(new HashSet<>(types.getOrDefault(typeName, Collections.emptySet())));
     }
 
-    public Map<String, Set<String>> getTypes() {
-        // make Map and contained sets unmodifiable
+    synchronized public Map<String, Set<String>> getTypes() {
+        // Provide an unmodifiable copy of the map and contained sets
         return Collections.unmodifiableMap(
-                types.entrySet().stream()
+                new HashSet<>(types.entrySet()).stream()
                         .collect(Collectors.toMap(
                                 Map.Entry::getKey,
-                                e -> Collections.unmodifiableSet(e.getValue())
+                                e -> Collections.unmodifiableSet(new HashSet<>(e.getValue()))
                         ))
         );
     }
 
-    public boolean hasType(String typeName) {
+    synchronized public boolean hasType(String typeName) {
         return types.containsKey(typeName);
     }
 
-    public boolean hasField(String fieldName) {
+    synchronized public boolean hasField(String fieldName) {
         return fields.contains(fieldName);
     }
 
-    public boolean hasField(String typeName, String fieldName) {
+    synchronized public boolean hasField(String typeName, String fieldName) {
         return types.getOrDefault(typeName, Collections.emptySet()).contains(fieldName);
     }
 
@@ -61,7 +64,7 @@ public class DgraphSchema {
         fields.add(fieldName);
     }
 
-    public void clear() {
+    synchronized public void clear() {
         types.clear();
         fields.clear();
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphContainer.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphContainer.java
@@ -1,0 +1,255 @@
+package com.linkedin.metadata.graph;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import lombok.NonNull;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Stream;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.stream.Collectors.toSet;
+
+public class DgraphContainer extends GenericContainer<DgraphContainer> {
+
+    /**
+     * The image defaults to the official Dgraph image: <a href="https://hub.docker.com/_/dgraph/dgraph">Dgraph</a>.
+     */
+    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("dgraph/dgraph");
+
+    private static final int HTTP_PORT = 8080;
+
+    private static final int GRPC_PORT = 9080;
+
+    private boolean started = false;
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        started = true;
+    }
+
+    @Override
+    protected void containerIsStopped(InspectContainerResponse containerInfo) {
+        super.containerIsStopped(containerInfo);
+        started = false;
+    }
+
+    private final Map<String, String> zeroArguments = new HashMap<>();
+
+    private final Map<String, String> alphaArguments = new HashMap<>();
+
+    /**
+     * Creates a DgraphContainer using a specific docker image and a startup timeout of 1 minute.
+     *
+     * @param dockerImageName The docker image to use.
+     */
+    public DgraphContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName), Duration.ofMinutes(1));
+    }
+
+    /**
+     * Creates a DgraphContainer using a specific docker image and a startup timeout of 1 minute.
+     *
+     * @param dockerImageName The docker image to use.
+     */
+    public DgraphContainer(@NonNull final DockerImageName dockerImageName) {
+        this(dockerImageName, Duration.ofMinutes(1));
+    }
+
+    /**
+     * Creates a DgraphContainer using a specific docker image. Connect the container
+     * to another DgraphContainer to form a cluster via `peerAlias`.
+     *
+     * @param dockerImageName The docker image to use.
+     * @param startupTimeout Timeout for the container startup.
+     */
+    public DgraphContainer(@NonNull final DockerImageName dockerImageName,
+                           @NonNull Duration startupTimeout) {
+        super(dockerImageName);
+
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        WaitStrategy waitForCluster = new LogMessageWaitStrategy()
+            .withRegEx(".* Server is ready\n");
+        WaitStrategy waitForHttp = new HttpWaitStrategy()
+            .forPort(HTTP_PORT)
+            .forStatusCodeMatching(response -> response == HTTP_OK);
+
+        this.waitStrategy = new WaitAllStrategy()
+            .withStrategy(waitForCluster)
+            .withStrategy(waitForHttp)
+            .withStartupTimeout(startupTimeout);
+
+        if (dockerImageName.getVersionPart().compareTo("v21.03.0") < 0) {
+            withAlphaArgument("whitelist", "0.0.0.0/0");
+        } else {
+            withAlphaArgumentValues("security", "whitelist=0.0.0.0/0");
+        }
+
+        addExposedPorts(HTTP_PORT, GRPC_PORT);
+    }
+
+    /**
+     * Adds an argument to the zero command.
+     *
+     * @param argument name of the argument
+     * @param value value, null if argument is a flag
+     * @return this
+     */
+    public DgraphContainer withZeroArgument(@NonNull String argument, String value) {
+        addArgument(zeroArguments, argument, value);
+        return this;
+    }
+
+    /**
+     * Adds a value to an argument list to the zero command.
+     *
+     * Some arguments of the zero command form a list of values, e.g. `audit` or `raft`.
+     * These values are separated by a ";". Setting multiple values for those arguments should
+     * be done via this method.
+     *
+     * @param argument name of the argument
+     * @param values values to add to the argument
+     * @return this
+     */
+    public DgraphContainer withZeroArgumentValues(@NonNull String argument, @NonNull String... values) {
+        addArgumentValues(zeroArguments, argument, values);
+        return this;
+    }
+
+    /**
+     * Adds an argument to the alpha command.
+     *
+     * @param argument name of the argument
+     * @param value value, null if argument is a flag
+     * @return this
+     */
+    public DgraphContainer withAlphaArgument(@NonNull String argument, String value) {
+        addArgument(alphaArguments, argument, value);
+        return this;
+    }
+
+    /**
+     * Adds a value to an argument list to the alpha command.
+     *
+     * Some arguments of the alpha command form a list of values, e.g. `audit` or `raft`.
+     * These values are separated by a ";". Setting multiple values for those arguments should
+     * be done via this method.
+     *
+     * @param argument name of the argument
+     * @param values values to add to the argument
+     * @return this
+     */
+    public DgraphContainer withAlphaArgumentValues(@NonNull String argument, @NonNull String... values) {
+        addArgumentValues(alphaArguments, argument, values);
+        return this;
+    }
+
+    private void addArgument(Map<String, String> arguments, @NonNull String argument, String value) {
+        if (started) {
+            throw new IllegalStateException("The container started already, cannot amend command arguments");
+        }
+
+        arguments.put(argument, value);
+    }
+
+    private void addArgumentValues(Map<String, String> arguments, @NonNull String argument, @NonNull String... values) {
+        if (started) {
+            throw new IllegalStateException("The container started already, cannot amend command arguments");
+        }
+
+        StringJoiner joiner = new StringJoiner("; ");
+        Arrays.stream(values).forEach(joiner::add);
+        String value = joiner.toString();
+
+        if (arguments.containsKey(argument)) {
+            arguments.put(argument, arguments.get(argument) + "; " + value);
+        } else {
+            arguments.put(argument, value);
+        }
+    }
+
+    /**
+     * Provides the command used to start the zero process. Command line arguments can be added
+     * by calling `withZeroArgument` and `withZeroArgumentValues` before calling this method.
+     * @return command string
+     */
+    public @NonNull String getZeroCommand() {
+        return getCommand("dgraph zero", zeroArguments);
+    }
+
+    /**
+     * Provides the command used to start the alpha process. Command line arguments can be added
+     * by calling `withAlphaArgument` and `withAlphaArgumentValues` before calling this method.
+     * @return command string
+     */
+    public @NonNull String getAlphaCommand() {
+        return getCommand("dgraph alpha", alphaArguments);
+    }
+
+    private @NonNull String getCommand(@NonNull String command, @NonNull Map<String, String> arguments) {
+        StringJoiner joiner = new StringJoiner(" --");
+
+        arguments.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(argument -> {
+                if (argument.getValue() == null) {
+                    return argument.getKey();
+                } else {
+                    return argument.getKey() + " \"" + argument.getValue() + "\"";
+                }
+            }).forEach(joiner::add);
+
+        if (joiner.length() == 0) {
+            return command;
+        } else {
+            return command + " --" + joiner;
+        }
+    }
+
+    @Override
+    public void start() {
+        String zeroCommand = this.getZeroCommand();
+        String alhpaCommand = this.getAlphaCommand();
+        this.setCommand("/bin/bash", "-c", zeroCommand + " & " + alhpaCommand);
+        super.start();
+    }
+
+    @Override
+    public Set<Integer> getLivenessCheckPortNumbers() {
+        return Stream.of(getHttpPort(), getGrpcPort())
+            .map(this::getMappedPort)
+            .collect(toSet());
+    }
+
+    @Override
+    protected void configure() { }
+
+    public int getHttpPort() {
+        return getMappedPort(HTTP_PORT);
+    }
+
+    public int getGrpcPort() {
+        return getMappedPort(GRPC_PORT);
+    }
+
+    public String getHttpUrl() {
+        return String.format("http://%s:%d", getHost(), getHttpPort());
+    }
+
+    public String getGrpcUrl() {
+        return String.format("%s:%d", getHost(), getGrpcPort());
+    }
+
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphContainer.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphContainer.java
@@ -50,32 +50,12 @@ public class DgraphContainer extends GenericContainer<DgraphContainer> {
     private final Map<String, String> alphaArguments = new HashMap<>();
 
     /**
-     * Creates a DgraphContainer using a specific docker image and a startup timeout of 1 minute.
-     *
-     * @param dockerImageName The docker image to use.
-     */
-    public DgraphContainer(String dockerImageName) {
-        this(DockerImageName.parse(dockerImageName), Duration.ofMinutes(1));
-    }
-
-    /**
-     * Creates a DgraphContainer using a specific docker image and a startup timeout of 1 minute.
-     *
-     * @param dockerImageName The docker image to use.
-     */
-    public DgraphContainer(@NonNull final DockerImageName dockerImageName) {
-        this(dockerImageName, Duration.ofMinutes(1));
-    }
-
-    /**
      * Creates a DgraphContainer using a specific docker image. Connect the container
      * to another DgraphContainer to form a cluster via `peerAlias`.
      *
      * @param dockerImageName The docker image to use.
-     * @param startupTimeout Timeout for the container startup.
      */
-    public DgraphContainer(@NonNull final DockerImageName dockerImageName,
-                           @NonNull Duration startupTimeout) {
+    public DgraphContainer(@NonNull final DockerImageName dockerImageName) {
         super(dockerImageName);
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
@@ -92,7 +72,7 @@ public class DgraphContainer extends GenericContainer<DgraphContainer> {
             .withStrategy(waitForLeader)
             .withStrategy(waitForCluster)
             .withStrategy(waitForHttp)
-            .withStartupTimeout(startupTimeout);
+            .withStartupTimeout(Duration.ofMinutes(1));
 
         if (dockerImageName.getVersionPart().compareTo("v21.03.0") < 0) {
             withAlphaArgument("whitelist", "0.0.0.0/0");

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphContainer.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphContainer.java
@@ -80,6 +80,8 @@ public class DgraphContainer extends GenericContainer<DgraphContainer> {
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
+        WaitStrategy waitForLeader = new LogMessageWaitStrategy()
+            .withRegEx(".* Got Zero leader: .*\n");
         WaitStrategy waitForCluster = new LogMessageWaitStrategy()
             .withRegEx(".* Server is ready\n");
         WaitStrategy waitForHttp = new HttpWaitStrategy()
@@ -87,6 +89,7 @@ public class DgraphContainer extends GenericContainer<DgraphContainer> {
             .forStatusCodeMatching(response -> response == HTTP_OK);
 
         this.waitStrategy = new WaitAllStrategy()
+            .withStrategy(waitForLeader)
             .withStrategy(waitForCluster)
             .withStrategy(waitForHttp)
             .withStartupTimeout(startupTimeout);

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -7,7 +7,9 @@ import io.dgraph.DgraphGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
@@ -27,11 +29,18 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
     private ManagedChannel _channel;
     private DgraphGraphService _service;
+    private DgraphContainer _container;
+
+    @BeforeTest
+    public void setup() {
+        _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"));
+        _container.start();
+    }
 
     @BeforeMethod
-    public void init() {
+    public void connect() {
         _channel = ManagedChannelBuilder
-                .forAddress("localhost", 9080)
+                .forAddress(_container.getHost(), _container.getGrpcPort())
                 .usePlaintext()
                 .build();
 
@@ -39,9 +48,14 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
     }
 
     @AfterMethod
-    public void tearDown() throws InterruptedException {
+    public void disconnect() throws InterruptedException {
         _channel.shutdownNow();
         _channel.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
+    @AfterTest
+    public void tearDown() {
+        _container.stop();
     }
 
     @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
@@ -24,21 +25,24 @@ import static org.testng.Assert.assertEquals;
 
 public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
+    private ManagedChannel _channel;
     private DgraphGraphService _service;
 
     @BeforeMethod
     public void init() {
-        ManagedChannel channel = ManagedChannelBuilder
+        _channel = ManagedChannelBuilder
                 .forAddress("localhost", 9080)
                 .usePlaintext()
                 .build();
-        DgraphGrpc.DgraphStub stub = DgraphGrpc.newStub(channel);
 
-        _service = new DgraphGraphService(new DgraphClient(stub));
+        _service = new DgraphGraphService(new DgraphClient(DgraphGrpc.newStub(_channel)));
     }
 
     @AfterMethod
-    public void tearDown() { }
+    public void tearDown() throws InterruptedException {
+        _channel.shutdownNow();
+        _channel.awaitTermination(10, TimeUnit.SECONDS);
+    }
 
     @Nonnull
     @Override

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -1,0 +1,536 @@
+package com.linkedin.metadata.graph;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.metadata.query.RelationshipFilter;
+import io.dgraph.DgraphClient;
+import io.dgraph.DgraphGrpc;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
+import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static org.testng.Assert.assertEquals;
+
+
+public class DgraphGraphServiceTest {
+
+    private DgraphGraphService _service;
+
+    @BeforeMethod
+    public void init() {
+        ManagedChannel channel = ManagedChannelBuilder
+                .forAddress("localhost", 9080)
+                .usePlaintext()
+                .build();
+        DgraphGrpc.DgraphStub stub = DgraphGrpc.newStub(channel);
+
+        _service = new DgraphGraphService(new DgraphClient(stub));
+    }
+
+    @AfterMethod
+    public void tearDown() { }
+
+    @Test
+    public void testAddEdge() throws Exception {
+        // test both directions
+        Edge edge1 = new Edge(
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+                "DownstreamOf");
+
+        _service.addEdge(edge1);
+
+        List<String> edgeTypes = new ArrayList<>();
+        edgeTypes.add("DownstreamOf");
+        RelationshipFilter relationshipFilter = new RelationshipFilter();
+        relationshipFilter.setDirection(RelationshipDirection.OUTGOING);
+        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+        List<String> relatedUrns = _service.findRelatedUrns(
+                "",
+                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "",
+                EMPTY_FILTER,
+                edgeTypes,
+                relationshipFilter,
+                0,
+                10);
+
+        assertEquals(relatedUrns.size(), 1);
+    }
+
+    @Test
+    public void testAddEdgeReverse() throws Exception {
+        Edge edge1 = new Edge(
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "DownstreamOf");
+
+        _service.addEdge(edge1);
+
+        List<String> edgeTypes = new ArrayList<>();
+        edgeTypes.add("DownstreamOf");
+        RelationshipFilter relationshipFilter = new RelationshipFilter();
+        relationshipFilter.setDirection(RelationshipDirection.INCOMING);
+        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+        List<String> relatedUrns = _service.findRelatedUrns(
+                "",
+                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "",
+                EMPTY_FILTER,
+                edgeTypes,
+                relationshipFilter,
+                0,
+                10);
+
+        assertEquals(relatedUrns.size(), 1);
+    }
+
+    @Test
+    public void testRemoveEdgesFromNode() throws Exception {
+        // TODO: test with both relationship directions
+        Edge edge1 = new Edge(
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+                "DownstreamOf");
+
+        _service.addEdge(edge1);
+
+        List<String> edgeTypes = new ArrayList<>();
+        edgeTypes.add("DownstreamOf");
+        RelationshipFilter relationshipFilter = new RelationshipFilter();
+        relationshipFilter.setDirection(RelationshipDirection.INCOMING);
+        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+        List<String> relatedUrns = _service.findRelatedUrns(
+                "",
+                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "",
+                EMPTY_FILTER,
+                edgeTypes,
+                relationshipFilter,
+                0,
+                10);
+
+        assertEquals(relatedUrns.size(), 1);
+
+        _service.removeEdgesFromNode(Urn.createFromString(
+                "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                edgeTypes,
+                relationshipFilter);
+
+        List<String> relatedUrnsPostDelete = _service.findRelatedUrns(
+                "",
+                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "",
+                EMPTY_FILTER,
+                edgeTypes,
+                relationshipFilter,
+                0,
+                10);
+
+        assertEquals(relatedUrnsPostDelete.size(), 0);
+    }
+
+    @Test
+    public void testClear() throws Exception {
+        // TODO: test with both relationship directions
+        Edge edge1 = new Edge(
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
+                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "DownstreamOf");
+
+        _service.addEdge(edge1);
+
+        List<String> edgeTypes = new ArrayList<>();
+        edgeTypes.add("DownstreamOf");
+        RelationshipFilter relationshipFilter = new RelationshipFilter();
+        relationshipFilter.setDirection(RelationshipDirection.INCOMING);
+        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+
+        List<String> relatedUrns = _service.findRelatedUrns(
+                "",
+                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "",
+                EMPTY_FILTER,
+                edgeTypes,
+                relationshipFilter,
+                0,
+                10);
+
+        assertEquals(relatedUrns.size(), 1);
+
+        _service.clear();
+
+        List<String> relatedUrnsPostDelete = _service.findRelatedUrns(
+                "",
+                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
+                "",
+                EMPTY_FILTER,
+                edgeTypes,
+                relationshipFilter,
+                0,
+                10);
+
+        assertEquals(relatedUrnsPostDelete.size(), 0);
+    }
+
+    @Test
+    public void testGetFilterConditions() {
+        // no filters
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
+                ""
+        );
+
+        // source type
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        "sourceTypeFilter",
+                        null,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
+                "@filter(\n" +
+                        "    uid(sourceTypeFilter)\n" +
+                        "  )"
+        );
+
+        // destination type not supported without restricting relationship types
+        // there must be as many relation type filter names as there are relationships
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        "destinationTypeFilter",
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Arrays.asList("RelationshipTypeFilter"),
+                        Arrays.asList("relationship")),
+                "@filter(\n" +
+                        "    (\n" +
+                        "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationTypeFilter))\n" +
+                        "    )\n" +
+                        "  )"
+        );
+
+        // source filters
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Arrays.asList("sourceFilter"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
+                "@filter(\n" +
+                        "    uid(sourceFilter)\n" +
+                        "  )"
+        );
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Arrays.asList("sourceFilter1", "sourceFilter2"),
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
+                "@filter(\n" +
+                        "    uid(sourceFilter1) AND\n" +
+                        "    uid(sourceFilter2)\n" +
+                        "  )"
+        );
+
+        // destination filter not supported without restricting relationship types
+        // there must be as many relation type filter names as there are relationships
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Collections.emptyList(),
+                        Arrays.asList("destinationFilter"),
+                        Arrays.asList("RelationshipTypeFilter"),
+                        Arrays.asList("relationship")),
+                "@filter(\n" +
+                        "    (\n" +
+                        "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter))\n" +
+                        "    )\n" +
+                        "  )"
+        );
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Collections.emptyList(),
+                        Arrays.asList("destinationFilter1", "destinationFilter2"),
+                        Arrays.asList("RelationshipTypeFilter"),
+                        Arrays.asList("relationship")),
+                "@filter(\n" +
+                        "    (\n" +
+                        "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))\n" +
+                        "    )\n" +
+                        "  )"
+        );
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Collections.emptyList(),
+                        Arrays.asList("destinationFilter1", "destinationFilter2"),
+                        Arrays.asList("RelationshipTypeFilter1", "RelationshipTypeFilter2"),
+                        Arrays.asList("relationship1", "relationship2")),
+                "@filter(\n" +
+                        "    (\n" +
+                        "      uid(RelationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
+                        "      uid(RelationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n" +
+                        "    )\n" +
+                        "  )"
+        );
+
+        // relationship type filters require relationship types
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        Arrays.asList("relationshipTypeFilter1", "relationshipTypeFilter2"),
+                        Arrays.asList("relationship1", "relationship2")),
+                "@filter(\n" +
+                        "    (\n" +
+                        "      uid(relationshipTypeFilter1) OR\n" +
+                        "      uid(relationshipTypeFilter2)\n" +
+                        "    )\n" +
+                        "  )"
+        );
+
+        // all filters at once
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        "sourceTypeFilter",
+                        "destinationTypeFilter",
+                        Arrays.asList("sourceFilter1", "sourceFilter2"),
+                        Arrays.asList("destinationFilter1", "destinationFilter2"),
+                        Arrays.asList("relationshipTypeFilter1", "relationshipTypeFilter2"),
+                        Arrays.asList("relationship1", "relationship2")),
+                "@filter(\n" +
+                        "    uid(sourceTypeFilter) AND\n" +
+                        "    uid(sourceFilter1) AND\n" +
+                        "    uid(sourceFilter2) AND\n" +
+                        "    (\n" +
+                        "      uid(relationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationTypeFilter)) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
+                        "      uid(relationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationTypeFilter)) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n" +
+                        "    )\n" +
+                        "  )"
+        );
+
+        // TODO: check getFilterConditions throws an exception when relationshipTypes and
+        //       relationshipTypeFilterNames do not have the same size
+    }
+
+    @Test
+    public void testGetRelationshipCondition() {
+        assertEquals(
+                DgraphGraphService.getRelationshipCondition(
+                        "relationship",
+                        "relationshipFilter",
+                        null,
+                        Collections.emptyList()),
+                "uid(relationshipFilter)"
+        );
+
+        assertEquals(
+                DgraphGraphService.getRelationshipCondition(
+                        "relationship",
+                        "relationshipFilter",
+                        "destinationTypeFilter",
+                        Collections.emptyList()),
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter))"
+        );
+
+        assertEquals(
+                DgraphGraphService.getRelationshipCondition(
+                        "relationship",
+                        "relationshipFilter",
+                        "destinationTypeFilter",
+                        Arrays.asList("destinationFilter")),
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter)) AND uid_in(<relationship>, uid(destinationFilter))"
+        );
+
+        assertEquals(
+                DgraphGraphService.getRelationshipCondition(
+                        "relationship",
+                        "relationshipFilter",
+                        "destinationTypeFilter",
+                        Arrays.asList("destinationFilter1", "destinationFilter2")),
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter)) AND uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))"
+        );
+
+        assertEquals(
+                DgraphGraphService.getRelationshipCondition(
+                        "relationship",
+                        "relationshipFilter",
+                        null,
+                        Arrays.asList("destinationFilter1", "destinationFilter2")),
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))"
+        );
+    }
+
+    @Test
+    public void testGetQueryForRelatedUrns() {
+        assertEquals(
+                DgraphGraphService.getQueryForRelatedUrns(
+                        "sourceType",
+                        newFilter(new HashMap<String, String>() {{
+                            put("urn", "urn:ns:type:source-key");
+                            put("key", "source-key");
+                        }}),
+                        "destinationType",
+                        newFilter(new HashMap<String, String>() {{
+                            put("urn", "urn:ns:type:dest-key");
+                            put("key", "dest-key");
+                        }}),
+                        Arrays.asList("relationship1", "relationship2"),
+                        new RelationshipFilter().setCriteria(EMPTY_FILTER.getCriteria()).setDirection(RelationshipDirection.INCOMING),
+                        0, 100
+                ),
+                "query {\n" +
+                        "  sourceType as var(func: eq(<type>, \"sourceType\"))\n" +
+                        "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n" +
+                        "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n" +
+                        "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n" +
+                        "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n" +
+                        "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n" +
+                        "  relationshipType1 as var(func: has(<relationship1>))\n" +
+                        "  relationshipType2 as var(func: has(<relationship2>))\n" +
+                        "\n" +
+                        "  result (func: uid(sourceFilter1), first: 100, offset: 0) @filter(\n" +
+                        "    uid(sourceType) AND\n" +
+                        "    uid(sourceFilter1) AND\n" +
+                        "    uid(sourceFilter2) AND\n" +
+                        "    (\n" +
+                        "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
+                        "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n" +
+                        "    )\n" +
+                        "  ) {\n" +
+                        "    uid\n" +
+                        "    <urn>\n" +
+                        "    <type>\n" +
+                        "    <key>\n" +
+                        "    <relationship1> { uid <urn> <type> <key> }\n" +
+                        "    <relationship2> { uid <urn> <type> <key> }\n" +
+                        "  }\n" +
+                        "}"
+        );
+    }
+
+    @Test
+    public void testGetDestinationUrnsFromResponseData() {
+        // no results
+        assertEquals(
+                DgraphGraphService.getDestinationUrnsFromResponseData(
+                        new HashMap<String, Object>() {{
+                            put("result", Collections.emptyList());
+                        }},
+                        Collections.emptyList()
+                ),
+                Collections.emptyList()
+        );
+
+        // one result and one relationship
+        assertEquals(
+                DgraphGraphService.getDestinationUrnsFromResponseData(
+                        new HashMap<String, Object>() {{
+                            put("result", Arrays.asList(
+                                    new HashMap<String, Object>() {{
+                                        put("relationship", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key");
+                                                }}
+                                        ));
+                                    }}
+                            ));
+                        }},
+                        Arrays.asList("relationship")
+                ),
+                Arrays.asList("urn:ns:type:dest-key")
+        );
+
+        // multiple results and one relationship
+        assertEquals(
+                DgraphGraphService.getDestinationUrnsFromResponseData(
+                        new HashMap<String, Object>() {{
+                            put("result", Arrays.asList(
+                                    new HashMap<String, Object>() {{
+                                        put("relationship", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key-1");
+                                                }}
+                                        ));
+                                    }},
+                                    new HashMap<String, Object>() {{
+                                        put("relationship", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key-2");
+                                                }}
+                                        ));
+                                    }}
+                            ));
+                        }},
+                        Arrays.asList("relationship")
+                ),
+                Arrays.asList("urn:ns:type:dest-key-1", "urn:ns:type:dest-key-2")
+        );
+
+        // multiple results and relationships
+        assertEquals(
+                DgraphGraphService.getDestinationUrnsFromResponseData(
+                        new HashMap<String, Object>() {{
+                            put("result", Arrays.asList(
+                                    new HashMap<String, Object>() {{
+                                        put("relationship1", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key-1");
+                                                }}
+                                        ));
+                                        put("relationship2", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key-2");
+                                                }}
+                                        ));
+                                    }},
+                                    new HashMap<String, Object>() {{
+                                        put("relationship2", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key-3");
+                                                }}
+                                        ));
+                                        put("relationship1", Arrays.asList(
+                                                new HashMap<String, Object>() {{
+                                                    put("urn", "urn:ns:type:dest-key-4");
+                                                }}
+                                        ));
+                                    }}
+                            ));
+                        }},
+                        Arrays.asList("relationship1", "relationship2")
+                ),
+                Arrays.asList("urn:ns:type:dest-key-1", "urn:ns:type:dest-key-2", "urn:ns:type:dest-key-4", "urn:ns:type:dest-key-3")
+        );
+    }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -11,8 +11,10 @@ import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import javax.annotation.Nonnull;
 import java.util.*;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
@@ -20,7 +22,7 @@ import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
 
 
-public class DgraphGraphServiceTest {
+public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
     private DgraphGraphService _service;
 
@@ -96,7 +98,7 @@ public class DgraphGraphServiceTest {
     }
 
     @Test
-    public void testRemoveEdgesFromNode() throws Exception {
+    public void testRemoveEdgesFromNodeDeprecated() throws Exception {
         // TODO: test with both relationship directions
         Edge edge1 = new Edge(
                 Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
@@ -140,6 +142,16 @@ public class DgraphGraphServiceTest {
 
         assertEquals(relatedUrnsPostDelete.size(), 0);
     }
+
+    @Nonnull
+    @Override
+    protected GraphService getGraphService() throws Exception {
+        _service.clear();
+        return _service;
+    }
+
+    @Override
+    protected void syncAfterWrite() throws Exception { }
 
     @Test
     public void testClear() throws Exception {

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -416,7 +416,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         "  relationshipType1 as var(func: has(<relationship1>))\n" +
                         "  relationshipType2 as var(func: has(<relationship2>))\n" +
                         "\n" +
-                        "  result (func: uid(sourceFilter1), first: 100, offset: 0) @filter(\n" +
+                        "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n" +
                         "    uid(sourceType) AND\n" +
                         "    uid(sourceFilter1) AND\n" +
                         "    uid(sourceFilter2) AND\n" +
@@ -449,7 +449,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         "  relationshipType1 as var(func: has(<~relationship1>))\n" +
                         "  relationshipType2 as var(func: has(<~relationship2>))\n" +
                         "\n" +
-                        "  result (func: uid(sourceFilter1), first: 100, offset: 0) @filter(\n" +
+                        "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n" +
                         "    uid(sourceType) AND\n" +
                         "    uid(sourceFilter1) AND\n" +
                         "    uid(sourceFilter2) AND\n" +
@@ -484,7 +484,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         "  relationshipType3 as var(func: has(<~relationship1>))\n" +
                         "  relationshipType4 as var(func: has(<~relationship2>))\n" +
                         "\n" +
-                        "  result (func: uid(sourceFilter1), first: 100, offset: 0) @filter(\n" +
+                        "  result (func: uid(relationshipType1, relationshipType2, relationshipType3, relationshipType4, sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n" +
                         "    uid(sourceType) AND\n" +
                         "    uid(sourceFilter1) AND\n" +
                         "    uid(sourceFilter2) AND\n" +

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -144,48 +144,51 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 ""
         );
 
-        // source type
+        // source type not supported without restricting relationship types
+        // there must be as many relation type filter names as there are relationships
         assertEquals(
                 DgraphGraphService.getFilterConditions(
                         "sourceTypeFilter",
                         null,
                         Collections.emptyList(),
                         Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList()),
+                        Arrays.asList("RelationshipTypeFilter"),
+                        Arrays.asList("relationship")),
                 "@filter(\n"
-                        + "    uid(sourceTypeFilter)\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(sourceTypeFilter))\n"
+                        + "    )\n"
                         + "  )"
         );
 
-        // destination type not supported without restricting relationship types
-        // there must be as many relation type filter names as there are relationships
+        // destination type
         assertEquals(
                 DgraphGraphService.getFilterConditions(
                         null,
                         "destinationTypeFilter",
                         Collections.emptyList(),
                         Collections.emptyList(),
-                        Arrays.asList("RelationshipTypeFilter"),
-                        Arrays.asList("relationship")),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
                 "@filter(\n"
-                        + "    (\n"
-                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationTypeFilter))\n"
-                        + "    )\n"
+                        + "    uid(destinationTypeFilter)\n"
                         + "  )"
         );
 
-        // source filters
+        // source filter not supported without restricting relationship types
+        // there must be as many relation type filter names as there are relationships
         assertEquals(
                 DgraphGraphService.getFilterConditions(
                         null,
                         null,
                         Arrays.asList("sourceFilter"),
                         Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList()),
+                        Arrays.asList("RelationshipTypeFilter"),
+                        Arrays.asList("relationship")),
                 "@filter(\n"
-                        + "    uid(sourceFilter)\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(sourceFilter))\n"
+                        + "    )\n"
                         + "  )"
         );
         assertEquals(
@@ -194,28 +197,44 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         null,
                         Arrays.asList("sourceFilter1", "sourceFilter2"),
                         Collections.emptyList(),
-                        Collections.emptyList(),
-                        Collections.emptyList()),
+                        Arrays.asList("RelationshipTypeFilter"),
+                        Arrays.asList("relationship")),
                 "@filter(\n"
-                        + "    uid(sourceFilter1) AND\n"
-                        + "    uid(sourceFilter2)\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(sourceFilter1)) AND "
+                        + "uid_in(<relationship>, uid(sourceFilter2))\n"
+                        + "    )\n"
+                        + "  )"
+        );
+        assertEquals(
+                DgraphGraphService.getFilterConditions(
+                        null,
+                        null,
+                        Arrays.asList("sourceFilter1", "sourceFilter2"),
+                        Collections.emptyList(),
+                        Arrays.asList("RelationshipTypeFilter1", "RelationshipTypeFilter2"),
+                        Arrays.asList("relationship1", "relationship2")),
+                "@filter(\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter1) AND uid_in(<relationship1>, uid(sourceFilter1)) AND "
+                        + "uid_in(<relationship1>, uid(sourceFilter2)) OR\n"
+                        + "      uid(RelationshipTypeFilter2) AND uid_in(<relationship2>, uid(sourceFilter1)) AND "
+                        + "uid_in(<relationship2>, uid(sourceFilter2))\n"
+                        + "    )\n"
                         + "  )"
         );
 
-        // destination filter not supported without restricting relationship types
-        // there must be as many relation type filter names as there are relationships
+        // destination filters
         assertEquals(
                 DgraphGraphService.getFilterConditions(
                         null,
                         null,
                         Collections.emptyList(),
                         Arrays.asList("destinationFilter"),
-                        Arrays.asList("RelationshipTypeFilter"),
-                        Arrays.asList("relationship")),
+                        Collections.emptyList(),
+                        Collections.emptyList()),
                 "@filter(\n"
-                        + "    (\n"
-                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter))\n"
-                        + "    )\n"
+                        + "    uid(destinationFilter)\n"
                         + "  )"
         );
         assertEquals(
@@ -224,30 +243,11 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         null,
                         Collections.emptyList(),
                         Arrays.asList("destinationFilter1", "destinationFilter2"),
-                        Arrays.asList("RelationshipTypeFilter"),
-                        Arrays.asList("relationship")),
-                "@filter(\n"
-                        + "    (\n"
-                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND "
-                        + "uid_in(<relationship>, uid(destinationFilter2))\n"
-                        + "    )\n"
-                        + "  )"
-        );
-        assertEquals(
-                DgraphGraphService.getFilterConditions(
-                        null,
-                        null,
                         Collections.emptyList(),
-                        Arrays.asList("destinationFilter1", "destinationFilter2"),
-                        Arrays.asList("RelationshipTypeFilter1", "RelationshipTypeFilter2"),
-                        Arrays.asList("relationship1", "relationship2")),
+                        Collections.emptyList()),
                 "@filter(\n"
-                        + "    (\n"
-                        + "      uid(RelationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationFilter1)) AND "
-                        + "uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
-                        + "      uid(RelationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationFilter1)) AND "
-                        + "uid_in(<relationship2>, uid(destinationFilter2))\n"
-                        + "    )\n"
+                        + "    uid(destinationFilter1) AND\n"
+                        + "    uid(destinationFilter2)\n"
                         + "  )"
         );
 
@@ -278,14 +278,14 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Arrays.asList("relationshipTypeFilter1", "relationshipTypeFilter2"),
                         Arrays.asList("relationship1", "relationship2")),
                 "@filter(\n"
-                        + "    uid(sourceTypeFilter) AND\n"
-                        + "    uid(sourceFilter1) AND\n"
-                        + "    uid(sourceFilter2) AND\n"
+                        + "    uid(destinationTypeFilter) AND\n"
+                        + "    uid(destinationFilter1) AND\n"
+                        + "    uid(destinationFilter2) AND\n"
                         + "    (\n"
-                        + "      uid(relationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationTypeFilter)) AND "
-                        + "uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
-                        + "      uid(relationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationTypeFilter)) AND "
-                        + "uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n"
+                        + "      uid(relationshipTypeFilter1) AND uid_in(<relationship1>, uid(sourceTypeFilter)) AND "
+                        + "uid_in(<relationship1>, uid(sourceFilter1)) AND uid_in(<relationship1>, uid(sourceFilter2)) OR\n"
+                        + "      uid(relationshipTypeFilter2) AND uid_in(<relationship2>, uid(sourceTypeFilter)) AND "
+                        + "uid_in(<relationship2>, uid(sourceFilter1)) AND uid_in(<relationship2>, uid(sourceFilter2))\n"
                         + "    )\n"
                         + "  )"
         );
@@ -350,32 +350,27 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
         doTestGetQueryForRelatedUrnsDirection(RelationshipDirection.OUTGOING,
                 "query {\n"
                         + "  sourceType as var(func: eq(<type>, \"sourceType\"))\n"
-                        + "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n"
+                        + "  destinationType as var(func: eq(<type>, \"destinationType\"))\n"
                         + "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n"
                         + "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n"
                         + "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n"
                         + "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n"
-                        + "  relationshipType1 as var(func: has(<relationship1>))\n"
-                        + "  relationshipType2 as var(func: has(<relationship2>))\n"
+                        + "  relationshipType1 as var(func: has(<~relationship1>))\n"
+                        + "  relationshipType2 as var(func: has(<~relationship2>))\n"
                         + "\n"
-                        + "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), "
+                        + "  result (func: uid(destinationFilter1, destinationFilter2, destinationType, relationshipType1, relationshipType2), "
                         + "first: 100, offset: 0) @filter(\n"
-                        + "    uid(sourceType) AND\n"
-                        + "    uid(sourceFilter1) AND\n"
-                        + "    uid(sourceFilter2) AND\n"
+                        + "    uid(destinationType) AND\n"
+                        + "    uid(destinationFilter1) AND\n"
+                        + "    uid(destinationFilter2) AND\n"
                         + "    (\n"
-                        + "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND "
-                        + "uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
-                        + "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND "
-                        + "uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n"
+                        + "      uid(relationshipType1) AND uid_in(<~relationship1>, uid(sourceType)) AND "
+                        + "uid_in(<~relationship1>, uid(sourceFilter1)) AND uid_in(<~relationship1>, uid(sourceFilter2)) OR\n"
+                        + "      uid(relationshipType2) AND uid_in(<~relationship2>, uid(sourceType)) AND "
+                        + "uid_in(<~relationship2>, uid(sourceFilter1)) AND uid_in(<~relationship2>, uid(sourceFilter2))\n"
                         + "    )\n"
                         + "  ) {\n"
-                        + "    uid\n"
                         + "    <urn>\n"
-                        + "    <type>\n"
-                        + "    <key>\n"
-                        + "    <relationship1> { uid <urn> <type> <key> }\n"
-                        + "    <relationship2> { uid <urn> <type> <key> }\n"
                         + "  }\n"
                         + "}"
         );
@@ -386,32 +381,27 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
         doTestGetQueryForRelatedUrnsDirection(RelationshipDirection.INCOMING,
                 "query {\n"
                         + "  sourceType as var(func: eq(<type>, \"sourceType\"))\n"
-                        + "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n"
+                        + "  destinationType as var(func: eq(<type>, \"destinationType\"))\n"
                         + "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n"
                         + "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n"
                         + "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n"
                         + "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n"
-                        + "  relationshipType1 as var(func: has(<~relationship1>))\n"
-                        + "  relationshipType2 as var(func: has(<~relationship2>))\n"
+                        + "  relationshipType1 as var(func: has(<relationship1>))\n"
+                        + "  relationshipType2 as var(func: has(<relationship2>))\n"
                         + "\n"
-                        + "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), "
+                        + "  result (func: uid(destinationFilter1, destinationFilter2, destinationType, relationshipType1, relationshipType2), "
                         + "first: 100, offset: 0) @filter(\n"
-                        + "    uid(sourceType) AND\n"
-                        + "    uid(sourceFilter1) AND\n"
-                        + "    uid(sourceFilter2) AND\n"
+                        + "    uid(destinationType) AND\n"
+                        + "    uid(destinationFilter1) AND\n"
+                        + "    uid(destinationFilter2) AND\n"
                         + "    (\n"
-                        + "      uid(relationshipType1) AND uid_in(<~relationship1>, uid(destinationTypeType)) AND "
-                        + "uid_in(<~relationship1>, uid(destinationFilter1)) AND uid_in(<~relationship1>, uid(destinationFilter2)) OR\n"
-                        + "      uid(relationshipType2) AND uid_in(<~relationship2>, uid(destinationTypeType)) AND "
-                        + "uid_in(<~relationship2>, uid(destinationFilter1)) AND uid_in(<~relationship2>, uid(destinationFilter2))\n"
+                        + "      uid(relationshipType1) AND uid_in(<relationship1>, uid(sourceType)) AND "
+                        + "uid_in(<relationship1>, uid(sourceFilter1)) AND uid_in(<relationship1>, uid(sourceFilter2)) OR\n"
+                        + "      uid(relationshipType2) AND uid_in(<relationship2>, uid(sourceType)) AND "
+                        + "uid_in(<relationship2>, uid(sourceFilter1)) AND uid_in(<relationship2>, uid(sourceFilter2))\n"
                         + "    )\n"
                         + "  ) {\n"
-                        + "    uid\n"
                         + "    <urn>\n"
-                        + "    <type>\n"
-                        + "    <key>\n"
-                        + "    <~relationship1> { uid <urn> <type> <key> }\n"
-                        + "    <~relationship2> { uid <urn> <type> <key> }\n"
                         + "  }\n"
                         + "}"
         );
@@ -422,7 +412,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
         doTestGetQueryForRelatedUrnsDirection(RelationshipDirection.UNDIRECTED,
                 "query {\n"
                         + "  sourceType as var(func: eq(<type>, \"sourceType\"))\n"
-                        + "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n"
+                        + "  destinationType as var(func: eq(<type>, \"destinationType\"))\n"
                         + "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n"
                         + "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n"
                         + "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n"
@@ -432,30 +422,23 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         + "  relationshipType3 as var(func: has(<~relationship1>))\n"
                         + "  relationshipType4 as var(func: has(<~relationship2>))\n"
                         + "\n"
-                        + "  result (func: uid(relationshipType1, relationshipType2, relationshipType3, relationshipType4, "
-                        + "sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n"
-                        + "    uid(sourceType) AND\n"
-                        + "    uid(sourceFilter1) AND\n"
-                        + "    uid(sourceFilter2) AND\n"
+                        + "  result (func: uid(destinationFilter1, destinationFilter2, destinationType, " +
+                        "relationshipType1, relationshipType2, relationshipType3, relationshipType4), first: 100, offset: 0) @filter(\n"
+                        + "    uid(destinationType) AND\n"
+                        + "    uid(destinationFilter1) AND\n"
+                        + "    uid(destinationFilter2) AND\n"
                         + "    (\n"
-                        + "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND "
-                        + "uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
-                        + "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND "
-                        + "uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2)) OR\n"
-                        + "      uid(relationshipType3) AND uid_in(<~relationship1>, uid(destinationTypeType)) AND "
-                        + "uid_in(<~relationship1>, uid(destinationFilter1)) AND uid_in(<~relationship1>, uid(destinationFilter2)) OR\n"
-                        + "      uid(relationshipType4) AND uid_in(<~relationship2>, uid(destinationTypeType)) AND "
-                        + "uid_in(<~relationship2>, uid(destinationFilter1)) AND uid_in(<~relationship2>, uid(destinationFilter2))\n"
+                        + "      uid(relationshipType1) AND uid_in(<relationship1>, uid(sourceType)) AND "
+                        + "uid_in(<relationship1>, uid(sourceFilter1)) AND uid_in(<relationship1>, uid(sourceFilter2)) OR\n"
+                        + "      uid(relationshipType2) AND uid_in(<relationship2>, uid(sourceType)) AND "
+                        + "uid_in(<relationship2>, uid(sourceFilter1)) AND uid_in(<relationship2>, uid(sourceFilter2)) OR\n"
+                        + "      uid(relationshipType3) AND uid_in(<~relationship1>, uid(sourceType)) AND "
+                        + "uid_in(<~relationship1>, uid(sourceFilter1)) AND uid_in(<~relationship1>, uid(sourceFilter2)) OR\n"
+                        + "      uid(relationshipType4) AND uid_in(<~relationship2>, uid(sourceType)) AND "
+                        + "uid_in(<~relationship2>, uid(sourceFilter1)) AND uid_in(<~relationship2>, uid(sourceFilter2))\n"
                         + "    )\n"
                         + "  ) {\n"
-                        + "    uid\n"
                         + "    <urn>\n"
-                        + "    <type>\n"
-                        + "    <key>\n"
-                        + "    <relationship1> { uid <urn> <type> <key> }\n"
-                        + "    <relationship2> { uid <urn> <type> <key> }\n"
-                        + "    <~relationship1> { uid <urn> <type> <key> }\n"
-                        + "    <~relationship2> { uid <urn> <type> <key> }\n"
                         + "  }\n"
                         + "}"
         );
@@ -489,8 +472,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 DgraphGraphService.getDestinationUrnsFromResponseData(
                         new HashMap<String, Object>() {{
                             put("result", Collections.emptyList());
-                        }},
-                        Collections.emptyList()
+                        }}
                 ),
                 Collections.emptyList()
         );
@@ -501,15 +483,10 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         new HashMap<String, Object>() {{
                             put("result", Arrays.asList(
                                     new HashMap<String, Object>() {{
-                                        put("relationship", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key");
-                                                }}
-                                        ));
+                                        put("urn", "urn:ns:type:dest-key");
                                     }}
                             ));
-                        }},
-                        Arrays.asList("relationship")
+                        }}
                 ),
                 Arrays.asList("urn:ns:type:dest-key")
         );
@@ -520,22 +497,13 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         new HashMap<String, Object>() {{
                             put("result", Arrays.asList(
                                     new HashMap<String, Object>() {{
-                                        put("relationship", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key-1");
-                                                }}
-                                        ));
+                                        put("urn", "urn:ns:type:dest-key-1");
                                     }},
                                     new HashMap<String, Object>() {{
-                                        put("relationship", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key-2");
-                                                }}
-                                        ));
+                                        put("urn", "urn:ns:type:dest-key-2");
                                     }}
                             ));
-                        }},
-                        Arrays.asList("relationship")
+                        }}
                 ),
                 Arrays.asList("urn:ns:type:dest-key-1", "urn:ns:type:dest-key-2")
         );
@@ -546,34 +514,21 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         new HashMap<String, Object>() {{
                             put("result", Arrays.asList(
                                     new HashMap<String, Object>() {{
-                                        put("relationship1", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key-1");
-                                                }}
-                                        ));
-                                        put("relationship2", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key-2");
-                                                }}
-                                        ));
+                                        put("urn", "urn:ns:type:dest-key-1");
                                     }},
                                     new HashMap<String, Object>() {{
-                                        put("relationship2", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key-3");
-                                                }}
-                                        ));
-                                        put("relationship1", Arrays.asList(
-                                                new HashMap<String, Object>() {{
-                                                    put("urn", "urn:ns:type:dest-key-4");
-                                                }}
-                                        ));
+                                        put("urn", "urn:ns:type:dest-key-2");
+                                    }},
+                                    new HashMap<String, Object>() {{
+                                        put("urn", "urn:ns:type:dest-key-3");
+                                    }},
+                                    new HashMap<String, Object>() {{
+                                        put("urn", "urn:ns:type:dest-key-4");
                                     }}
                             ));
-                        }},
-                        Arrays.asList("relationship1", "relationship2")
+                        }}
                 ),
-                Arrays.asList("urn:ns:type:dest-key-1", "urn:ns:type:dest-key-2", "urn:ns:type:dest-key-4", "urn:ns:type:dest-key-3")
+                Arrays.asList("urn:ns:type:dest-key-1", "urn:ns:type:dest-key-2", "urn:ns:type:dest-key-3", "urn:ns:type:dest-key-4")
         );
     }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -6,13 +6,16 @@ import io.dgraph.DgraphClient;
 import io.dgraph.DgraphGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import org.junit.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
@@ -49,48 +52,48 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
     @Test
     public void testGetSchema() {
-        DgraphSchema schema = DgraphGraphService.getSchema("{\n" +
-                "    \"schema\": [\n" +
-                "      {\n" +
-                "        \"predicate\": \"PredOne\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"predicate\": \"PredTwo\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"predicate\": \"dgraph.type\"\n" +
-                "      }\n" +
-                "    ],\n" +
-                "    \"types\": [\n" +
-                "      {\n" +
-                "        \"fields\": [\n" +
-                "          {\n" +
-                "            \"name\": \"dgraph.type\"\n" +
-                "          }\n" +
-                "        ],\n" +
-                "        \"name\": \"dgraph.meta\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"fields\": [\n" +
-                "          {\n" +
-                "            \"name\": \"PredOne\"\n" +
-                "          },\n" +
-                "          {\n" +
-                "            \"name\": \"PredTwo\"\n" +
-                "          }\n" +
-                "        ],\n" +
-                "        \"name\": \"ns:typeOne\"\n" +
-                "      },\n" +
-                "      {\n" +
-                "        \"fields\": [\n" +
-                "          {\n" +
-                "            \"name\": \"PredTwo\"\n" +
-                "          }\n" +
-                "        ],\n" +
-                "        \"name\": \"ns:typeTwo\"\n" +
-                "      }\n" +
-                "    ]\n" +
-                "  }");
+        DgraphSchema schema = DgraphGraphService.getSchema("{\n"
+                + "    \"schema\": [\n"
+                + "      {\n"
+                + "        \"predicate\": \"PredOne\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"predicate\": \"PredTwo\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"predicate\": \"dgraph.type\"\n"
+                + "      }\n"
+                + "    ],\n"
+                + "    \"types\": [\n"
+                + "      {\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"name\": \"dgraph.type\"\n"
+                + "          }\n"
+                + "        ],\n"
+                + "        \"name\": \"dgraph.meta\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"name\": \"PredOne\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"name\": \"PredTwo\"\n"
+                + "          }\n"
+                + "        ],\n"
+                + "        \"name\": \"ns:typeOne\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"name\": \"PredTwo\"\n"
+                + "          }\n"
+                + "        ],\n"
+                + "        \"name\": \"ns:typeTwo\"\n"
+                + "      }\n"
+                + "    ]\n"
+                + "  }");
         assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo")));
 
         assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
@@ -150,9 +153,9 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Collections.emptyList(),
                         Collections.emptyList(),
                         Collections.emptyList()),
-                "@filter(\n" +
-                        "    uid(sourceTypeFilter)\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    uid(sourceTypeFilter)\n"
+                        + "  )"
         );
 
         // destination type not supported without restricting relationship types
@@ -165,11 +168,11 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Collections.emptyList(),
                         Arrays.asList("RelationshipTypeFilter"),
                         Arrays.asList("relationship")),
-                "@filter(\n" +
-                        "    (\n" +
-                        "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationTypeFilter))\n" +
-                        "    )\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationTypeFilter))\n"
+                        + "    )\n"
+                        + "  )"
         );
 
         // source filters
@@ -181,9 +184,9 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Collections.emptyList(),
                         Collections.emptyList(),
                         Collections.emptyList()),
-                "@filter(\n" +
-                        "    uid(sourceFilter)\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    uid(sourceFilter)\n"
+                        + "  )"
         );
         assertEquals(
                 DgraphGraphService.getFilterConditions(
@@ -193,10 +196,10 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Collections.emptyList(),
                         Collections.emptyList(),
                         Collections.emptyList()),
-                "@filter(\n" +
-                        "    uid(sourceFilter1) AND\n" +
-                        "    uid(sourceFilter2)\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    uid(sourceFilter1) AND\n"
+                        + "    uid(sourceFilter2)\n"
+                        + "  )"
         );
 
         // destination filter not supported without restricting relationship types
@@ -209,11 +212,11 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Arrays.asList("destinationFilter"),
                         Arrays.asList("RelationshipTypeFilter"),
                         Arrays.asList("relationship")),
-                "@filter(\n" +
-                        "    (\n" +
-                        "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter))\n" +
-                        "    )\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter))\n"
+                        + "    )\n"
+                        + "  )"
         );
         assertEquals(
                 DgraphGraphService.getFilterConditions(
@@ -223,11 +226,12 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Arrays.asList("destinationFilter1", "destinationFilter2"),
                         Arrays.asList("RelationshipTypeFilter"),
                         Arrays.asList("relationship")),
-                "@filter(\n" +
-                        "    (\n" +
-                        "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))\n" +
-                        "    )\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND "
+                        + "uid_in(<relationship>, uid(destinationFilter2))\n"
+                        + "    )\n"
+                        + "  )"
         );
         assertEquals(
                 DgraphGraphService.getFilterConditions(
@@ -237,12 +241,14 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Arrays.asList("destinationFilter1", "destinationFilter2"),
                         Arrays.asList("RelationshipTypeFilter1", "RelationshipTypeFilter2"),
                         Arrays.asList("relationship1", "relationship2")),
-                "@filter(\n" +
-                        "    (\n" +
-                        "      uid(RelationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
-                        "      uid(RelationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n" +
-                        "    )\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    (\n"
+                        + "      uid(RelationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationFilter1)) AND "
+                        + "uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
+                        + "      uid(RelationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationFilter1)) AND "
+                        + "uid_in(<relationship2>, uid(destinationFilter2))\n"
+                        + "    )\n"
+                        + "  )"
         );
 
         // relationship type filters require relationship types
@@ -254,12 +260,12 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Collections.emptyList(),
                         Arrays.asList("relationshipTypeFilter1", "relationshipTypeFilter2"),
                         Arrays.asList("relationship1", "relationship2")),
-                "@filter(\n" +
-                        "    (\n" +
-                        "      uid(relationshipTypeFilter1) OR\n" +
-                        "      uid(relationshipTypeFilter2)\n" +
-                        "    )\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    (\n"
+                        + "      uid(relationshipTypeFilter1) OR\n"
+                        + "      uid(relationshipTypeFilter2)\n"
+                        + "    )\n"
+                        + "  )"
         );
 
         // all filters at once
@@ -271,15 +277,17 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         Arrays.asList("destinationFilter1", "destinationFilter2"),
                         Arrays.asList("relationshipTypeFilter1", "relationshipTypeFilter2"),
                         Arrays.asList("relationship1", "relationship2")),
-                "@filter(\n" +
-                        "    uid(sourceTypeFilter) AND\n" +
-                        "    uid(sourceFilter1) AND\n" +
-                        "    uid(sourceFilter2) AND\n" +
-                        "    (\n" +
-                        "      uid(relationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationTypeFilter)) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
-                        "      uid(relationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationTypeFilter)) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n" +
-                        "    )\n" +
-                        "  )"
+                "@filter(\n"
+                        + "    uid(sourceTypeFilter) AND\n"
+                        + "    uid(sourceFilter1) AND\n"
+                        + "    uid(sourceFilter2) AND\n"
+                        + "    (\n"
+                        + "      uid(relationshipTypeFilter1) AND uid_in(<relationship1>, uid(destinationTypeFilter)) AND "
+                        + "uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
+                        + "      uid(relationshipTypeFilter2) AND uid_in(<relationship2>, uid(destinationTypeFilter)) AND "
+                        + "uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n"
+                        + "    )\n"
+                        + "  )"
         );
 
         // TODO: check getFilterConditions throws an exception when relationshipTypes and
@@ -312,7 +320,8 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         "relationshipFilter",
                         "destinationTypeFilter",
                         Arrays.asList("destinationFilter")),
-                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter)) AND uid_in(<relationship>, uid(destinationFilter))"
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter)) AND "
+                        + "uid_in(<relationship>, uid(destinationFilter))"
         );
 
         assertEquals(
@@ -321,7 +330,8 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         "relationshipFilter",
                         "destinationTypeFilter",
                         Arrays.asList("destinationFilter1", "destinationFilter2")),
-                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter)) AND uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))"
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationTypeFilter)) AND "
+                        + "uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))"
         );
 
         assertEquals(
@@ -330,112 +340,124 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                         "relationshipFilter",
                         null,
                         Arrays.asList("destinationFilter1", "destinationFilter2")),
-                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND uid_in(<relationship>, uid(destinationFilter2))"
+                "uid(relationshipFilter) AND uid_in(<relationship>, uid(destinationFilter1)) AND "
+                        + "uid_in(<relationship>, uid(destinationFilter2))"
         );
     }
 
     @Test
     public void testGetQueryForRelatedUrnsOutgoing() {
         doTestGetQueryForRelatedUrnsDirection(RelationshipDirection.OUTGOING,
-                "query {\n" +
-                        "  sourceType as var(func: eq(<type>, \"sourceType\"))\n" +
-                        "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n" +
-                        "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n" +
-                        "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n" +
-                        "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n" +
-                        "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n" +
-                        "  relationshipType1 as var(func: has(<relationship1>))\n" +
-                        "  relationshipType2 as var(func: has(<relationship2>))\n" +
-                        "\n" +
-                        "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n" +
-                        "    uid(sourceType) AND\n" +
-                        "    uid(sourceFilter1) AND\n" +
-                        "    uid(sourceFilter2) AND\n" +
-                        "    (\n" +
-                        "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
-                        "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n" +
-                        "    )\n" +
-                        "  ) {\n" +
-                        "    uid\n" +
-                        "    <urn>\n" +
-                        "    <type>\n" +
-                        "    <key>\n" +
-                        "    <relationship1> { uid <urn> <type> <key> }\n" +
-                        "    <relationship2> { uid <urn> <type> <key> }\n" +
-                        "  }\n" +
-                        "}"
+                "query {\n"
+                        + "  sourceType as var(func: eq(<type>, \"sourceType\"))\n"
+                        + "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n"
+                        + "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n"
+                        + "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n"
+                        + "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n"
+                        + "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n"
+                        + "  relationshipType1 as var(func: has(<relationship1>))\n"
+                        + "  relationshipType2 as var(func: has(<relationship2>))\n"
+                        + "\n"
+                        + "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), "
+                        + "first: 100, offset: 0) @filter(\n"
+                        + "    uid(sourceType) AND\n"
+                        + "    uid(sourceFilter1) AND\n"
+                        + "    uid(sourceFilter2) AND\n"
+                        + "    (\n"
+                        + "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND "
+                        + "uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
+                        + "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND "
+                        + "uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2))\n"
+                        + "    )\n"
+                        + "  ) {\n"
+                        + "    uid\n"
+                        + "    <urn>\n"
+                        + "    <type>\n"
+                        + "    <key>\n"
+                        + "    <relationship1> { uid <urn> <type> <key> }\n"
+                        + "    <relationship2> { uid <urn> <type> <key> }\n"
+                        + "  }\n"
+                        + "}"
         );
     }
 
     @Test
     public void testGetQueryForRelatedUrnsIncoming() {
         doTestGetQueryForRelatedUrnsDirection(RelationshipDirection.INCOMING,
-                "query {\n" +
-                        "  sourceType as var(func: eq(<type>, \"sourceType\"))\n" +
-                        "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n" +
-                        "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n" +
-                        "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n" +
-                        "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n" +
-                        "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n" +
-                        "  relationshipType1 as var(func: has(<~relationship1>))\n" +
-                        "  relationshipType2 as var(func: has(<~relationship2>))\n" +
-                        "\n" +
-                        "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n" +
-                        "    uid(sourceType) AND\n" +
-                        "    uid(sourceFilter1) AND\n" +
-                        "    uid(sourceFilter2) AND\n" +
-                        "    (\n" +
-                        "      uid(relationshipType1) AND uid_in(<~relationship1>, uid(destinationTypeType)) AND uid_in(<~relationship1>, uid(destinationFilter1)) AND uid_in(<~relationship1>, uid(destinationFilter2)) OR\n" +
-                        "      uid(relationshipType2) AND uid_in(<~relationship2>, uid(destinationTypeType)) AND uid_in(<~relationship2>, uid(destinationFilter1)) AND uid_in(<~relationship2>, uid(destinationFilter2))\n" +
-                        "    )\n" +
-                        "  ) {\n" +
-                        "    uid\n" +
-                        "    <urn>\n" +
-                        "    <type>\n" +
-                        "    <key>\n" +
-                        "    <~relationship1> { uid <urn> <type> <key> }\n" +
-                        "    <~relationship2> { uid <urn> <type> <key> }\n" +
-                        "  }\n" +
-                        "}"
+                "query {\n"
+                        + "  sourceType as var(func: eq(<type>, \"sourceType\"))\n"
+                        + "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n"
+                        + "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n"
+                        + "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n"
+                        + "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n"
+                        + "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n"
+                        + "  relationshipType1 as var(func: has(<~relationship1>))\n"
+                        + "  relationshipType2 as var(func: has(<~relationship2>))\n"
+                        + "\n"
+                        + "  result (func: uid(relationshipType1, relationshipType2, sourceFilter1, sourceFilter2, sourceType), "
+                        + "first: 100, offset: 0) @filter(\n"
+                        + "    uid(sourceType) AND\n"
+                        + "    uid(sourceFilter1) AND\n"
+                        + "    uid(sourceFilter2) AND\n"
+                        + "    (\n"
+                        + "      uid(relationshipType1) AND uid_in(<~relationship1>, uid(destinationTypeType)) AND "
+                        + "uid_in(<~relationship1>, uid(destinationFilter1)) AND uid_in(<~relationship1>, uid(destinationFilter2)) OR\n"
+                        + "      uid(relationshipType2) AND uid_in(<~relationship2>, uid(destinationTypeType)) AND "
+                        + "uid_in(<~relationship2>, uid(destinationFilter1)) AND uid_in(<~relationship2>, uid(destinationFilter2))\n"
+                        + "    )\n"
+                        + "  ) {\n"
+                        + "    uid\n"
+                        + "    <urn>\n"
+                        + "    <type>\n"
+                        + "    <key>\n"
+                        + "    <~relationship1> { uid <urn> <type> <key> }\n"
+                        + "    <~relationship2> { uid <urn> <type> <key> }\n"
+                        + "  }\n"
+                        + "}"
         );
     }
 
     @Test
     public void testGetQueryForRelatedUrnsUndirected() {
         doTestGetQueryForRelatedUrnsDirection(RelationshipDirection.UNDIRECTED,
-                "query {\n" +
-                        "  sourceType as var(func: eq(<type>, \"sourceType\"))\n" +
-                        "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n" +
-                        "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n" +
-                        "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n" +
-                        "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n" +
-                        "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n" +
-                        "  relationshipType1 as var(func: has(<relationship1>))\n" +
-                        "  relationshipType2 as var(func: has(<relationship2>))\n" +
-                        "  relationshipType3 as var(func: has(<~relationship1>))\n" +
-                        "  relationshipType4 as var(func: has(<~relationship2>))\n" +
-                        "\n" +
-                        "  result (func: uid(relationshipType1, relationshipType2, relationshipType3, relationshipType4, sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n" +
-                        "    uid(sourceType) AND\n" +
-                        "    uid(sourceFilter1) AND\n" +
-                        "    uid(sourceFilter2) AND\n" +
-                        "    (\n" +
-                        "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n" +
-                        "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2)) OR\n" +
-                        "      uid(relationshipType3) AND uid_in(<~relationship1>, uid(destinationTypeType)) AND uid_in(<~relationship1>, uid(destinationFilter1)) AND uid_in(<~relationship1>, uid(destinationFilter2)) OR\n" +
-                        "      uid(relationshipType4) AND uid_in(<~relationship2>, uid(destinationTypeType)) AND uid_in(<~relationship2>, uid(destinationFilter1)) AND uid_in(<~relationship2>, uid(destinationFilter2))\n" +
-                        "    )\n" +
-                        "  ) {\n" +
-                        "    uid\n" +
-                        "    <urn>\n" +
-                        "    <type>\n" +
-                        "    <key>\n" +
-                        "    <relationship1> { uid <urn> <type> <key> }\n" +
-                        "    <relationship2> { uid <urn> <type> <key> }\n" +
-                        "    <~relationship1> { uid <urn> <type> <key> }\n" +
-                        "    <~relationship2> { uid <urn> <type> <key> }\n" +
-                        "  }\n" +
-                        "}"
+                "query {\n"
+                        + "  sourceType as var(func: eq(<type>, \"sourceType\"))\n"
+                        + "  destinationTypeType as var(func: eq(<type>, \"destinationType\"))\n"
+                        + "  sourceFilter1 as var(func: eq(<urn>, \"urn:ns:type:source-key\"))\n"
+                        + "  sourceFilter2 as var(func: eq(<key>, \"source-key\"))\n"
+                        + "  destinationFilter1 as var(func: eq(<urn>, \"urn:ns:type:dest-key\"))\n"
+                        + "  destinationFilter2 as var(func: eq(<key>, \"dest-key\"))\n"
+                        + "  relationshipType1 as var(func: has(<relationship1>))\n"
+                        + "  relationshipType2 as var(func: has(<relationship2>))\n"
+                        + "  relationshipType3 as var(func: has(<~relationship1>))\n"
+                        + "  relationshipType4 as var(func: has(<~relationship2>))\n"
+                        + "\n"
+                        + "  result (func: uid(relationshipType1, relationshipType2, relationshipType3, relationshipType4, "
+                        + "sourceFilter1, sourceFilter2, sourceType), first: 100, offset: 0) @filter(\n"
+                        + "    uid(sourceType) AND\n"
+                        + "    uid(sourceFilter1) AND\n"
+                        + "    uid(sourceFilter2) AND\n"
+                        + "    (\n"
+                        + "      uid(relationshipType1) AND uid_in(<relationship1>, uid(destinationTypeType)) AND "
+                        + "uid_in(<relationship1>, uid(destinationFilter1)) AND uid_in(<relationship1>, uid(destinationFilter2)) OR\n"
+                        + "      uid(relationshipType2) AND uid_in(<relationship2>, uid(destinationTypeType)) AND "
+                        + "uid_in(<relationship2>, uid(destinationFilter1)) AND uid_in(<relationship2>, uid(destinationFilter2)) OR\n"
+                        + "      uid(relationshipType3) AND uid_in(<~relationship1>, uid(destinationTypeType)) AND "
+                        + "uid_in(<~relationship1>, uid(destinationFilter1)) AND uid_in(<~relationship1>, uid(destinationFilter2)) OR\n"
+                        + "      uid(relationshipType4) AND uid_in(<~relationship2>, uid(destinationTypeType)) AND "
+                        + "uid_in(<~relationship2>, uid(destinationFilter1)) AND uid_in(<~relationship2>, uid(destinationFilter2))\n"
+                        + "    )\n"
+                        + "  ) {\n"
+                        + "    uid\n"
+                        + "    <urn>\n"
+                        + "    <type>\n"
+                        + "    <key>\n"
+                        + "    <relationship1> { uid <urn> <type> <key> }\n"
+                        + "    <relationship2> { uid <urn> <type> <key> }\n"
+                        + "    <~relationship1> { uid <urn> <type> <key> }\n"
+                        + "    <~relationship2> { uid <urn> <type> <key> }\n"
+                        + "  }\n"
+                        + "}"
         );
     }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -1,17 +1,14 @@
 package com.linkedin.metadata.graph;
 
-import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
 import io.dgraph.DgraphClient;
 import io.dgraph.DgraphGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
+import org.junit.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import javax.annotation.Nonnull;
@@ -40,160 +37,94 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
     @AfterMethod
     public void tearDown() { }
 
-    @Test
-    public void testAddEdge() throws Exception {
-        // test both directions
-        Edge edge1 = new Edge(
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-                "DownstreamOf");
-
-        _service.addEdge(edge1);
-
-        List<String> edgeTypes = new ArrayList<>();
-        edgeTypes.add("DownstreamOf");
-        RelationshipFilter relationshipFilter = new RelationshipFilter();
-        relationshipFilter.setDirection(RelationshipDirection.OUTGOING);
-        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-        List<String> relatedUrns = _service.findRelatedUrns(
-                "",
-                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "",
-                EMPTY_FILTER,
-                edgeTypes,
-                relationshipFilter,
-                0,
-                10);
-
-        assertEquals(relatedUrns.size(), 1);
-    }
-
-    @Test
-    public void testAddEdgeReverse() throws Exception {
-        Edge edge1 = new Edge(
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "DownstreamOf");
-
-        _service.addEdge(edge1);
-
-        List<String> edgeTypes = new ArrayList<>();
-        edgeTypes.add("DownstreamOf");
-        RelationshipFilter relationshipFilter = new RelationshipFilter();
-        relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-        List<String> relatedUrns = _service.findRelatedUrns(
-                "",
-                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "",
-                EMPTY_FILTER,
-                edgeTypes,
-                relationshipFilter,
-                0,
-                10);
-
-        assertEquals(relatedUrns.size(), 1);
-    }
-
-    @Test
-    public void testRemoveEdgesFromNodeDeprecated() throws Exception {
-        // TODO: test with both relationship directions
-        Edge edge1 = new Edge(
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-                "DownstreamOf");
-
-        _service.addEdge(edge1);
-
-        List<String> edgeTypes = new ArrayList<>();
-        edgeTypes.add("DownstreamOf");
-        RelationshipFilter relationshipFilter = new RelationshipFilter();
-        relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
-
-        List<String> relatedUrns = _service.findRelatedUrns(
-                "",
-                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "",
-                EMPTY_FILTER,
-                edgeTypes,
-                relationshipFilter,
-                0,
-                10);
-
-        assertEquals(relatedUrns.size(), 1);
-
-        _service.removeEdgesFromNode(Urn.createFromString(
-                "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                edgeTypes,
-                relationshipFilter);
-
-        List<String> relatedUrnsPostDelete = _service.findRelatedUrns(
-                "",
-                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "",
-                EMPTY_FILTER,
-                edgeTypes,
-                relationshipFilter,
-                0,
-                10);
-
-        assertEquals(relatedUrnsPostDelete.size(), 0);
-    }
-
     @Nonnull
     @Override
-    protected GraphService getGraphService() throws Exception {
+    protected GraphService getGraphService() {
         _service.clear();
         return _service;
     }
 
     @Override
-    protected void syncAfterWrite() throws Exception { }
+    protected void syncAfterWrite() { }
 
     @Test
-    public void testClear() throws Exception {
-        // TODO: test with both relationship directions
-        Edge edge1 = new Edge(
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:hive,SampleHiveDataset,PROD)"),
-                Urn.createFromString("urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "DownstreamOf");
+    public void testGetSchema() {
+        DgraphSchema schema = DgraphGraphService.getSchema("{\n" +
+                "    \"schema\": [\n" +
+                "      {\n" +
+                "        \"predicate\": \"PredOne\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"predicate\": \"PredTwo\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"predicate\": \"dgraph.type\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"types\": [\n" +
+                "      {\n" +
+                "        \"fields\": [\n" +
+                "          {\n" +
+                "            \"name\": \"dgraph.type\"\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"name\": \"dgraph.meta\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"fields\": [\n" +
+                "          {\n" +
+                "            \"name\": \"PredOne\"\n" +
+                "          },\n" +
+                "          {\n" +
+                "            \"name\": \"PredTwo\"\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"name\": \"ns:typeOne\"\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"fields\": [\n" +
+                "          {\n" +
+                "            \"name\": \"PredTwo\"\n" +
+                "          }\n" +
+                "        ],\n" +
+                "        \"name\": \"ns:typeTwo\"\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  }");
+        assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo")));
 
-        _service.addEdge(edge1);
+        assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
+            put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo")));
+            put("ns:typeTwo", new HashSet<>(Arrays.asList("PredTwo")));
+        }});
 
-        List<String> edgeTypes = new ArrayList<>();
-        edgeTypes.add("DownstreamOf");
-        RelationshipFilter relationshipFilter = new RelationshipFilter();
-        relationshipFilter.setDirection(RelationshipDirection.INCOMING);
-        relationshipFilter.setCriteria(EMPTY_FILTER.getCriteria());
+        assertEquals(schema.getFields("ns:typeOne"), new HashSet<>(Arrays.asList("PredOne", "PredTwo")));
+        assertEquals(schema.getFields("ns:typeTwo"), new HashSet<>(Arrays.asList("PredTwo")));
+        assertEquals(schema.getFields("ns:unknown"), Collections.emptySet());
 
-        List<String> relatedUrns = _service.findRelatedUrns(
-                "",
-                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "",
-                EMPTY_FILTER,
-                edgeTypes,
-                relationshipFilter,
-                0,
-                10);
+        schema.addField("newType", "newField");
+        assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo", "newField")));
+        assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
+            put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo")));
+            put("ns:typeTwo", new HashSet<>(Arrays.asList("PredTwo")));
+            put("newType", new HashSet<>(Arrays.asList("newField")));
+        }});
 
-        assertEquals(relatedUrns.size(), 1);
+        schema.addField("ns:typeOne", "otherField");
+        assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo", "newField", "otherField")));
+        assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
+            put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo", "otherField")));
+            put("ns:typeTwo", new HashSet<>(Arrays.asList("PredTwo")));
+            put("newType", new HashSet<>(Arrays.asList("newField")));
+        }});
 
-        _service.clear();
-
-        List<String> relatedUrnsPostDelete = _service.findRelatedUrns(
-                "",
-                newFilter("urn", "urn:li:dataset:(urn:li:dataPlatform:kafka,SampleKafkaDataset,PROD)"),
-                "",
-                EMPTY_FILTER,
-                edgeTypes,
-                relationshipFilter,
-                0,
-                10);
-
-        assertEquals(relatedUrnsPostDelete.size(), 0);
+        schema.addField("ns:typeTwo", "PredTwo");
+        assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo", "newField", "otherField")));
+        assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
+            put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo", "otherField")));
+            put("ns:typeTwo", new HashSet<>(Arrays.asList("PredTwo")));
+            put("newType", new HashSet<>(Arrays.asList("newField")));
+        }});
     }
 
     @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -78,7 +78,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
             @Override
             public <REQ, RESP> ClientCall<REQ, RESP> interceptCall(
                     MethodDescriptor<REQ, RESP> method, CallOptions callOptions, Channel next) {
-                return next.newCall(method, callOptions.withDeadlineAfter(10, TimeUnit.SECONDS));
+                return next.newCall(method, callOptions.withDeadlineAfter(30, TimeUnit.SECONDS));
             }
         };
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -44,7 +44,11 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 .usePlaintext()
                 .build();
 
-        _service = new DgraphGraphService(new DgraphClient(DgraphGrpc.newStub(_channel)));
+        DgraphGrpc.DgraphStub stub = DgraphGrpc.newStub(_channel)
+                .withDeadlineAfter(10, TimeUnit.SECONDS)
+                .withWaitForReady();
+
+        _service = new DgraphGraphService(new DgraphClient(stub));
     }
 
     @AfterMethod

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -34,7 +34,7 @@ import java.util.function.Consumer;
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 @Slf4j
 public class DgraphGraphServiceTest extends GraphServiceTestBase {
@@ -209,7 +209,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 + "    ],\n"
                 + "    \"types\": \"not a list\"\n"
                 + "  }");
-        assertNull(schemaWithNonListTypes, "Should be null if type field is not a list");
+        assertTrue(schemaWithNonListTypes.isEmpty(), "Should be empty if type field is not a list");
 
         DgraphSchema schemaWithoutTypes = DgraphGraphService.getSchema("{\n"
                 + "    \"schema\": [\n"
@@ -224,15 +224,15 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 + "      }\n"
                 + "    ]"
                 + "  }");
-        assertNull(schemaWithoutTypes, "Should be null if no type field exists");
+        assertTrue(schemaWithoutTypes.isEmpty(), "Should be empty if no type field exists");
 
         DgraphSchema schemaWithNonListSchema = DgraphGraphService.getSchema("{\n"
                 + "    \"schema\": \"not a list\""
                 + "  }");
-        assertNull(schemaWithNonListSchema, "Should be null if schema field is not a list");
+        assertTrue(schemaWithNonListSchema.isEmpty(), "Should be empty if schema field is not a list");
 
-        DgraphSchema schemaWithoutSchema = DgraphGraphService.getSchema("{ }", null);
-        assertNull(schemaWithoutSchema, "Should be null if no schema field exists");
+        DgraphSchema schemaWithoutSchema = DgraphGraphService.getSchema("{ }");
+        assertTrue(schemaWithoutSchema.isEmpty(), "Should be empty if no schema field exists");
     }
 
     @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -7,12 +7,13 @@ import io.dgraph.DgraphGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.output.OutputFrame;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+import scala.Console;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -21,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
@@ -38,8 +40,13 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
         _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"));
         _container.start();
 
-        Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
-        _container.followOutput(logConsumer);
+        // use Slf4jLogConsumer instead: Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+        _container.followOutput(new Consumer<OutputFrame>() {
+            @Override
+            public void accept(OutputFrame outputFrame) {
+                Console.print(outputFrame.getUtf8String());
+            }
+        });
     }
 
     @BeforeMethod

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -6,6 +6,8 @@ import io.dgraph.DgraphClient;
 import io.dgraph.DgraphGrpc;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
@@ -24,7 +26,7 @@ import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
 
-
+@Slf4j
 public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
     private ManagedChannel _channel;
@@ -35,6 +37,9 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
     public void setup() {
         _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"));
         _container.start();
+
+        Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+        _container.followOutput(logConsumer);
     }
 
     @BeforeMethod

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -33,6 +33,7 @@ import java.util.function.Consumer;
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
 @Slf4j
 public class DgraphGraphServiceTest extends GraphServiceTestBase {
@@ -176,6 +177,48 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
             put("ns:typeTwo", new HashSet<>(Arrays.asList("PredTwo")));
             put("newType", new HashSet<>(Arrays.asList("newField")));
         }});
+    }
+
+    @Test
+    public void testGetSchemaIncomplete() {
+        DgraphSchema schemaWithNonListTypes = DgraphGraphService.getSchema("{\n"
+                + "    \"schema\": [\n"
+                + "      {\n"
+                + "        \"predicate\": \"PredOne\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"predicate\": \"PredTwo\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"predicate\": \"dgraph.type\"\n"
+                + "      }\n"
+                + "    ],\n"
+                + "    \"types\": \"not a list\"\n"
+                + "  }");
+        assertNull(schemaWithNonListTypes, "Should be null if type field is not a list");
+
+        DgraphSchema schemaWithoutTypes = DgraphGraphService.getSchema("{\n"
+                + "    \"schema\": [\n"
+                + "      {\n"
+                + "        \"predicate\": \"PredOne\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"predicate\": \"PredTwo\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"predicate\": \"dgraph.type\"\n"
+                + "      }\n"
+                + "    ]"
+                + "  }");
+        assertNull(schemaWithoutTypes, "Should be null if no type field exists");
+
+        DgraphSchema schemaWithNonListSchema = DgraphGraphService.getSchema("{\n"
+                + "    \"schema\": \"not a list\""
+                + "  }");
+        assertNull(schemaWithNonListSchema, "Should be null if schema field is not a list");
+
+        DgraphSchema schemaWithoutSchema = DgraphGraphService.getSchema("{ }");
+        assertNull(schemaWithoutSchema, "Should be null if no schema field exists");
     }
 
     @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 import scala.Console;
 
 import javax.annotation.Nonnull;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,7 +56,9 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
     }
 
     @BeforeMethod
-    public void connect() {
+    public void connect(Method method) {
+        System.out.println(System.currentTimeMillis() + ": Running test " + method.getName());
+
         _channel = ManagedChannelBuilder
                 .forAddress(_container.getHost(), _container.getGrpcPort())
                 .usePlaintext()

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -80,8 +80,13 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
     @AfterMethod
     public void disconnect() throws InterruptedException {
-        _channel.shutdownNow();
-        _channel.awaitTermination(10, TimeUnit.SECONDS);
+        try {
+            _channel.shutdownNow();
+            _channel.awaitTermination(10, TimeUnit.SECONDS);
+        } finally {
+            _channel = null;
+            _service = null;
+        }
     }
 
     @AfterTest

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -43,6 +43,11 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
     private DgraphGraphService _service;
     private DgraphContainer _container;
 
+    @Override
+    protected Duration getTestConcurrentOpTimeout() {
+        return Duration.ofMinutes(5);
+    }
+
     @BeforeTest
     public void setup() {
         _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"))

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -12,17 +12,14 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import lombok.extern.slf4j.Slf4j;
-import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-import scala.Console;
 
 import javax.annotation.Nonnull;
-import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,7 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.graph;
 
-import com.linkedin.metadata.query.RelationshipDirection;
-import com.linkedin.metadata.query.RelationshipFilter;
+import com.linkedin.metadata.query.filter.RelationshipDirection;
 import io.dgraph.DgraphClient;
 import io.dgraph.DgraphGrpc;
 import io.grpc.CallOptions;
@@ -28,11 +27,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
-import static com.linkedin.metadata.dao.utils.QueryUtils.newFilter;
+import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
+import static com.linkedin.metadata.search.utils.QueryUtils.newFilter;
+import static com.linkedin.metadata.search.utils.QueryUtils.newRelationshipFilter;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 @Slf4j
 public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
@@ -641,7 +642,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                             put("key", "dest-key");
                         }}),
                         Arrays.asList("relationship1", "relationship2"),
-                        new RelationshipFilter().setCriteria(EMPTY_FILTER.getCriteria()).setDirection(direction),
+                        newRelationshipFilter(EMPTY_FILTER, direction),
                         0, 100
                 ),
                 expectedQuery

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -154,7 +154,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
         assertEquals(schema.getFields("ns:typeTwo"), new HashSet<>(Arrays.asList("PredTwo")));
         assertEquals(schema.getFields("ns:unknown"), Collections.emptySet());
 
-        schema.addField("newType", "newField");
+        schema.ensureField("newType", "newField");
         assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo", "newField")));
         assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
             put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo")));
@@ -162,7 +162,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
             put("newType", new HashSet<>(Arrays.asList("newField")));
         }});
 
-        schema.addField("ns:typeOne", "otherField");
+        schema.ensureField("ns:typeOne", "otherField");
         assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo", "newField", "otherField")));
         assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
             put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo", "otherField")));
@@ -170,7 +170,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
             put("newType", new HashSet<>(Arrays.asList("newField")));
         }});
 
-        schema.addField("ns:typeTwo", "PredTwo");
+        schema.ensureField("ns:typeTwo", "PredTwo");
         assertEquals(schema.getFields(), new HashSet<>(Arrays.asList("PredOne", "PredTwo", "newField", "otherField")));
         assertEquals(schema.getTypes(), new HashMap<String, Set<String>>() {{
             put("ns:typeOne", new HashSet<>(Arrays.asList("PredOne", "PredTwo", "otherField")));
@@ -217,8 +217,13 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 + "  }");
         assertNull(schemaWithNonListSchema, "Should be null if schema field is not a list");
 
-        DgraphSchema schemaWithoutSchema = DgraphGraphService.getSchema("{ }");
+        DgraphSchema schemaWithoutSchema = DgraphGraphService.getSchema("{ }", null);
         assertNull(schemaWithoutSchema, "Should be null if no schema field exists");
+    }
+
+    @Test
+    public void testGetSchemaDgraph() {
+        // TODO: test that dgraph schema gets altered
     }
 
     @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -13,6 +13,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
@@ -56,19 +57,12 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 .withStartupAttempts(3);
         _container.start();
 
-        // use Slf4jLogConsumer instead: Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
-        _container.followOutput(new Consumer<OutputFrame>() {
-            @Override
-            public void accept(OutputFrame outputFrame) {
-                Console.print(outputFrame.getUtf8String());
-            }
-        });
+        Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
+        _container.followOutput(logConsumer);
     }
 
     @BeforeMethod
-    public void connect(Method method) {
-        System.out.println(System.currentTimeMillis() + ": Running test " + method.getName());
-
+    public void connect() {
         _channel = ManagedChannelBuilder
                 .forAddress(_container.getHost(), _container.getGrpcPort())
                 .usePlaintext()

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -51,6 +51,7 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
     @BeforeTest
     public void setup() {
         _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"))
+                .withTmpFs(Collections.singletonMap("/dgraph", "rw,noexec,nosuid,size=1g"))
                 .withStartupTimeout(Duration.ofMinutes(1))
                 .withStartupAttempts(3);
         _container.start();

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -22,6 +22,7 @@ import scala.Console;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,7 +45,9 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
 
     @BeforeTest
     public void setup() {
-        _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"));
+        _container = new DgraphContainer(DgraphContainer.DEFAULT_IMAGE_NAME.withTag("v21.03.0"))
+                .withStartupTimeout(Duration.ofMinutes(1))
+                .withStartupAttempts(3);
         _container.start();
 
         // use Slf4jLogConsumer instead: Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -126,6 +127,13 @@ abstract public class GraphServiceTestBase {
    * Any source and destination type value.
    */
   protected static @Nullable String anyType = null;
+
+  /**
+   * Timeout used to test concurrent ops in doTestConcurrentOp.
+   */
+  protected Duration getTestConcurrentOpTimeout() {
+      return Duration.ofMinutes(1);
+  }
 
   @Test
   public void testStaticUrns() {
@@ -1434,7 +1442,7 @@ abstract public class GraphServiceTestBase {
           }
       }).start());
 
-      assertTrue(finished.await(60, TimeUnit.SECONDS));
+      assertTrue(finished.await(getTestConcurrentOpTimeout().toMillis(), TimeUnit.MILLISECONDS));
       assertEquals(throwables.size(), 0);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1301,7 +1301,7 @@ abstract public class GraphServiceTestBase {
       // too many edges may cause too many threads throwing
       // java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
       int nodes = 5;
-      int relationshipTypes = 5;
+      int relationshipTypes = 3;
       List<String> allRelationships = IntStream.range(1, relationshipTypes + 1).mapToObj(id -> "relationship" + id).collect(Collectors.toList());
       List<Edge> edges = getFullyConnectedGraph(nodes, allRelationships);
 
@@ -1332,8 +1332,8 @@ abstract public class GraphServiceTestBase {
   public void testConcurrentRemoveEdgesFromNode() throws Exception {
     final GraphService service = getGraphService();
 
-    int nodes = 10;
-    int relationshipTypes = 5;
+    int nodes = 5;
+    int relationshipTypes = 3;
     List<String> allRelationships = IntStream.range(1, relationshipTypes + 1).mapToObj(id -> "relationship" + id).collect(Collectors.toList());
     List<Edge> edges = getFullyConnectedGraph(nodes, allRelationships);
 
@@ -1376,8 +1376,8 @@ abstract public class GraphServiceTestBase {
 
     // too many edges may cause too many threads throwing
     // java.util.concurrent.RejectedExecutionException: Thread limit exceeded replacing blocked worker
-    int nodes = 10;
-    int relationshipTypes = 5;
+    int nodes = 5;
+    int relationshipTypes = 3;
     List<String> allRelationships = IntStream.range(1, relationshipTypes + 1).mapToObj(id -> "relationship" + id).collect(Collectors.toList());
     List<Edge> edges = getFullyConnectedGraph(nodes, allRelationships);
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1426,11 +1426,11 @@ abstract public class GraphServiceTestBase {
                   }
 
                   operation.run();
-                  finished.countDown();
               } catch (Throwable t) {
                   t.printStackTrace();
                   throwables.add(t);
               }
+              finished.countDown();
           }
       }).start());
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1443,6 +1443,7 @@ abstract public class GraphServiceTestBase {
       }).start());
 
       assertTrue(finished.await(getTestConcurrentOpTimeout().toMillis(), TimeUnit.MILLISECONDS));
+      throwables.forEach(throwable -> System.out.printf(System.currentTimeMillis() + ": exception occurred: %s%n", throwable));
       assertEquals(throwables.size(), 0);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1434,7 +1434,7 @@ abstract public class GraphServiceTestBase {
           }
       }).start());
 
-      assertTrue(finished.await(10, TimeUnit.SECONDS));
+      assertTrue(finished.await(60, TimeUnit.SECONDS));
       assertEquals(throwables.size(), 0);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/GraphServiceTestBase.java
@@ -1443,7 +1443,7 @@ abstract public class GraphServiceTestBase {
       }).start());
 
       assertTrue(finished.await(getTestConcurrentOpTimeout().toMillis(), TimeUnit.MILLISECONDS));
-      throwables.forEach(throwable -> System.out.printf(System.currentTimeMillis() + ": exception occurred: %s%n", throwable));
+      throwables.forEach(throwable -> System.err.printf(System.currentTimeMillis() + ": exception occurred: %s%n", throwable));
       assertEquals(throwables.size(), 0);
   }
 


### PR DESCRIPTION
This implements the GraphService API for Dgraph (https://dgraph.io). This implementation passes all GraphService tests added in #3011. Integration of Dgraph into GMS factories and the Docker setup is happening in a follow-up PR.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

Fixes #3084.