### PR TITLE
fix(ingest): Fix sasl exception for hive ingestion

### DIFF
--- a/docker/datahub-ingestion/Dockerfile
+++ b/docker/datahub-ingestion/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
         python3-ldap \
         libldap2-dev \
         libsasl2-dev \
+        libsasl2-modules \
         ldap-utils \
     && python -m pip install --upgrade pip wheel setuptools==57.5.0
 


### PR DESCRIPTION
Hive ingestion receives the following exception.

```
thrift.transport.TTransport.TTransportException: Could not start SASL: b’Error in sasl_client_start (-4) SASL(-4): no mechanism available: No worthy mechs found’
```
In order to fix that, we added `libsasl2-modules` in datahub ingestion docker image.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

