### PR TITLE
fix(ingest): looker explores with joins, parsing failures on lateral …

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker_common.py
@@ -485,6 +485,13 @@ class LookerExplore:
             explore = client.lookml_model_explore(model, explore_name)
             views = set()
             if explore.joins is not None and explore.joins != []:
+                if explore.view_name is not None and explore.view_name != explore.name:
+                    # explore is renaming the view name, we will need to swap references to explore.name with explore.view_name
+                    aliased_explore = True
+                    views.add(explore.view_name)
+                else:
+                    aliased_explore = False
+
                 for e_join in [
                     e for e in explore.joins if e.dependent_fields is not None
                 ]:
@@ -492,6 +499,9 @@ class LookerExplore:
                     for field_name in e_join.dependent_fields:
                         try:
                             view_name = LookerUtil._extract_view_from_field(field_name)
+                            if (view_name == explore.name) and aliased_explore:
+                                assert explore.view_name is not None
+                                view_name = explore.view_name
                             views.add(view_name)
                         except AssertionError:
                             reporter.report_warning(

--- a/metadata-ingestion/src/datahub/utilities/sql_parser.py
+++ b/metadata-ingestion/src/datahub/utilities/sql_parser.py
@@ -18,6 +18,9 @@ class SQLParser(metaclass=ABCMeta):
 
 class DefaultSQLParser(SQLParser):
     def __init__(self, sql_query: str) -> None:
+        # MetadataSQLParser makes mistakes on lateral flatten queries, use the prefix
+        if "lateral flatten" in sql_query:
+            sql_query = sql_query[: sql_query.find("lateral flatten")]
         self._parser = MetadataSQLParser(sql_query)
 
     def get_tables(self) -> List[str]:


### PR DESCRIPTION
…flatten

Looker explores with joins can have from: clauses to restate the view they are joining from. Previous code was not handling this correctly. 

Also puts in a duct-tape fix for issues parsing sql with lateral flatten directives in them

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
