### PR TITLE
fix(test): Fix ES syncAfterWrite timeout

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,13 @@ on:
 
 jobs:
   build:
+    name: "build (#${{ matrix.high-digit}}${{ matrix.low-digit}})"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        high-digit: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        low-digit: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -30,10 +36,11 @@ jobs:
       - name: Gradle build (and test)
         run: ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: Test Results
+          name: "Test Results #${{ matrix.high-digit}}${{ matrix.low-digit}}"
           path: "**/build/reports/tests/test/**"
+          retention-days: 5
       - name: Ensure codegen is updated
         run: |
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then


### PR DESCRIPTION
Sometimes, ElasticSearchGraphServiceTest sees errors like theses:

```
ElasticSearchGraphServiceTest. wipe
java.net.SocketTimeoutException: 30,000 milliseconds timeout on connection http-outgoing-5 [ACTIVE]
	at org.elasticsearch.client.RestClient.extractAndWrapCause(RestClient.java:834)
	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:259)
	at org.elasticsearch.client.RestClient.performRequest(RestClient.java:246)
	at org.elasticsearch.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1613)
	at org.elasticsearch.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1583)
	at org.elasticsearch.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1553)
	at org.elasticsearch.client.IndicesClient.flush(IndicesClient.java:726)
```