### PR TITLE
fix(tox): allow tox to recreate testenv when new dependencies are added to setup.py

### DIFF
--- a/metadata-ingestion/tox.ini
+++ b/metadata-ingestion/tox.ini
@@ -11,8 +11,15 @@ python =
     3.6: py3-full, py3-airflow1
     3.9: py3-full, py3-airflow1
 
+# Providing optional features that add dependencies from setup.py as deps here 
+# allows tox to recreate testenv when new dependencies are added to setup.py.
+# Previous approach of using the tox global setting extras is not recommended  
+# as extras is only called when the testenv is created for the first time!
+# see more here -> https://github.com/tox-dev/tox/issues/1105#issuecomment-448596282
+
 [testenv]
-extras = dev
+deps = 
+    .[dev]
 commands =
     pytest --cov={envsitepackagesdir}/datahub --cov={envsitepackagesdir}/datahub_provider \
         py3-quick,py3-airflow1: -m 'not integration' \
@@ -23,7 +30,10 @@ setenv =
     AIRFLOW_HOME = /tmp/airflow/thisshouldnotexist-{envname}
 
 [testenv:py3-airflow1]
-extras = dev-airflow1
+deps = 
+    .[dev-airflow1]
 
 [testenv:py3-full]
-extras = dev,integration-tests
+deps =
+    .[dev]
+    .[integration-tests]


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
