### PR TITLE
feat(ui): Improve add owner search experience

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
@@ -1,10 +1,13 @@
-import { Button, Form, message, Modal, Select } from 'antd';
-import React, { useEffect } from 'react';
+import { Button, Form, message, Modal, Select, Tag, Typography } from 'antd';
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import { useAddOwnerMutation } from '../../../../../../../graphql/mutations.generated';
-import { EntityType, OwnerEntityType, OwnershipType } from '../../../../../../../types.generated';
-import { capitalizeFirstLetter } from '../../../../../../shared/capitalizeFirstLetter';
+import { useGetSearchResultsLazyQuery } from '../../../../../../../graphql/search.generated';
+import { CorpUser, EntityType, OwnerEntityType, SearchResult } from '../../../../../../../types.generated';
+import { useEntityRegistry } from '../../../../../../useEntityRegistry';
 import { useEntityData } from '../../../../EntityContext';
-import { LdapFormItem } from './LdapFormItem';
+import { CustomAvatar } from '../../../../../../shared/avatar';
 
 type Props = {
     visible: boolean;
@@ -12,29 +15,55 @@ type Props = {
     refetch?: () => Promise<any>;
 };
 
-export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
-    const [form] = Form.useForm();
-    const { urn } = useEntityData();
+const SearchResultContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px;
+`;
 
+const SearchResultContent = styled.div`
+    display: flex;
+    justify-content: start;
+    align-items: center;
+`;
+
+const SearchResultDisplayName = styled.div`
+    margin-left: 12px;
+`;
+
+type SelectedActor = {
+    displayName: string;
+    type: EntityType;
+    urn: string;
+};
+
+export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
+    const entityRegistry = useEntityRegistry();
+    const { urn } = useEntityData();
+    const [selectedActor, setSelectedActor] = useState<SelectedActor | undefined>(undefined);
+    const [userSearch, { data: userSearchData }] = useGetSearchResultsLazyQuery();
+    const [groupSearch, { data: groupSearchData }] = useGetSearchResultsLazyQuery();
     const [addOwnerMutation] = useAddOwnerMutation();
 
-    useEffect(() => {
-        form.setFieldsValue({
-            ldap: '',
-            role: OwnershipType.Stakeholder,
-            type: EntityType.CorpUser,
-        });
-    }, [form]);
+    // User and group dropdown search results!
+    const userSearchResults = userSearchData?.search?.searchResults || [];
+    const groupSearchResults = groupSearchData?.search?.searchResults || [];
+    const combinedSearchResults = [...userSearchResults, ...groupSearchResults];
+
+    const inputEl = useRef(null);
 
     const onOk = async () => {
-        const row = await form.validateFields();
+        if (!selectedActor) {
+            return;
+        }
         try {
             const ownerEntityType =
-                row.type === EntityType.CorpGroup ? OwnerEntityType.CorpGroup : OwnerEntityType.CorpUser;
+                selectedActor.type === EntityType.CorpGroup ? OwnerEntityType.CorpGroup : OwnerEntityType.CorpUser;
             await addOwnerMutation({
                 variables: {
                     input: {
-                        ownerUrn: `urn:li:${row.type === EntityType.CorpGroup ? 'corpGroup' : 'corpuser'}:${row.ldap}`,
+                        ownerUrn: selectedActor.urn,
                         resourceUrn: urn,
                         ownerEntityType,
                     },
@@ -51,6 +80,91 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
         onClose();
     };
 
+    // When a user search result is selected, set the urn as the selected urn.
+    const onSelectActor = (newUrn: string) => {
+        if (inputEl && inputEl.current) {
+            (inputEl.current as any).blur();
+        }
+        const filteredActors = combinedSearchResults
+            .filter((result) => result.entity.urn === newUrn)
+            .map((result) => result.entity);
+        if (filteredActors.length) {
+            const actor = filteredActors[0];
+            setSelectedActor({
+                displayName: entityRegistry.getDisplayName(actor.type, actor),
+                type: actor.type,
+                urn: actor.urn,
+            });
+        }
+    };
+
+    // When a user search result is selected, set the urn as the selected urn.
+    const onDeselectActor = (_: string) => {
+        setSelectedActor(undefined);
+    };
+
+    // Invokes the search API as the user types
+    const handleSearch = (type: EntityType, text: string, searchQuery: any) => {
+        console.log(text);
+        if (text.length > 2) {
+            searchQuery({
+                variables: {
+                    input: {
+                        type,
+                        query: text,
+                        start: 0,
+                        count: 5,
+                    },
+                },
+            });
+        }
+    };
+
+    // Invokes the user search API for both users and groups.
+    // TODO: replace with multi entity search.
+    const handleActorSearch = (text: string) => {
+        handleSearch(EntityType.CorpUser, text, userSearch);
+        handleSearch(EntityType.CorpGroup, text, groupSearch);
+    };
+
+    // Renders a search result in the select dropdown.
+    const renderSearchResult = (result: SearchResult) => {
+        const avatarUrl =
+            result.entity.type === EntityType.CorpUser
+                ? (result.entity as CorpUser).editableProperties?.pictureLink || undefined
+                : undefined;
+        const displayName = entityRegistry.getDisplayName(result.entity.type, result.entity);
+        return (
+            <SearchResultContainer>
+                <SearchResultContent>
+                    <CustomAvatar
+                        size={32}
+                        name={displayName}
+                        photoUrl={avatarUrl}
+                        isGroup={result.entity.type === EntityType.CorpGroup}
+                    />
+                    <SearchResultDisplayName>
+                        <div>
+                            <Typography.Text type="secondary">
+                                {entityRegistry.getEntityName(result.entity.type)}
+                            </Typography.Text>
+                        </div>
+                        <div>{displayName}</div>
+                    </SearchResultDisplayName>
+                </SearchResultContent>
+                <Link
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    to={() => `/${entityRegistry.getPathName(result.entity.type)}/${result.entity.urn}`}
+                >
+                    View
+                </Link>{' '}
+            </SearchResultContainer>
+        );
+    };
+
+    const selectValue = (selectedActor && [selectedActor.displayName]) || [];
+
     return (
         <Modal
             title="Add owner"
@@ -61,46 +175,26 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
                     <Button onClick={onClose} type="text">
                         Cancel
                     </Button>
-                    <Button onClick={onOk}>Add</Button>
+                    <Button disabled={selectedActor === undefined} onClick={onOk}>
+                        Add
+                    </Button>
                 </>
             }
         >
-            <Form form={form} component={false}>
-                <LdapFormItem form={form} />
-                <Form.Item
-                    name="type"
-                    rules={[
-                        {
-                            required: true,
-                            type: 'string',
-                            message: `Please select a type!`,
-                        },
-                    ]}
-                >
-                    <Select placeholder="Select a type" defaultValue={EntityType.CorpUser}>
-                        <Select.Option value={EntityType.CorpUser} key={EntityType.CorpUser}>
-                            User
-                        </Select.Option>
-                        <Select.Option value={EntityType.CorpGroup} key={EntityType.CorpGroup}>
-                            Group
-                        </Select.Option>
-                    </Select>
-                </Form.Item>
-                <Form.Item
-                    name="role"
-                    rules={[
-                        {
-                            required: true,
-                            type: 'string',
-                            message: `Please select a role!`,
-                        },
-                    ]}
-                >
-                    <Select placeholder="Select a role">
-                        {Object.values(OwnershipType).map((value) => (
-                            <Select.Option value={value} key={value}>
-                                {capitalizeFirstLetter(value)}
-                            </Select.Option>
+            <Form component={false}>
+                <Form.Item>
+                    <Select
+                        value={selectValue}
+                        mode="multiple"
+                        ref={inputEl}
+                        placeholder="Search for users or groups..."
+                        onSelect={(actorUrn: any) => onSelectActor(actorUrn)}
+                        onDeselect={(actorUrn: any) => onDeselectActor(actorUrn)}
+                        onSearch={handleActorSearch}
+                        tagRender={(tagProps) => <Tag>{tagProps.value}</Tag>}
+                    >
+                        {combinedSearchResults?.map((result) => (
+                            <Select.Option value={result.entity.urn}>{renderSearchResult(result)}</Select.Option>
                         ))}
                     </Select>
                 </Form.Item>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
@@ -76,6 +76,7 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
                 message.error({ content: `Failed to add owner: \n ${e.message || ''}`, duration: 3 });
             }
         }
+        setSelectedActor(undefined);
         refetch?.();
         onClose();
     };

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
@@ -106,7 +106,6 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
 
     // Invokes the search API as the user types
     const handleSearch = (type: EntityType, text: string, searchQuery: any) => {
-        console.log(text);
         if (text.length > 2) {
             searchQuery({
                 variables: {

--- a/datahub-web-react/src/app/policy/PolicyActorForm.tsx
+++ b/datahub-web-react/src/app/policy/PolicyActorForm.tsx
@@ -129,14 +129,12 @@ export default function PolicyActorForm({ policyType, actors, setActors }: Props
     };
 
     // Invokes the user search API as the user types
-    const handleUserSearch = (event: any) => {
-        const text = event.target.value as string;
+    const handleUserSearch = (text: string) => {
         return handleSearch(EntityType.CorpUser, text, userSearch);
     };
 
     // Invokes the group search API as the user types
-    const handleGroupSearch = (event: any) => {
-        const text = event.target.value as string;
+    const handleGroupSearch = (text: string) => {
         return handleSearch(EntityType.CorpGroup, text, groupSearch);
     };
 
@@ -194,7 +192,7 @@ export default function PolicyActorForm({ policyType, actors, setActors }: Props
                     placeholder="Search for users..."
                     onSelect={(asset: any) => onSelectUserActor(asset)}
                     onDeselect={(asset: any) => onDeselectUserActor(asset)}
-                    onInputKeyDown={handleUserSearch}
+                    onSearch={handleUserSearch}
                     tagRender={(tagProps) => (
                         <Tag closable={tagProps.closable} onClose={tagProps.onClose}>
                             {tagProps.value}
@@ -218,7 +216,7 @@ export default function PolicyActorForm({ policyType, actors, setActors }: Props
                     placeholder="Search for groups..."
                     onSelect={(asset: any) => onSelectGroupActor(asset)}
                     onDeselect={(asset: any) => onDeselectGroupActor(asset)}
-                    onInputKeyDown={handleGroupSearch}
+                    onSearch={handleGroupSearch}
                     tagRender={(tagProps) => (
                         <Tag closable={tagProps.closable} onClose={tagProps.onClose}>
                             {tagProps.value}

--- a/datahub-web-react/src/app/policy/PolicyPrivilegeForm.tsx
+++ b/datahub-web-react/src/app/policy/PolicyPrivilegeForm.tsx
@@ -138,10 +138,9 @@ export default function PolicyPrivilegeForm({
     };
 
     // Handle resource search, if the resource type has an associated EntityType mapping.
-    const handleSearch = (event: any) => {
+    const handleSearch = (text: string) => {
         const maybeEntityType = mapResourceTypeToEntityType(resources.type, resourcePrivileges);
         if (maybeEntityType) {
-            const text = event.target.value as string;
             if (text.length > 2) {
                 search({
                     variables: {
@@ -205,7 +204,7 @@ export default function PolicyPrivilegeForm({
                         placeholder={`Search for ${selectedResourceDisplayName}...`}
                         onSelect={(asset: any) => onSelectResource(asset)}
                         onDeselect={(asset: any) => onDeselectResource(asset)}
-                        onInputKeyDown={handleSearch}
+                        onSearch={handleSearch}
                         tagRender={(tagProps) => (
                             <Tag closable={tagProps.closable} onClose={tagProps.onClose}>
                                 {tagProps.value}


### PR DESCRIPTION
Previously, adding an owner required a selection of "user" or "group" type along with using a strange ldap field to find them. I've gone ahead and simplified the flow, replacing it with a simple search bar that finds users and groups for you as you type. 

Before:
<img width="1436" alt="Screen Shot 2021-09-28 at 7 58 57 PM" src="https://user-images.githubusercontent.com/17549204/135195623-6e084b87-861a-45c1-adf6-445e492ef16a.png">


After:
<img width="723" alt="Screen Shot 2021-09-28 at 7 57 45 PM" src="https://user-images.githubusercontent.com/17549204/135195588-49ea9e59-dea7-465d-8378-b659a6d68888.png">




## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
