### PR TITLE
fix(browse paths): Adjust Default browse path logic for datasets

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathUtils.java
@@ -38,7 +38,7 @@ public class BrowsePathUtils {
     switch (urn.getEntityType()) {
       case "dataset":
         DatasetKey dsKey = (DatasetKey) EntityKeyUtils.convertUrnToEntityKey(urn, getKeySchema(urn.getEntityType(), entityRegistry));
-        DataPlatformKey dpKey = (DataPlatformKey) EntityKeyUtils.convertUrnToEntityKey(dsKey.getPlatform(), getKeySchema(dsKey.getPlatform().getEntityType(), entityRegistry);
+        DataPlatformKey dpKey = (DataPlatformKey) EntityKeyUtils.convertUrnToEntityKey(dsKey.getPlatform(), getKeySchema(dsKey.getPlatform().getEntityType(), entityRegistry));
         return ("/" + dsKey.getOrigin() + "/" + dpKey.getPlatformName() + "/"
             + dsKey.getName()).replace('.', '/').toLowerCase();
       case "chart":

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathUtils.java
@@ -38,7 +38,10 @@ public class BrowsePathUtils {
     switch (urn.getEntityType()) {
       case "dataset":
         DatasetKey dsKey = (DatasetKey) EntityKeyUtils.convertUrnToEntityKey(urn, getKeySchema(urn.getEntityType(), entityRegistry));
-        DataPlatformKey dpKey = (DataPlatformKey) EntityKeyUtils.convertUrnToEntityKey(dsKey.getPlatform(), getKeySchema(dsKey.getPlatform().getEntityType(), entityRegistry));
+        DataPlatformKey dpKey = (DataPlatformKey) EntityKeyUtils.convertUrnToEntityKey(
+            dsKey.getPlatform(),
+            getKeySchema(dsKey.getPlatform().getEntityType(),
+                entityRegistry));
         return ("/" + dsKey.getOrigin() + "/" + dpKey.getPlatformName() + "/"
             + dsKey.getName()).replace('.', '/').toLowerCase();
       case "chart":

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/BrowsePathUtils.java
@@ -8,6 +8,7 @@ import com.linkedin.metadata.key.ChartKey;
 import com.linkedin.metadata.key.DashboardKey;
 import com.linkedin.metadata.key.DataFlowKey;
 import com.linkedin.metadata.key.DataJobKey;
+import com.linkedin.metadata.key.DataPlatformKey;
 import com.linkedin.metadata.key.DatasetKey;
 import com.linkedin.metadata.key.GlossaryTermKey;
 import com.linkedin.metadata.models.AspectSpec;
@@ -37,7 +38,8 @@ public class BrowsePathUtils {
     switch (urn.getEntityType()) {
       case "dataset":
         DatasetKey dsKey = (DatasetKey) EntityKeyUtils.convertUrnToEntityKey(urn, getKeySchema(urn.getEntityType(), entityRegistry));
-        return ("/" + dsKey.getOrigin() + "/" + dsKey.getPlatform() + "/"
+        DataPlatformKey dpKey = (DataPlatformKey) EntityKeyUtils.convertUrnToEntityKey(dsKey.getPlatform(), getKeySchema(dsKey.getPlatform().getEntityType(), entityRegistry);
+        return ("/" + dsKey.getOrigin() + "/" + dpKey.getPlatformName() + "/"
             + dsKey.getName()).replace('.', '/').toLowerCase();
       case "chart":
         ChartKey chartKey = (ChartKey) EntityKeyUtils.convertUrnToEntityKey(urn, getKeySchema(urn.getEntityType(), entityRegistry));


### PR DESCRIPTION
During a recent code cleanup, we moved the logic of computing browse paths to BrowsePathUtils, which uses entity keys to compute default browse path. We were mistakenly taking the DataPlatform URN associated with a Dataset instead of its platform name (the legacy behavior). 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
