### PR TITLE
feat(redshift): added ability to extract external schema from Redshift spectrum

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/mce_builder.py
+++ b/metadata-ingestion/src/datahub/emitter/mce_builder.py
@@ -1,11 +1,13 @@
 """Convenience functions for creating MCEs"""
 import logging
+import re
 import time
 from typing import List, Optional, Type, TypeVar, cast, get_type_hints
 
 import typing_inspect
 from avrogen.dict_wrapper import DictWrapper
 
+from datahub.metadata.com.linkedin.pegasus2avro.metadata.key import DatasetKey
 from datahub.metadata.schema_classes import (
     DatasetLineageTypeClass,
     DatasetSnapshotClass,
@@ -42,6 +44,16 @@ def make_data_platform_urn(platform: str) -> str:
 
 def make_dataset_urn(platform: str, name: str, env: str = DEFAULT_ENV) -> str:
     return f"urn:li:dataset:({make_data_platform_urn(platform)},{name},{env})"
+
+
+def dataset_urn_to_key(dataset_urn: str) -> Optional[DatasetKey]:
+    pattern = r"urn:li:dataset:\(urn:li:dataPlatform:(.*),(.*),(.*)\)"
+    results = re.search(pattern, dataset_urn)
+    if results is not None:
+        return DatasetKey(
+            platform=results.group(1), name=results.group(2), origin=results.group(3)
+        )
+    return None
 
 
 def make_user_urn(username: str) -> str:

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -1,17 +1,34 @@
-from typing import Dict
+from collections import defaultdict
+from typing import Dict, Iterable, Optional, Union
 
 # These imports verify that the dependencies are available.
 import psycopg2  # noqa: F401
 import sqlalchemy_redshift  # noqa: F401
-from sqlalchemy.engine import reflection
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.engine import Connection, reflection
+from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy_redshift.dialect import RedshiftDialect, RelationKey
 
+from datahub.emitter import mce_builder
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.postgres import PostgresConfig
-from datahub.ingestion.source.sql.sql_common import SQLAlchemySource
+from datahub.ingestion.source.sql.sql_common import (
+    SQLAlchemySource,
+    SqlWorkUnit,
+    logger,
+)
 
 # TRICKY: it's necessary to import the Postgres source because
 # that module has some side effects that we care about here.
+from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
+from datahub.metadata.schema_classes import (
+    ChangeTypeClass,
+    DatasetLineageTypeClass,
+    UpstreamClass,
+    UpstreamLineageClass,
+)
 
 
 class RedshiftConfig(PostgresConfig):
@@ -61,13 +78,127 @@ def get_table_comment(self, connection, table_name, schema=None, **kw):
     return {"text": all_table_comments.get(key)}
 
 
+# gets all the relations for internal schemas and external schemas
+# by UNION of internal schemas (excluding namespaces starting with pg_)
+# and external schemas
+@reflection.cache  # type: ignore
+def _get_all_relation_info(self, connection, **kw):
+    result = connection.execute(
+        """
+        SELECT c.relkind,
+            n.oid AS "schema_oid",
+            n.nspname AS "schema",
+            c.oid AS "rel_oid",
+            c.relname,
+            CASE c.reldiststyle
+                WHEN 0 THEN 'EVEN'
+                WHEN 1 THEN 'KEY'
+                WHEN 8 THEN 'ALL'
+            END AS "diststyle",
+            c.relowner AS "owner_id",
+            u.usename AS "owner_name",
+            TRIM(TRAILING ';' FROM pg_catalog.pg_get_viewdef (c.oid,TRUE)) AS "view_definition",
+            pg_catalog.array_to_string(c.relacl,'\n') AS "privileges"
+        FROM pg_catalog.pg_class c
+        LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_catalog.pg_user u ON u.usesysid = c.relowner
+        WHERE c.relkind IN ('r','v','m','S','f')
+        AND   n.nspname !~ '^pg_'
+        AND   n.nspname != 'information_schema'
+        UNION
+        SELECT 'r' AS "relkind",
+            NULL AS "schema_oid",
+            schemaname AS "schema",
+            NULL AS "rel_oid",
+            tablename AS "relname",
+            NULL AS "diststyle",
+            NULL AS "owner_id",
+            NULL AS "owner_name",
+            NULL AS "view_definition",
+            NULL AS "privileges"
+        FROM pg_catalog.svv_external_tables
+        ORDER BY "schema",
+                "relname";"""
+    )
+    relations = {}
+    for rel in result:
+        key = RelationKey(rel.relname, rel.schema, connection)
+        relations[key] = rel
+    return relations
+
+
+# workaround to get external tables
+# Ideally, we would monkey patch by UNION of SVV_EXTERNAL_COLUMNS
+# to the existing query in dialect.py _get_schema_column_info().
+# However, the SVV_EXTERNAL_COLUMNS external_type column is
+# different than the System Catalog tables (tables with a PG prefix).
+# So, we're querying from SVV_COLUMNS (a join of System Catalog tables and SVV_EXTERNAL_COLUMNS)
+# while skipping the System Catalog tables to get a similar result.
+# Reference: https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_EXTERNAL_COLUMNS.html
+# https://docs.amazonaws.cn/en_us/redshift/latest/dg/r_SVV_COLUMNS.html
+@reflection.cache  # type: ignore
+def _get_schema_column_info(self, connection, schema=None, **kw):
+    schema_clause = "AND schema = '{schema}'".format(schema=schema) if schema else ""
+    all_columns = defaultdict(list)
+    with connection.connect() as cc:
+        result = cc.execute(
+            """
+            SELECT s.table_schema AS "schema",
+                s.table_name AS "table_name",
+                s.column_name AS "name",
+                NULL AS "encode",
+                s.data_type AS "type",
+                NULL AS "distkey",
+                NULL AS "sortkey",
+                NULL AS "notnull",
+                NULL AS "comment",
+                NULL AS "adsrc",
+                NULL AS "attnum",
+                s.data_type AS "format_type",
+                NULL AS "default",
+                NULL AS "schema_oid",
+                NULL AS "table_oid"
+            FROM SVV_COLUMNS s
+            WHERE s.table_schema !~ '^pg_'
+            {schema_clause}
+        """.format(
+                schema_clause=schema_clause
+            )
+        )
+        for col in result:
+            key = RelationKey(col.table_name, col.schema, connection)
+            all_columns[key].append(col)
+    return dict(all_columns)
+
+
+def _get_external_db_mapping(connection):
+    # SQL query to get mapping of external schemas in redshift to its external database.
+    try:
+        result = connection.execute(
+            """
+            select * from svv_external_schemas
+            """
+        )
+        return result
+    except Exception as e:
+        logger.error(
+            "Error querying svv_external_schemas to get external database mapping.", e
+        )
+        return None
+
+
 # This monkey-patching enables us to batch fetch the table descriptions, rather than
 # fetching them one at a time.
 RedshiftDialect._get_all_table_comments = _get_all_table_comments
 RedshiftDialect.get_table_comment = get_table_comment
+RedshiftDialect._get_all_relation_info = _get_all_relation_info
+RedshiftDialect._get_schema_column_info = _get_schema_column_info
 
 
 class RedshiftSource(SQLAlchemySource):
+    catalog_metadata: Dict = {}
+    eskind_to_platform = {1: "glue", 2: "hive", 3: "postgres", 4: "redshift"}
+
     def __init__(self, config: RedshiftConfig, ctx: PipelineContext):
         super().__init__(config, ctx, "redshift")
 
@@ -75,3 +206,94 @@ class RedshiftSource(SQLAlchemySource):
     def create(cls, config_dict, ctx):
         config = RedshiftConfig.parse_obj(config_dict)
         return cls(config, ctx)
+
+    def get_catalog_metadata(self, conn: Connection) -> None:
+        catalog_metadata = _get_external_db_mapping(conn)
+        if catalog_metadata is None:
+            return
+        db_name = getattr(self.config, "database")
+        db_alias = getattr(self.config, "database_alias")
+        if db_alias:
+            db_name = db_alias
+
+        external_schema_mapping = {}
+        for rel in catalog_metadata:
+            if rel.eskind != 1:
+                logger.debug(
+                    f"Skipping {rel.schemaname} for mapping to external database as currently we only "
+                    f"support glue"
+                )
+                continue
+            external_schema_mapping[rel.schemaname] = {
+                "eskind": rel.eskind,
+                "external_database": rel.databasename,
+                "esoptions": rel.esoptions,
+                "esoid": rel.esoid,
+                "esowner": rel.esowner,
+            }
+        self.catalog_metadata[db_name] = external_schema_mapping
+
+    def get_inspectors(self) -> Iterable[Inspector]:
+        # This method can be overridden in the case that you want to dynamically
+        # run on multiple databases.
+        url = self.config.get_sql_alchemy_url()
+        logger.debug(f"sql_alchemy_url={url}")
+        engine = create_engine(url, **self.config.options)
+        with engine.connect() as conn:
+            self.get_catalog_metadata(conn)
+            inspector = inspect(conn)
+            yield inspector
+
+    def get_workunits(self) -> Iterable[Union[MetadataWorkUnit, SqlWorkUnit]]:
+        for wu in super().get_workunits():
+            yield wu
+            if isinstance(wu, SqlWorkUnit) and isinstance(
+                wu.metadata, MetadataChangeEvent
+            ):
+                lineage_mcp = self.get_lineage_mcp(wu.metadata.proposedSnapshot.urn)
+                if lineage_mcp is not None:
+                    lineage_wu = MetadataWorkUnit(
+                        id=f"redshift-{lineage_mcp.entityUrn}-{lineage_mcp.aspectName}",
+                        mcp=lineage_mcp,
+                    )
+                    self.report.report_workunit(lineage_wu)
+                    yield lineage_wu
+
+    def get_lineage_mcp(
+        self, dataset_urn: str
+    ) -> Optional[MetadataChangeProposalWrapper]:
+        dataset_key = mce_builder.dataset_urn_to_key(dataset_urn)
+        if dataset_key is None:
+            return None
+
+        dataset_params = dataset_key.name.split(".")
+        db_name = dataset_params[0]
+        schemaname = dataset_params[1]
+        tablename = dataset_params[2]
+        if db_name in self.catalog_metadata:
+            if schemaname in self.catalog_metadata[db_name]:
+                external_db_params = self.catalog_metadata[db_name][schemaname]
+                upstream_lineage = UpstreamLineageClass(
+                    upstreams=[
+                        UpstreamClass(
+                            mce_builder.make_dataset_urn(
+                                self.eskind_to_platform[external_db_params["eskind"]],
+                                "{database}.{table}".format(
+                                    database=external_db_params["external_database"],
+                                    table=tablename,
+                                ),
+                                self.config.env,
+                            ),
+                            DatasetLineageTypeClass.COPY,
+                        )
+                    ]
+                )
+                mcp = MetadataChangeProposalWrapper(
+                    entityType="dataset",
+                    changeType=ChangeTypeClass.UPSERT,
+                    entityUrn=dataset_urn,
+                    aspectName="upstreamLineage",
+                    aspect=upstream_lineage,
+                )
+                return mcp
+        return None


### PR DESCRIPTION
This PR proposes to ingest redshift external tables and links the external tables to the corresponding external database and its table as upstream lineage. Currently, only supporting glue external database.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
