### PR TITLE
fix(docs): fix graphql deprecated comment

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -549,7 +549,7 @@ type Dataset implements EntityWithRelationships & Entity {
     platformNativeType: PlatformNativeType @deprecated
 
     """
-    Deprecated, use externalUrl instead
+    Deprecated, use properties instead
     Native Dataset Uri
     Uri should not include any environment specific properties
     """


### PR DESCRIPTION
External url has moved twice now- updated first deprecation notice

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
