### PR TITLE
fix(ingestion): make dbt tag prefix configurable

### DIFF
--- a/metadata-ingestion/source_docs/dbt.md
+++ b/metadata-ingestion/source_docs/dbt.md
@@ -26,6 +26,8 @@ This plugin pulls metadata from dbt's artifact files:
   - Load schemas from dbt catalog file, not necessary when the underlying data platform already has this data.
 - use_identifiers:
   - Use model [identifier](https://docs.getdbt.com/reference/resource-properties/identifier) instead of model name if defined (if not, default to model name).
+- tag_prefix:
+  - Prefix added to tags during ingestion.
 - node_type_pattern:
   - Use this filter to exclude and include node types using allow or deny method
 
@@ -65,6 +67,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `target_platform`         | ✅       |          | The platform that dbt is loading onto.                                                                                                                |
 | `load_schemas`            | ✅       |          | Whether to load database schemas. If set to `False`, table schema details (e.g. columns) will not be ingested.                                        |
 | `use_identifiers`         |         | `False`   | Whether to use model identifiers instead of names, if defined (if not, default to names)                                                             |
+| `tag_prefix`              |         | `dbt:`    | Prefix added to tags during ingestion. |
 | `node_type_pattern.allow` |          |          | List of regex patterns for dbt nodes to include in ingestion.                                                                                                  |
 | `node_type_pattern.deny`  |          |          | List of regex patterns for dbt nodes to exclude from ingestion.                                                                                                |
 | `node_type_pattern.ignoreCase`  |          | `True` | Whether to ignore case sensitivity during pattern matching.                                                                                                                                  |


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)

This PR allows the dbt tag prefix that was introduced in https://github.com/linkedin/datahub/pull/3270 to be configurable instead of hard-coded.

Tested locally with DataHub v0.8.15.
