### PR TITLE
ui: Migrate UI to use "properties" field of entity for descriptions

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetSnapshotMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetSnapshotMapper.java
@@ -68,6 +68,7 @@ public class DatasetSnapshotMapper implements ModelMapper<DatasetSnapshot, Datas
                 if (gmsProperties.hasCustomProperties()) {
                     properties.setCustomProperties(StringMapMapper.map(gmsProperties.getCustomProperties()));
                 }
+                properties.setName(dataset.getUrn().getDatasetNameEntity()); // TODO: Move to using a display name produced by ingestion soures
                 result.setProperties(properties);
                 result.setDescription(properties.getDescription());
                 if (gmsProperties.hasUri()) {

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -617,6 +617,12 @@ type Dataset implements EntityWithRelationships & Entity {
 Additional read only properties about a Dataset
 """
 type DatasetProperties {
+
+    """
+    The name of the dataset used in display
+    """
+    name: String
+
     """
     Environment in which the dataset belongs to or where it was generated
     Note that this field will soon be deprecated in favor of a more standardized concept of Environment

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -111,18 +111,20 @@ const dataset1 = {
     name: 'The Great Test Dataset',
     origin: 'PROD',
     tags: ['Private', 'PII'],
-    description: 'This is the greatest dataset in the world, youre gonna love it!',
     uri: 'www.google.com',
-    properties: [
-        {
-            key: 'TestProperty',
-            value: 'My property value.',
-        },
-        {
-            key: 'AnotherTestProperty',
-            value: 'My other property value.',
-        },
-    ],
+    properties: {
+        description: 'This is the greatest dataset in the world, youre gonna love it!',
+        customProperties: [
+            {
+                key: 'TestProperty',
+                value: 'My property value.',
+            },
+            {
+                key: 'AnotherTestProperty',
+                value: 'My other property value.',
+            },
+        ],
+    },
     editableProperties: null,
     created: {
         time: 0,
@@ -194,9 +196,11 @@ const dataset2 = {
     name: 'Some Other Dataset',
     origin: 'PROD',
     tags: ['Outdated'],
-    description: 'This is some other dataset, so who cares!',
     uri: 'www.google.com',
-    properties: [],
+    properties: {
+        description: 'This is some other dataset, so who cares!',
+        customProperties: [],
+    },
     editableProperties: null,
     created: {
         time: 0,
@@ -262,9 +266,9 @@ export const dataset3 = {
     platformNativeType: 'STREAM',
     name: 'Yet Another Dataset',
     origin: 'PROD',
-    description: 'This and here we have yet another Dataset (YAN). Are there more?',
     uri: 'www.google.com',
     properties: {
+        description: 'This and here we have yet another Dataset (YAN). Are there more?',
         origin: 'PROD',
         customProperties: [{ key: 'propertyAKey', value: 'propertyAValue' }],
         externalUrl: 'https://data.hub',
@@ -869,8 +873,7 @@ export const dataJob1 = {
             time: 0,
         },
     },
-    info: {
-        __typename: 'DataJobInfo',
+    properties: {
         name: 'DataJobInfoName',
         description: 'DataJobInfo1 Description',
         externalUrl: null,
@@ -937,8 +940,7 @@ export const dataJob2 = {
             time: 0,
         },
     },
-    info: {
-        __typename: 'DataJobInfo',
+    properties: {
         name: 'DataJobInfoName2',
         description: 'DataJobInfo2 Description',
         externalUrl: null,
@@ -991,8 +993,7 @@ export const dataJob3 = {
             time: 0,
         },
     },
-    info: {
-        __typename: 'DataJobInfo',
+    properties: {
         name: 'DataJobInfoName3',
         description: 'DataJobInfo3 Description',
         externalUrl: null,

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -805,8 +805,7 @@ export const dataFlow1 = {
     orchestrator: 'Airflow',
     flowId: 'flowId1',
     cluster: 'cluster1',
-    info: {
-        __typename: 'DataFlowInfo',
+    properties: {
         name: 'DataFlowInfoName',
         description: 'DataFlowInfo1 Description',
         project: 'DataFlowInfo1 project',

--- a/datahub-web-react/src/app/browse/BrowseResultsPage.tsx
+++ b/datahub-web-react/src/app/browse/BrowseResultsPage.tsx
@@ -57,7 +57,7 @@ export const BrowseResultsPage = () => {
 
     return (
         <SearchablePage>
-            <Affix offsetTop={64}>
+            <Affix offsetTop={60}>
                 <LegacyBrowsePath type={entityType} path={path} isBrowsable />
             </Affix>
             {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}

--- a/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entity/chart/ChartEntity.tsx
@@ -117,8 +117,8 @@ export class ChartEntity implements Entity<Chart> {
     getOverridePropertiesFromEntity = (chart?: Chart | null): GenericEntityProperties => {
         // TODO: Get rid of this once we have correctly formed platform coming back.
         const tool = chart?.tool || '';
-        const name = chart?.info?.name;
-        const externalUrl = chart?.info?.externalUrl;
+        const name = chart?.properties?.name;
+        const externalUrl = chart?.properties?.externalUrl;
         return {
             name,
             externalUrl,
@@ -141,9 +141,9 @@ export class ChartEntity implements Entity<Chart> {
             <ChartPreview
                 urn={data.urn}
                 platform={data.tool}
-                name={data.info?.name}
-                description={data.editableProperties?.description || data.info?.description}
-                access={data.info?.access}
+                name={data.properties?.name}
+                description={data.editableProperties?.description || data.properties?.description}
+                access={data.properties?.access}
                 owners={data.ownership?.owners}
                 tags={data?.globalTags || undefined}
                 glossaryTerms={data?.glossaryTerms}
@@ -157,9 +157,9 @@ export class ChartEntity implements Entity<Chart> {
             <ChartPreview
                 urn={data.urn}
                 platform={data.tool}
-                name={data.info?.name}
-                description={data.editableProperties?.description || data.info?.description}
-                access={data.info?.access}
+                name={data.properties?.name}
+                description={data.editableProperties?.description || data.properties?.description}
+                access={data.properties?.access}
                 owners={data.ownership?.owners}
                 tags={data?.globalTags || undefined}
                 glossaryTerms={data?.glossaryTerms}
@@ -171,7 +171,7 @@ export class ChartEntity implements Entity<Chart> {
     getLineageVizConfig = (entity: Chart) => {
         return {
             urn: entity.urn,
-            name: entity.info?.name || '',
+            name: entity.properties?.name || '',
             type: EntityType.Chart,
             // eslint-disable-next-line @typescript-eslint/dot-notation
             upstreamChildren: entity?.['inputs']?.relationships?.map(
@@ -187,7 +187,7 @@ export class ChartEntity implements Entity<Chart> {
     };
 
     displayName = (data: Chart) => {
-        return data.info?.name || data.urn;
+        return data.properties?.name || data.urn;
     };
 
     getGenericEntityProperties = (data: Chart) => {

--- a/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entity/dashboard/DashboardEntity.tsx
@@ -112,8 +112,8 @@ export class DashboardEntity implements Entity<Dashboard> {
     getOverridePropertiesFromEntity = (dashboard?: Dashboard | null): GenericEntityProperties => {
         // TODO: Get rid of this once we have correctly formed platform coming back.
         const tool = dashboard?.tool || '';
-        const name = dashboard?.info?.name;
-        const externalUrl = dashboard?.info?.externalUrl;
+        const name = dashboard?.properties?.name;
+        const externalUrl = dashboard?.properties?.externalUrl;
         return {
             name,
             externalUrl,
@@ -136,9 +136,9 @@ export class DashboardEntity implements Entity<Dashboard> {
             <DashboardPreview
                 urn={data.urn}
                 platform={data.tool}
-                name={data.info?.name}
-                description={data.editableProperties?.description || data.info?.description}
-                access={data.info?.access}
+                name={data.properties?.name}
+                description={data.editableProperties?.description || data.properties?.description}
+                access={data.properties?.access}
                 tags={data.globalTags || undefined}
                 owners={data.ownership?.owners}
                 glossaryTerms={data?.glossaryTerms}
@@ -152,9 +152,9 @@ export class DashboardEntity implements Entity<Dashboard> {
             <DashboardPreview
                 urn={data.urn}
                 platform={data.tool}
-                name={data.info?.name}
-                description={data.editableProperties?.description || data.info?.description}
-                access={data.info?.access}
+                name={data.properties?.name}
+                description={data.editableProperties?.description || data.properties?.description}
+                access={data.properties?.access}
                 tags={data.globalTags || undefined}
                 owners={data.ownership?.owners}
                 glossaryTerms={data?.glossaryTerms}
@@ -166,7 +166,7 @@ export class DashboardEntity implements Entity<Dashboard> {
     getLineageVizConfig = (entity: Dashboard) => {
         return {
             urn: entity.urn,
-            name: entity.info?.name || '',
+            name: entity.properties?.name || '',
             type: EntityType.Dashboard,
             // eslint-disable-next-line @typescript-eslint/dot-notation
             upstreamChildren: entity?.['charts']?.relationships?.map(
@@ -179,7 +179,7 @@ export class DashboardEntity implements Entity<Dashboard> {
     };
 
     displayName = (data: Dashboard) => {
-        return data.info?.name || data.urn;
+        return data.properties?.name || data.urn;
     };
 
     getGenericEntityProperties = (data: Dashboard) => {

--- a/datahub-web-react/src/app/entity/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataFlow/DataFlowEntity.tsx
@@ -97,8 +97,8 @@ export class DataFlowEntity implements Entity<DataFlow> {
     getOverridePropertiesFromEntity = (dataFlow?: DataFlow | null): GenericEntityProperties => {
         // TODO: Get rid of this once we have correctly formed platform coming back.
         const tool = dataFlow?.orchestrator || '';
-        const name = dataFlow?.info?.name;
-        const externalUrl = dataFlow?.info?.externalUrl;
+        const name = dataFlow?.properties?.name;
+        const externalUrl = dataFlow?.properties?.externalUrl;
         return {
             name,
             externalUrl,
@@ -121,8 +121,8 @@ export class DataFlowEntity implements Entity<DataFlow> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.info?.name || ''}
-                description={data.editableProperties?.description || data.info?.description}
+                name={data.properties?.name || ''}
+                description={data.editableProperties?.description || data.properties?.description}
                 platformName={platformName}
                 platformLogo={getLogoFromPlatform(data.orchestrator)}
                 owners={data.ownership?.owners}
@@ -137,8 +137,8 @@ export class DataFlowEntity implements Entity<DataFlow> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.info?.name || ''}
-                description={data.editableProperties?.description || data.info?.description || ''}
+                name={data.properties?.name || ''}
+                description={data.editableProperties?.description || data.properties?.description || ''}
                 platformName={platformName}
                 platformLogo={getLogoFromPlatform(data.orchestrator)}
                 owners={data.ownership?.owners}
@@ -149,7 +149,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
     };
 
     displayName = (data: DataFlow) => {
-        return data.info?.name || data.urn;
+        return data.properties?.name || data.urn;
     };
 
     getGenericEntityProperties = (data: DataFlow) => {

--- a/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataJob/DataJobEntity.tsx
@@ -109,8 +109,8 @@ export class DataJobEntity implements Entity<DataJob> {
     getOverridePropertiesFromEntity = (dataJob?: DataJob | null): GenericEntityProperties => {
         // TODO: Get rid of this once we have correctly formed platform coming back.
         const tool = dataJob?.dataFlow?.orchestrator || '';
-        const name = dataJob?.info?.name;
-        const externalUrl = dataJob?.info?.externalUrl;
+        const name = dataJob?.properties?.name;
+        const externalUrl = dataJob?.properties?.externalUrl;
         return {
             name,
             externalUrl,
@@ -135,8 +135,8 @@ export class DataJobEntity implements Entity<DataJob> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.info?.name || ''}
-                description={data.editableProperties?.description || data.info?.description}
+                name={data.properties?.name || ''}
+                description={data.editableProperties?.description || data.properties?.description}
                 platformName={platformName}
                 platformLogo={getLogoFromPlatform(data.dataFlow?.orchestrator || '')}
                 owners={data.ownership?.owners}
@@ -153,8 +153,8 @@ export class DataJobEntity implements Entity<DataJob> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.info?.name || ''}
-                description={data.editableProperties?.description || data.info?.description}
+                name={data.properties?.name || ''}
+                description={data.editableProperties?.description || data.properties?.description}
                 platformName={platformName}
                 platformLogo={getLogoFromPlatform(data.dataFlow?.orchestrator || '')}
                 owners={data.ownership?.owners}
@@ -167,7 +167,7 @@ export class DataJobEntity implements Entity<DataJob> {
     getLineageVizConfig = (entity: DataJob) => {
         return {
             urn: entity?.urn,
-            name: entity?.info?.name || '',
+            name: entity?.properties?.name || '',
             type: EntityType.DataJob,
             downstreamChildren: getChildrenFromRelationships({
                 // eslint-disable-next-line @typescript-eslint/dot-notation
@@ -189,7 +189,7 @@ export class DataJobEntity implements Entity<DataJob> {
     };
 
     displayName = (data: DataJob) => {
-        return data.info?.name || data.urn;
+        return data.properties?.name || data.urn;
     };
 
     getGenericEntityProperties = (data: DataJob) => {

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -186,7 +186,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 name={data.name}
                 origin={data.origin}
                 subtype={data.subTypes?.typeNames?.[0]}
-                description={data.editableProperties?.description || data.description}
+                description={data.editableProperties?.description || data.properties?.description}
                 platformName={data.platform.displayName || data.platform.name}
                 platformLogo={data.platform.info?.logoUrl}
                 owners={data.ownership?.owners}
@@ -203,7 +203,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 urn={data.urn}
                 name={data.name}
                 origin={data.origin}
-                description={data.editableProperties?.description || data.description}
+                description={data.editableProperties?.description || data.properties?.description}
                 platformName={data.platform.name}
                 platformLogo={data.platform.info?.logoUrl}
                 owners={data.ownership?.owners}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/SidebarAboutSection.tsx
@@ -41,7 +41,7 @@ export const SidebarAboutSection = () => {
     const refetch = useRefetch();
     const routeToTab = useRouteToTab();
 
-    const description = entityData?.editableProperties?.description || entityData?.description;
+    const description = entityData?.editableProperties?.description || entityData?.properties?.description;
     const links = entityData?.institutionalMemory?.elements || [];
 
     const isUntouched = !description && !(links?.length > 0);

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -24,7 +24,7 @@ const DocumentationContainer = styled.div`
 export const DocumentationTab = () => {
     const { entityData } = useEntityData();
     const refetch = useRefetch();
-    const description = entityData?.editableProperties?.description || entityData?.description || '';
+    const description = entityData?.editableProperties?.description || entityData?.properties?.description || '';
     const links = entityData?.institutionalMemory?.elements || [];
 
     const routeToTab = useRouteToTab();

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/__tests__/DocumentationTab.test.tsx
@@ -17,7 +17,9 @@ describe('SchemaDescriptionField', () => {
                             urn: 'urn:li:dataset:123',
                             entityType: EntityType.Dataset,
                             entityData: {
-                                description: 'This is a description',
+                                properties: {
+                                    description: 'This is a description',
+                                },
                             },
                             baseEntity: {},
                             updateEntity: jest.fn(),

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -15,7 +15,7 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
     const refetch = useRefetch();
     const updateEntity = useEntityUpdate<GenericEntityUpdate>();
 
-    const description = entityData?.editableProperties?.description || entityData?.description || '';
+    const description = entityData?.editableProperties?.description || entityData?.properties?.description || '';
     const [updatedDescription, setUpdatedDescription] = useState(description);
 
     const handleSaveDescription = async () => {

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -40,7 +40,9 @@ export type EntitySidebarSection = {
 export type GenericEntityProperties = {
     urn?: string;
     name?: Maybe<string>;
-    description?: Maybe<string>;
+    properties?: {
+        description?: string;
+    };
     globalTags?: Maybe<GlobalTags>;
     glossaryTerms?: Maybe<GlossaryTerms>;
     ownership?: Maybe<Ownership>;

--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -106,9 +106,9 @@ function getSuggestionFieldsFromResult(result: GetSearchResultsQuery | undefined
                     case 'CorpUser':
                         return entity.username;
                     case 'Chart':
-                        return entity.info?.name;
+                        return entity.properties?.name;
                     case 'Dashboard':
-                        return entity.info?.name;
+                        return entity.properties?.name;
                     default:
                         return undefined;
                 }

--- a/datahub-web-react/src/app/shared/entitySearch/__tests__/RelatedEntity.test.tsx
+++ b/datahub-web-react/src/app/shared/entitySearch/__tests__/RelatedEntity.test.tsx
@@ -17,7 +17,9 @@ const searchResult: {
                 type: EntityType.Dataset,
                 name: 'HiveDataset',
                 origin: 'PROD',
-                description: 'this is a dataset',
+                properties: {
+                    description: 'this is a dataset',
+                },
                 platformNativeType: PlatformNativeType.Table,
                 platform: {
                     name: 'hive',
@@ -32,7 +34,9 @@ const searchResult: {
                 type: EntityType.Dataset,
                 name: 'KafkaDataset',
                 origin: 'PROD',
-                description: 'this is also a dataset',
+                properties: {
+                    description: 'this is also a dataset',
+                },
                 platformNativeType: PlatformNativeType.Table,
                 platform: {
                     name: 'kafka',

--- a/datahub-web-react/src/app/shared/entitySearch/__tests__/RelatedEntityResult.test.tsx
+++ b/datahub-web-react/src/app/shared/entitySearch/__tests__/RelatedEntityResult.test.tsx
@@ -17,8 +17,10 @@ const searchResult: {
                 type: EntityType.Dataset,
                 name: 'HiveDataset',
                 origin: 'PROD',
-                description: 'this is a dataset',
                 platformNativeType: PlatformNativeType.Table,
+                properties: {
+                    description: 'this is a dataset',
+                },
                 platform: {
                     name: 'hive',
                 },
@@ -32,8 +34,10 @@ const searchResult: {
                 type: EntityType.Dataset,
                 name: 'KafkaDataset',
                 origin: 'PROD',
-                description: 'this is also a dataset',
                 platformNativeType: PlatformNativeType.Table,
+                properties: {
+                    description: 'this is also a dataset',
+                },
                 platform: {
                     name: 'kafka',
                 },

--- a/datahub-web-react/src/graphql/browse.graphql
+++ b/datahub-web-react/src/graphql/browse.graphql
@@ -12,7 +12,12 @@ query getBrowseResults($input: BrowseInput!) {
             ... on Dataset {
                 name
                 origin
-                description
+                properties {
+                    description
+                }
+                editableProperties {
+                    description
+                }
                 platform {
                     name
                     info {
@@ -37,7 +42,7 @@ query getBrowseResults($input: BrowseInput!) {
                 type
                 tool
                 dashboardId
-                info {
+                properties {
                     name
                     description
                     externalUrl
@@ -45,6 +50,9 @@ query getBrowseResults($input: BrowseInput!) {
                     lastModified {
                         time
                     }
+                }
+                editableProperties {
+                    description
                 }
                 ownership {
                     ...ownershipFields
@@ -77,7 +85,7 @@ query getBrowseResults($input: BrowseInput!) {
                 type
                 tool
                 chartId
-                info {
+                properties {
                     name
                     description
                     externalUrl
@@ -86,6 +94,9 @@ query getBrowseResults($input: BrowseInput!) {
                     lastModified {
                         time
                     }
+                }
+                editableProperties {
+                    description
                 }
                 ownership {
                     ...ownershipFields
@@ -103,10 +114,13 @@ query getBrowseResults($input: BrowseInput!) {
                 orchestrator
                 flowId
                 cluster
-                info {
+                properties {
                     name
                     description
                     project
+                }
+                editableProperties {
+                    description
                 }
                 ownership {
                     ...ownershipFields

--- a/datahub-web-react/src/graphql/chart.graphql
+++ b/datahub-web-react/src/graphql/chart.graphql
@@ -4,7 +4,7 @@ query getChart($urn: String!) {
         type
         tool
         chartId
-        info {
+        properties {
             name
             description
             externalUrl

--- a/datahub-web-react/src/graphql/dataFlow.graphql
+++ b/datahub-web-react/src/graphql/dataFlow.graphql
@@ -4,7 +4,7 @@ fragment dataFlowFields on DataFlow {
     orchestrator
     flowId
     cluster
-    info {
+    properties {
         name
         description
         project
@@ -63,7 +63,7 @@ query getDataFlow($urn: String!) {
                         ownership {
                             ...ownershipFields
                         }
-                        info {
+                        properties {
                             name
                             description
                         }

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -96,7 +96,6 @@ fragment nonRecursiveDatasetFields on Dataset {
     name
     type
     origin
-    description
     uri
     platform {
         name
@@ -107,6 +106,7 @@ fragment nonRecursiveDatasetFields on Dataset {
     }
     platformNativeType
     properties {
+        description
         customProperties {
             key
             value
@@ -171,7 +171,7 @@ fragment nonRecursiveDataFlowFields on DataFlow {
     orchestrator
     flowId
     cluster
-    info {
+    properties {
         name
         description
         project
@@ -191,7 +191,7 @@ fragment nonRecursiveDataFlowFields on DataFlow {
 
 fragment nonRecursiveDataJobFields on DataJob {
     urn
-    info {
+    properties {
         name
         description
         externalUrl
@@ -226,7 +226,7 @@ fragment dataJobFields on DataJob {
             ...nonRecursiveDataJobFields
         }
     }
-    info {
+    properties {
         name
         description
         externalUrl
@@ -265,7 +265,7 @@ fragment dashboardFields on Dashboard {
     type
     tool
     dashboardId
-    info {
+    properties {
         name
         description
         customProperties {
@@ -500,8 +500,10 @@ fragment schemaMetadataFields on SchemaMetadata {
             name
             type
             origin
-            description
             uri
+            properties {
+                description
+            }
             platform {
                 name
                 info {

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -4,7 +4,6 @@ fragment entityPreview on Entity {
     ... on Dataset {
         name
         origin
-        description
         uri
         platform {
             name
@@ -18,6 +17,7 @@ fragment entityPreview on Entity {
         }
         platformNativeType
         properties {
+            description
             customProperties {
                 key
                 value
@@ -85,7 +85,7 @@ fragment entityPreview on Entity {
         type
         tool
         dashboardId
-        info {
+        properties {
             name
             description
             externalUrl
@@ -112,7 +112,7 @@ fragment entityPreview on Entity {
         type
         tool
         chartId
-        info {
+        properties {
             name
             description
             externalUrl
@@ -141,7 +141,7 @@ fragment entityPreview on Entity {
         orchestrator
         flowId
         cluster
-        info {
+        properties {
             name
             description
             project
@@ -169,7 +169,7 @@ fragment entityPreview on Entity {
         ownership {
             ...ownershipFields
         }
-        info {
+        properties {
             name
             description
         }

--- a/datahub-web-react/src/graphql/relationships.graphql
+++ b/datahub-web-react/src/graphql/relationships.graphql
@@ -12,7 +12,7 @@ fragment relationshipFields on Entity {
         orchestrator
         flowId
         cluster
-        info {
+        properties {
             name
             description
             project
@@ -40,12 +40,9 @@ fragment relationshipFields on Entity {
     ... on Chart {
         tool
         chartId
-        info {
+        properties {
             name
             description
-            inputs {
-                urn
-            }
         }
         editableProperties {
             description
@@ -57,7 +54,9 @@ fragment relationshipFields on Entity {
     }
     ... on Dataset {
         name
-        description
+        properties {
+            description
+        }
         editableProperties {
             description
         }

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -26,7 +26,6 @@ fragment searchResults on SearchResults {
             ... on Dataset {
                 name
                 origin
-                description
                 uri
                 platform {
                     name
@@ -39,6 +38,7 @@ fragment searchResults on SearchResults {
                 }
                 platformNativeType
                 properties {
+                    description
                     customProperties {
                         key
                         value
@@ -106,7 +106,7 @@ fragment searchResults on SearchResults {
                 type
                 tool
                 dashboardId
-                info {
+                properties {
                     name
                     description
                     externalUrl
@@ -133,7 +133,7 @@ fragment searchResults on SearchResults {
                 type
                 tool
                 chartId
-                info {
+                properties {
                     name
                     description
                     externalUrl
@@ -162,7 +162,7 @@ fragment searchResults on SearchResults {
                 orchestrator
                 flowId
                 cluster
-                info {
+                properties {
                     name
                     description
                     project
@@ -190,7 +190,7 @@ fragment searchResults on SearchResults {
                 ownership {
                     ...ownershipFields
                 }
-                info {
+                properties {
                     name
                     description
                 }


### PR DESCRIPTION
This PR migrates to using the description field of the standard "properties" bag in the GraphQL API, moving away from using the deprecated "info" fields sporadically. It also addresses a few description-rendering related bugs:

- Browse previews will correctly reflected edited descriptions
- All entity pages will correctly reflect system-provisioned descriptions

This is part of an initiative to more toward convergence of common entity fields to make UI development a simpler proecss.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
