### PR TITLE
feat(transform): adds replace_existing config to set_dataset_browse_path

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_browse_path.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_browse_path.py
@@ -13,6 +13,7 @@ from datahub.metadata.schema_classes import (
 
 class AddDatasetBrowsePathConfig(ConfigModel):
     path_templates: List[str]
+    full_overwrite: bool = False
 
 
 class AddDatasetBrowsePathTransformer(DatasetTransformer):
@@ -49,6 +50,10 @@ class AddDatasetBrowsePathTransformer(DatasetTransformer):
                 paths=[],
             ),
         )
+
+        if self.config.full_overwrite:
+            browse_paths.paths = []
+
         for template in self.config.path_templates:
             browse_path = (
                 template.replace("PLATFORM", platform)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_browse_path.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_browse_path.py
@@ -13,7 +13,7 @@ from datahub.metadata.schema_classes import (
 
 class AddDatasetBrowsePathConfig(ConfigModel):
     path_templates: List[str]
-    full_overwrite: bool = False
+    replace_existing: bool = False
 
 
 class AddDatasetBrowsePathTransformer(DatasetTransformer):
@@ -51,7 +51,7 @@ class AddDatasetBrowsePathTransformer(DatasetTransformer):
             ),
         )
 
-        if self.config.full_overwrite:
+        if self.config.replace_existing:
             browse_paths.paths = []
 
         for template in self.config.path_templates:

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -238,6 +238,24 @@ def test_add_dataset_browse_paths():
         "/prod/bigquery/bar/example1/",
     ]
 
+    transformer = AddDatasetBrowsePathTransformer.create(
+        {
+            "path_templates": [
+                "/xyz",
+            ],
+            "full_overwrite": True,
+        },
+        PipelineContext(run_id="test"),
+    )
+    transformed = list(transformer.transform([RecordEnvelope(dataset, metadata={})]))
+    browse_path_aspect = builder.get_aspect_if_available(
+        transformed[0].record, models.BrowsePathsClass
+    )
+    assert browse_path_aspect
+    assert browse_path_aspect.paths == [
+        "/xyz",
+    ]
+
 
 def test_simple_dataset_tags_transformation(mock_time):
     dataset_mce = make_generic_dataset()

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -243,7 +243,7 @@ def test_add_dataset_browse_paths():
             "path_templates": [
                 "/xyz",
             ],
-            "full_overwrite": True,
+            "replace_existing": True,
         },
         PipelineContext(run_id="test"),
     )

--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -140,17 +140,17 @@ transformers:
 ```
 This will add 2 browse paths like `/mysql/marketing_db/sales/orders` and `/data_warehouse/sales/orders` for a table `sales.orders` in `mysql` database instance.
 
-Default behaviour of the transform is to add new browse paths, you can optionally set `full_overwrite: True` so 
+Default behaviour of the transform is to add new browse paths, you can optionally set `replace_existing: True` so 
 the transform becomes a _set_ operation instead of an _append_.
 ```yaml
 transformers:
   - type: "set_dataset_browse_path"
     config:
-      full_overwrite: True
+      replace_existing: True
       path_templates:
         - /ENV/PLATFORM/DATASET_PARTS/
 ```
-In thi case, the resulting dataset will have only 1 browse path, the one from the transform.
+In this case, the resulting dataset will have only 1 browse path, the one from the transform.
 
 Note that whatever browse paths you send via this will overwrite the browse paths present in the UI.
 ## Writing a custom transformer from scratch

--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -140,6 +140,18 @@ transformers:
 ```
 This will add 2 browse paths like `/mysql/marketing_db/sales/orders` and `/data_warehouse/sales/orders` for a table `sales.orders` in `mysql` database instance.
 
+Default behaviour of the transform is to add new browse paths, you can optionally set `full_overwrite: True` so 
+the transform becomes a _set_ operation instead of an _append_.
+```yaml
+transformers:
+  - type: "set_dataset_browse_path"
+    config:
+      full_overwrite: True
+      path_templates:
+        - /ENV/PLATFORM/DATASET_PARTS/
+```
+In thi case, the resulting dataset will have only 1 browse path, the one from the transform.
+
 Note that whatever browse paths you send via this will overwrite the browse paths present in the UI.
 ## Writing a custom transformer from scratch
 


### PR DESCRIPTION
## Description
This is adding `replace_existing` config option to `set_dataset_browse_path` transform enabling two different behaviours for the transform: adding browse paths (default) or set browse paths (so overwriting existing browse paths if any).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
