### PR TITLE
feat(oidc): Support NONE client auth method in OIDC (stopgap) 

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/OidcProvider.java
+++ b/datahub-frontend/app/auth/sso/oidc/OidcProvider.java
@@ -1,6 +1,7 @@
 package auth.sso.oidc;
 
 import auth.sso.SsoProvider;
+import auth.sso.oidc.custom.CustomOidcClient;
 import com.google.common.collect.ImmutableMap;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.http.callback.PathParameterCallbackUrlResolver;
@@ -58,8 +59,7 @@ public class OidcProvider implements SsoProvider<OidcConfigs> {
     _oidcConfigs.getCustomParamResource()
         .ifPresent(value -> oidcConfiguration.setCustomParams(ImmutableMap.of("resource", value)));
 
-    final org.pac4j.oidc.client.OidcClient<OidcProfile, OidcConfiguration> oidcClient =
-        new org.pac4j.oidc.client.OidcClient<>(oidcConfiguration);
+    final CustomOidcClient oidcClient = new CustomOidcClient(oidcConfiguration);
     oidcClient.setName(OIDC_CLIENT_NAME);
     oidcClient.setCallbackUrl(_oidcConfigs.getAuthBaseUrl() + _oidcConfigs.getAuthBaseCallbackPath());
     oidcClient.setCallbackUrlResolver(new PathParameterCallbackUrlResolver());

--- a/datahub-frontend/app/auth/sso/oidc/custom/CustomOidcAuthenticator.java
+++ b/datahub-frontend/app/auth/sso/oidc/custom/CustomOidcAuthenticator.java
@@ -1,0 +1,179 @@
+package auth.sso.oidc.custom;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretPost;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.authenticator.Authenticator;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.OidcCredentials;
+import org.pac4j.oidc.credentials.authenticator.OidcAuthenticator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class CustomOidcAuthenticator implements Authenticator<OidcCredentials> {
+
+  private static final Logger logger = LoggerFactory.getLogger(OidcAuthenticator.class);
+
+  private static final Collection<ClientAuthenticationMethod> SUPPORTED_METHODS =
+      Arrays.asList(
+          ClientAuthenticationMethod.CLIENT_SECRET_POST,
+          ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+          ClientAuthenticationMethod.NONE);
+
+  protected OidcConfiguration configuration;
+
+  protected OidcClient client;
+
+  private ClientAuthentication clientAuthentication;
+
+  public CustomOidcAuthenticator(final OidcConfiguration configuration, final OidcClient client) {
+    CommonHelper.assertNotNull("configuration", configuration);
+    CommonHelper.assertNotNull("client", client);
+    this.configuration = configuration;
+    this.client = client;
+
+    // check authentication methods
+    final List<ClientAuthenticationMethod> metadataMethods = configuration.findProviderMetadata().getTokenEndpointAuthMethods();
+
+    final ClientAuthenticationMethod preferredMethod = getPreferredAuthenticationMethod(configuration);
+
+    final ClientAuthenticationMethod chosenMethod;
+    if (CommonHelper.isNotEmpty(metadataMethods)) {
+      if (preferredMethod != null) {
+        if (metadataMethods.contains(preferredMethod)) {
+          chosenMethod = preferredMethod;
+        } else {
+          throw new TechnicalException(
+              "Preferred authentication method (" + preferredMethod + ") not supported " +
+                  "by provider according to provider metadata (" + metadataMethods + ").");
+        }
+      } else {
+        chosenMethod = firstSupportedMethod(metadataMethods);
+      }
+    } else {
+      chosenMethod = preferredMethod != null ? preferredMethod : ClientAuthenticationMethod.getDefault();
+      logger.info("Provider metadata does not provide Token endpoint authentication methods. Using: {}",
+          chosenMethod);
+    }
+
+    final ClientID _clientID = new ClientID(configuration.getClientId());
+    if (ClientAuthenticationMethod.NONE.equals(chosenMethod)) {
+      clientAuthentication = new EmptyAuthentication(_clientID);
+    } else if (ClientAuthenticationMethod.CLIENT_SECRET_POST.equals(chosenMethod)) {
+      final Secret _secret = new Secret(configuration.getSecret());
+      clientAuthentication = new ClientSecretPost(_clientID, _secret);
+    } else if (ClientAuthenticationMethod.CLIENT_SECRET_BASIC.equals(chosenMethod)) {
+      final Secret _secret = new Secret(configuration.getSecret());
+      clientAuthentication = new ClientSecretBasic(_clientID, _secret);
+    } else {
+      throw new TechnicalException("Unsupported client authentication method: " + chosenMethod);
+    }
+  }
+
+  /**
+   * The preferred {@link ClientAuthenticationMethod} specified in the given
+   * {@link OidcConfiguration}, or <code>null</code> meaning that the a
+   * provider-supported method should be chosen.
+   */
+  private static ClientAuthenticationMethod getPreferredAuthenticationMethod(OidcConfiguration config) {
+    final ClientAuthenticationMethod configurationMethod = config.getClientAuthenticationMethod();
+    if (configurationMethod == null) {
+      return null;
+    }
+
+    if (!SUPPORTED_METHODS.contains(configurationMethod)) {
+      throw new TechnicalException("Configured authentication method (" + configurationMethod + ") is not supported.");
+    }
+
+    return configurationMethod;
+  }
+
+  /**
+   * The first {@link ClientAuthenticationMethod} from the given list of
+   * methods that is supported by this implementation.
+   *
+   * @throws TechnicalException
+   *         if none of the provider-supported methods is supported.
+   */
+  private static ClientAuthenticationMethod firstSupportedMethod(final List<ClientAuthenticationMethod> metadataMethods) {
+    Optional<ClientAuthenticationMethod> firstSupported =
+        metadataMethods.stream().filter((m) -> SUPPORTED_METHODS.contains(m)).findFirst();
+    if (firstSupported.isPresent()) {
+      return firstSupported.get();
+    } else {
+      throw new TechnicalException("None of the Token endpoint provider metadata authentication methods are supported: " +
+          metadataMethods);
+    }
+  }
+
+  @Override
+  public void validate(final OidcCredentials credentials, final WebContext context) {
+    final AuthorizationCode code = credentials.getCode();
+    // if we have a code
+    if (code != null) {
+      try {
+        final String computedCallbackUrl = client.computeFinalCallbackUrl(context);
+        // Token request
+        final TokenRequest request = new TokenRequest(configuration.findProviderMetadata().getTokenEndpointURI(),
+            this.clientAuthentication, new AuthorizationCodeGrant(code, new URI(computedCallbackUrl)));
+        HTTPRequest tokenHttpRequest = request.toHTTPRequest();
+        tokenHttpRequest.setConnectTimeout(configuration.getConnectTimeout());
+        tokenHttpRequest.setReadTimeout(configuration.getReadTimeout());
+
+        final HTTPResponse httpResponse = tokenHttpRequest.send();
+        logger.debug("Token response: status={}, content={}", httpResponse.getStatusCode(),
+            httpResponse.getContent());
+
+        final TokenResponse response = OIDCTokenResponseParser.parse(httpResponse);
+        if (response instanceof TokenErrorResponse) {
+          throw new TechnicalException("Bad token response, error=" + ((TokenErrorResponse) response).getErrorObject());
+        }
+        logger.debug("Token response successful");
+        final OIDCTokenResponse tokenSuccessResponse = (OIDCTokenResponse) response;
+
+        // save tokens in credentials
+        final OIDCTokens oidcTokens = tokenSuccessResponse.getOIDCTokens();
+        credentials.setAccessToken(oidcTokens.getAccessToken());
+        credentials.setRefreshToken(oidcTokens.getRefreshToken());
+        credentials.setIdToken(oidcTokens.getIDToken());
+
+      } catch (final URISyntaxException | IOException | ParseException e) {
+        throw new TechnicalException(e);
+      }
+    }
+  }
+
+  public ClientAuthentication getClientAuthentication() {
+    return clientAuthentication;
+  }
+
+  public void setClientAuthentication(final ClientAuthentication clientAuthentication) {
+    this.clientAuthentication = clientAuthentication;
+  }
+}

--- a/datahub-frontend/app/auth/sso/oidc/custom/CustomOidcClient.java
+++ b/datahub-frontend/app/auth/sso/oidc/custom/CustomOidcClient.java
@@ -1,0 +1,30 @@
+package auth.sso.oidc.custom;
+
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.extractor.OidcExtractor;
+import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
+import org.pac4j.oidc.profile.OidcProfile;
+import org.pac4j.oidc.profile.creator.OidcProfileCreator;
+import org.pac4j.oidc.redirect.OidcRedirectActionBuilder;
+
+
+public class CustomOidcClient extends OidcClient<OidcProfile, OidcConfiguration> {
+
+  public CustomOidcClient(final OidcConfiguration configuration) {
+    setConfiguration(configuration);
+  }
+
+  @Override
+  protected void clientInit() {
+    CommonHelper.assertNotNull("configuration", getConfiguration());
+    getConfiguration().init();
+
+    defaultRedirectActionBuilder(new OidcRedirectActionBuilder(getConfiguration(), this));
+    defaultCredentialsExtractor(new OidcExtractor(getConfiguration(), this));
+    defaultAuthenticator(new CustomOidcAuthenticator(getConfiguration(), this));
+    defaultProfileCreator(new OidcProfileCreator<>(getConfiguration()));
+    defaultLogoutActionBuilder(new OidcLogoutActionBuilder<>(getConfiguration()));
+  }
+}

--- a/datahub-frontend/app/auth/sso/oidc/custom/EmptyAuthentication.java
+++ b/datahub-frontend/app/auth/sso/oidc/custom/EmptyAuthentication.java
@@ -1,0 +1,23 @@
+package auth.sso.oidc.custom;
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+
+
+public class EmptyAuthentication extends ClientAuthentication {
+  /**
+   * Creates a new "None" client authentication.
+   *
+   * @param clientID The client identifier. Must not be {@code null}.
+   */
+  protected EmptyAuthentication(ClientID clientID) {
+    super(ClientAuthenticationMethod.NONE, clientID);
+  }
+
+  @Override
+  public void applyTo(HTTPRequest httpRequest) {
+    return;
+  }
+}

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -30,11 +30,11 @@ ELASTIC_CLIENT_HOST=localhost
 ELASTIC_CLIENT_PORT=9200
 
 # OIDC Configs
-AUTH_OIDC_ENABLED=true
-AUTH_OIDC_CLIENT_ID=0oabfikkjHRi4ayUM5d6
-AUTH_OIDC_CLIENT_SECRET=fNIv0Cms_LUoe2XUfuh2c8MjsgZZ4HDJMe0wmsUc
-AUTH_OIDC_DISCOVERY_URI=https://dev-33231928.okta.com/.well-known/openid-configuration
-AUTH_OIDC_BASE_URL=http://localhost:9002
+# AUTH_OIDC_ENABLED=true
+# AUTH_OIDC_CLIENT_ID=<client-id>>
+# AUTH_OIDC_CLIENT_SECRET=<client-secret>
+# AUTH_OIDC_DISCOVERY_URI=<idp-domain>/.well-known/openid-configuration
+# AUTH_OIDC_BASE_URL=http://localhost:9002
 # User and groups provisioning
 # AUTH_OIDC_JIT_PROVISIONING_ENABLED=true
 # AUTH_OIDC_PRE_PROVISIONING_REQUIRED=false

--- a/datahub-frontend/run/frontend.env
+++ b/datahub-frontend/run/frontend.env
@@ -30,11 +30,11 @@ ELASTIC_CLIENT_HOST=localhost
 ELASTIC_CLIENT_PORT=9200
 
 # OIDC Configs
-# AUTH_OIDC_ENABLED=true
-# AUTH_OIDC_CLIENT_ID=<client-id>>
-# AUTH_OIDC_CLIENT_SECRET=<client-secret>
-# AUTH_OIDC_DISCOVERY_URI=<idp-domain>/.well-known/openid-configuration
-# AUTH_OIDC_BASE_URL=http://localhost:9002
+AUTH_OIDC_ENABLED=true
+AUTH_OIDC_CLIENT_ID=0oabfikkjHRi4ayUM5d6
+AUTH_OIDC_CLIENT_SECRET=fNIv0Cms_LUoe2XUfuh2c8MjsgZZ4HDJMe0wmsUc
+AUTH_OIDC_DISCOVERY_URI=https://dev-33231928.okta.com/.well-known/openid-configuration
+AUTH_OIDC_BASE_URL=http://localhost:9002
 # User and groups provisioning
 # AUTH_OIDC_JIT_PROVISIONING_ENABLED=true
 # AUTH_OIDC_PRE_PROVISIONING_REQUIRED=false


### PR DESCRIPTION
We've received a few asks from the community to supporting the "NONE" OIDC authentication method. This PR introduces that support by extending Pac4j's default OIDC Client + Authenticator classes. 

An alternative solution to this would have been upgrading Play & Pac4j, which proved very challenging due to the Play Gradle plugin we are leveraging. The long term solution will involve performing this upgrade, if possible. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
