### PR TITLE
fix(oidc): Attach Client ID to token request when Authentication Mode= NONE

### DIFF
--- a/datahub-frontend/app/auth/sso/oidc/custom/EmptyAuthentication.java
+++ b/datahub-frontend/app/auth/sso/oidc/custom/EmptyAuthentication.java
@@ -4,6 +4,10 @@ import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 
 public class EmptyAuthentication extends ClientAuthentication {
@@ -18,6 +22,9 @@ public class EmptyAuthentication extends ClientAuthentication {
 
   @Override
   public void applyTo(HTTPRequest httpRequest) {
-    return;
+    Map<String, List<String>> params = httpRequest.getQueryParameters();
+    params.put("client_id", Collections.singletonList(getClientID().getValue()));
+    String queryString = URLUtils.serializeParameters(params);
+    httpRequest.setQuery(queryString);
   }
 }


### PR DESCRIPTION
Title says it. Even in none mode, we'll try to attach a client id. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
