### PR TITLE
docs(entity): fix link in entity docs

### DIFF
--- a/docs/what/entity.md
+++ b/docs/what/entity.md
@@ -1,5 +1,5 @@
 # Entities
 
 
-This page has been moved. Please refer to [The Metadata Model](../modeling/extending-the-metadata-model) for details on
+This page has been moved. Please refer to [The Metadata Model](../modeling/extending-the-metadata-model.md) for details on
 the metadata model.


### PR DESCRIPTION
This link needed a `.md` suffix.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
