### PR TITLE
(fix) Set ebean transaction level to be repeatable read

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanAspectDao.java
@@ -24,6 +24,7 @@ import io.ebean.Query;
 import io.ebean.RawSql;
 import io.ebean.RawSqlBuilder;
 import io.ebean.Transaction;
+import io.ebean.annotation.TxIsolation;
 import io.ebean.config.ServerConfig;
 import java.net.URISyntaxException;
 import java.sql.Timestamp;
@@ -471,7 +472,7 @@ public class EbeanAspectDao {
 
     T result = null;
     do {
-      try (Transaction transaction = _server.beginTransaction()) {
+      try (Transaction transaction = _server.beginTransaction(TxIsolation.REPEATABLE_READ)) {
         result = block.get();
         transaction.commit();
         lastException = null;


### PR DESCRIPTION
The current implementation of aspect versioning relies on the transactions to be with the isolation level of repeatable read in order to avoid lost updates (as discussed in https://datahubproject.io/docs/advanced/aspect-versioning/#transaction-isolation-1 and illustrated in https://github.com/linkedin/datahub/issues/3231).

Although the default isolation level is repeatable read for MySQL, ebean sets the default transaction isolation to be read committed (https://github.com/ebean-orm/ebean-datasource/blob/master/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java#L38); this PR ensures that the transactions use the repeatable read isolation level.

Another option would be to set it as the default/make it configurable (e.g. in https://github.com/linkedin/datahub/blob/master/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/LocalEbeanServerConfigFactory.java) - regardless, @dexter-mh-lee should run some performance regression testing before merging in.
