### PR TITLE
docs(datahub-frontend): add build instructions for the datahub-frontend docker image

### DIFF
--- a/docker/datahub-frontend/README.md
+++ b/docker/datahub-frontend/README.md
@@ -20,3 +20,11 @@ http://localhost:9001
 ```
 
 You can sign in with `datahub` as username and password.
+
+## Build instructions
+
+If you want to build the `datahub-frontend` Docker image yourself, you can run this command from the root directory of the DataHub repository you have locally:
+
+`docker build -t your_datahub_frontend -f ./docker/datahub-frontend/Dockerfile .`
+
+Please note the final `.` and that the tag `your_datahub_frontend` is determined by you.


### PR DESCRIPTION
## Description

An issue came up in the community Slack with someone trying to build the `datahub-frontend` docker image to test changes they had made.

Current docs point you to the datahub-frontend folder where the Dockerfile exists, but did not include any instructions for building. I added a few simple instructions after discussing in Slack and testing locally.

Small addition, but hope it helps.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
