### PR TITLE
fix(chartinfo): only map chartinfo inputs if exists

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartSnapshotMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/mappers/ChartSnapshotMapper.java
@@ -67,11 +67,14 @@ public class ChartSnapshotMapper implements ModelMapper<ChartSnapshot, Chart> {
         result.setDescription(info.getDescription());
         result.setName(info.getTitle());
         result.setLastRefreshed(info.getLastRefreshed());
-        result.setInputs(info.getInputs().stream().map(input -> {
-            final Dataset dataset = new Dataset();
-            dataset.setUrn(input.getDatasetUrn().toString());
-            return dataset;
-        }).collect(Collectors.toList()));
+
+        if (info.hasInputs()) {
+            result.setInputs(info.getInputs().stream().map(input -> {
+                final Dataset dataset = new Dataset();
+                dataset.setUrn(input.getDatasetUrn().toString());
+                return dataset;
+            }).collect(Collectors.toList()));
+        }
 
         if (info.hasAccess()) {
             result.setAccess(AccessLevel.valueOf(info.getAccess().toString()));


### PR DESCRIPTION
Inputs is optional, can cause NPE if accessed when null.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
