### PR TITLE
add tooltip for owner category in dataset profile page

### DIFF
--- a/datahub-web-react/src/app/entity/shared/components/styled/ExpandedOwner.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/ExpandedOwner.tsx
@@ -1,4 +1,4 @@
-import { message, Modal, Tag } from 'antd';
+import { message, Modal, Tag, Tooltip } from 'antd';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -75,7 +75,9 @@ export const ExpandedOwner = ({ entityUrn, owner, refetch }: Props) => {
         <OwnerTag onClose={onClose} closable>
             <Link to={`/${entityRegistry.getPathName(owner.owner.type)}/${owner.owner.urn}`}>
                 <CustomAvatar name={name} photoUrl={pictureLink} useDefaultAvatar={false} />
-                {name}
+                <Tooltip placement="top" title={owner.type}>
+                    {name}
+                </Tooltip>
             </Link>
         </OwnerTag>
     );


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
