### PR TITLE
feat(deletes): support deletion of non-snapshot aspects

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/SendMAEStep.java
@@ -14,8 +14,6 @@ import com.linkedin.metadata.entity.ebean.EbeanUtils;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
-import com.linkedin.metadata.utils.GenericAspectUtils;
-import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.SystemMetadata;
 import io.ebean.EbeanServer;
 import io.ebean.PagedList;
@@ -108,16 +106,9 @@ public class SendMAEStep implements UpgradeStep {
 
           SystemMetadata latestSystemMetadata = EbeanUtils.parseSystemMetadata(aspect.getSystemMetadata());
 
-          final MetadataChangeLog metadataChangeLog = new MetadataChangeLog();
-          metadataChangeLog.setEntityType(entityName);
-          metadataChangeLog.setEntityUrn(urn);
-          metadataChangeLog.setChangeType(ChangeType.UPSERT);
-          metadataChangeLog.setAspectName(aspectName);
-          metadataChangeLog.setAspect(GenericAspectUtils.serializeAspect(aspectRecord));
-          metadataChangeLog.setSystemMetadata(latestSystemMetadata);
-
           // 5. Produce MAE events for the aspect record
-          _entityService.produceMetadataChangeLog(urn, aspectSpec, metadataChangeLog);
+          _entityService.produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, null, aspectRecord, null,
+              latestSystemMetadata, ChangeType.UPSERT);
 
           totalRowsMigrated++;
         }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/RollbackResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/RollbackResult.java
@@ -1,9 +1,9 @@
 package com.linkedin.metadata.entity;
 
 import com.linkedin.common.urn.Urn;
+
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.events.metadata.ChangeType;
-import com.linkedin.mxe.MetadataAuditOperation;
 import com.linkedin.mxe.SystemMetadata;
 import lombok.Value;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/RollbackResult.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/RollbackResult.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.entity;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.mxe.MetadataAuditOperation;
 import com.linkedin.mxe.SystemMetadata;
 import lombok.Value;
@@ -10,11 +11,13 @@ import lombok.Value;
 @Value
 public class RollbackResult {
   public Urn urn;
+  public String entityName;
+  public String aspectName;
   public RecordTemplate oldValue;
   public RecordTemplate newValue;
   public SystemMetadata oldSystemMetadata;
   public SystemMetadata newSystemMetadata;
-  public MetadataAuditOperation operation;
+  public ChangeType changeType;
   public Boolean keyAffected;
   public Integer additionalRowsAffected;
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.entity.ebean;
 
 import com.codahale.metrics.Timer;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.linkedin.common.AuditStamp;
@@ -19,6 +18,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.ListResult;
 import com.linkedin.metadata.entity.RollbackResult;
 import com.linkedin.metadata.entity.RollbackRunResult;
+import com.linkedin.metadata.entity.ValidationUtils;
 import com.linkedin.metadata.event.EntityEventProducer;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
@@ -28,7 +28,6 @@ import com.linkedin.metadata.run.AspectRowSummary;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericAspectUtils;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
-import com.linkedin.metadata.entity.ValidationUtils;
 import com.linkedin.mxe.MetadataAuditOperation;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -106,9 +105,8 @@ public class EbeanEntityService extends EntityService {
     });
 
     Map<EbeanAspectV2.PrimaryKey, EbeanAspectV2> batchGetResults = new HashMap<>();
-    Iterators.partition(dbKeys.iterator(), 500).forEachRemaining(
-        batch -> batchGetResults.putAll(_entityDao.batchGet(ImmutableSet.copyOf(batch)))
-    );
+    Iterators.partition(dbKeys.iterator(), 500)
+        .forEachRemaining(batch -> batchGetResults.putAll(_entityDao.batchGet(ImmutableSet.copyOf(batch))));
 
     batchGetResults.forEach((key, aspectEntry) -> {
       final Urn urn = toUrn(key.getUrn());
@@ -337,20 +335,8 @@ public class EbeanEntityService extends EntityService {
 
     if (emitMae) {
       log.debug(String.format("Producing MetadataAuditEvent for updated aspect %s, urn %s", aspectName, urn));
-      final MetadataChangeLog metadataChangeLog = new MetadataChangeLog();
-      metadataChangeLog.setEntityType(entityName);
-      metadataChangeLog.setEntityUrn(urn);
-      metadataChangeLog.setChangeType(ChangeType.UPSERT);
-      metadataChangeLog.setAspectName(aspectName);
-      metadataChangeLog.setAspect(GenericAspectUtils.serializeAspect(newValue));
-      metadataChangeLog.setSystemMetadata(result.newSystemMetadata);
-      if (oldValue != null) {
-        metadataChangeLog.setPreviousAspectValue(GenericAspectUtils.serializeAspect(oldValue));
-      }
-      if (result.oldSystemMetadata != null) {
-        metadataChangeLog.setPreviousSystemMetadata(result.oldSystemMetadata);
-      }
-      produceMetadataChangeLog(urn, aspectSpec, metadataChangeLog);
+      produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, oldValue, newValue, result.oldSystemMetadata,
+          result.newSystemMetadata, ChangeType.UPSERT);
     } else {
       log.debug(String.format("Skipped producing MetadataAuditEvent for updated aspect %s, urn %s. emitMAE is false.",
           aspectName, urn));
@@ -532,11 +518,11 @@ public class EbeanEntityService extends EntityService {
             : toAspectRecord(Urn.createFromString(previousAspect.getKey().getUrn()),
                 previousAspect.getKey().getAspect(), previousMetadata, getEntityRegistry());
 
-        return new RollbackResult(Urn.createFromString(urn), latestValue,
+        final Urn urnObj = Urn.createFromString(urn);
+        return new RollbackResult(urnObj, urnObj.getEntityType(), latest.getAspect(), latestValue,
             previousValue == null ? latestValue : previousValue, latestSystemMetadata,
             previousValue == null ? null : parseSystemMetadata(previousAspect.getSystemMetadata()),
-            previousAspect == null ? MetadataAuditOperation.DELETE : MetadataAuditOperation.UPDATE, isKeyAspect,
-            additionalRowsDeleted);
+            previousAspect == null ? ChangeType.DELETE : ChangeType.UPSERT, isKeyAspect, additionalRowsDeleted);
       } catch (URISyntaxException e) {
         e.printStackTrace();
       }
@@ -555,12 +541,18 @@ public class EbeanEntityService extends EntityService {
     aspectRows.forEach(aspectToRemove -> {
 
       RollbackResult result = deleteAspect(aspectToRemove.getUrn(), aspectToRemove.getAspectName(), runId);
+      Optional<AspectSpec> aspectSpec = getAspectSpec(result.entityName, result.aspectName);
+      if (!aspectSpec.isPresent()) {
+        log.error("Issue while rolling back: unknown aspect {} for entity {}", result.entityName, result.aspectName);
+        return;
+      }
 
       if (result != null) {
         rowsDeletedFromEntityDeletion.addAndGet(result.additionalRowsAffected);
         removedAspects.add(aspectToRemove);
-        produceMetadataAuditEvent(result.getUrn(), result.getOldValue(), result.getNewValue(),
-            result.getOldSystemMetadata(), result.getNewSystemMetadata(), result.getOperation());
+        produceMetadataChangeLog(result.getUrn(), result.getEntityName(), result.getAspectName(), aspectSpec.get(),
+            result.getOldValue(), result.getNewValue(), result.getOldSystemMetadata(), result.getNewSystemMetadata(),
+            result.getChangeType());
       }
     });
 
@@ -581,8 +573,12 @@ public class EbeanEntityService extends EntityService {
     SystemMetadata latestKeySystemMetadata = parseSystemMetadata(latestKey.getSystemMetadata());
 
     RollbackResult result = deleteAspect(urn.toString(), keyAspectName, latestKeySystemMetadata.getRunId());
+    Optional<AspectSpec> aspectSpec = getAspectSpec(result.entityName, result.aspectName);
+    if (!aspectSpec.isPresent()) {
+      log.error("Issue while rolling back: unknown aspect {} for entity {}", result.entityName, result.aspectName);
+    }
 
-    if (result != null) {
+    if (result != null && aspectSpec.isPresent()) {
       AspectRowSummary summary = new AspectRowSummary();
       summary.setUrn(urn.toString());
       summary.setKeyAspect(true);
@@ -592,8 +588,9 @@ public class EbeanEntityService extends EntityService {
 
       rowsDeletedFromEntityDeletion = result.additionalRowsAffected;
       removedAspects.add(summary);
-      produceMetadataAuditEvent(result.getUrn(), result.getOldValue(), result.getNewValue(),
-          result.getOldSystemMetadata(), result.getNewSystemMetadata(), result.getOperation());
+      produceMetadataChangeLog(result.getUrn(), result.getEntityName(), result.getAspectName(), aspectSpec.get(),
+          result.getOldValue(), result.getNewValue(), result.getOldSystemMetadata(), result.getNewSystemMetadata(),
+          result.getChangeType());
     }
 
     return new RollbackRunResult(removedAspects, rowsDeletedFromEntityDeletion);

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.entity.ebean;
 
 import com.codahale.metrics.Timer;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.linkedin.common.AuditStamp;
@@ -541,13 +542,13 @@ public class EbeanEntityService extends EntityService {
     aspectRows.forEach(aspectToRemove -> {
 
       RollbackResult result = deleteAspect(aspectToRemove.getUrn(), aspectToRemove.getAspectName(), runId);
-      Optional<AspectSpec> aspectSpec = getAspectSpec(result.entityName, result.aspectName);
-      if (!aspectSpec.isPresent()) {
-        log.error("Issue while rolling back: unknown aspect {} for entity {}", result.entityName, result.aspectName);
-        return;
-      }
-
       if (result != null) {
+        Optional<AspectSpec> aspectSpec = getAspectSpec(result.entityName, result.aspectName);
+        if (!aspectSpec.isPresent()) {
+          log.error("Issue while rolling back: unknown aspect {} for entity {}", result.entityName, result.aspectName);
+          return;
+        }
+
         rowsDeletedFromEntityDeletion.addAndGet(result.additionalRowsAffected);
         removedAspects.add(aspectToRemove);
         produceMetadataChangeLog(result.getUrn(), result.getEntityName(), result.getAspectName(), aspectSpec.get(),

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -44,7 +44,12 @@ public class SearchDocumentTransformer {
     return Optional.of(searchDocument.toString());
   }
 
-  public static Optional<String> transformAspect(final Urn urn, final RecordTemplate aspect, final AspectSpec aspectSpec) {
+  public static Optional<String> transformAspect(
+      final Urn urn,
+      final RecordTemplate aspect,
+      final AspectSpec aspectSpec,
+      final Boolean forDelete
+  ) {
     final Map<SearchableFieldSpec, List<Object>> extractedFields =
         FieldExtractor.extractFields(aspect, aspectSpec.getSearchableFieldSpecs());
     if (extractedFields.isEmpty()) {
@@ -52,7 +57,7 @@ public class SearchDocumentTransformer {
     }
     final ObjectNode searchDocument = JsonNodeFactory.instance.objectNode();
     searchDocument.put("urn", urn.toString());
-    extractedFields.forEach((key, value) -> setValue(key, value, searchDocument, false));
+    extractedFields.forEach((key, value) -> setValue(key, value, searchDocument, forDelete));
     return Optional.of(searchDocument.toString());
   }
 

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -138,8 +138,7 @@ public class MetadataChangeLogProcessor {
         updateGraphService(urn, aspectSpec, aspect);
         updateSystemMetadata(event.getSystemMetadata(), urn, aspectSpec);
       }
-    }
-    if (event.getChangeType() == ChangeType.DELETE) {
+    } else if (event.getChangeType() == ChangeType.DELETE) {
       if (!event.hasAspectName() || !event.hasAspect()) {
         log.error("Aspect or aspect name is missing");
         return;

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -1,6 +1,7 @@
 package com.linkedin.metadata.kafka;
 
 import com.codahale.metrics.Histogram;
+
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -47,7 +48,6 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.jute.Record;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -8,6 +8,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.gms.factory.common.GraphServiceFactory;
+import com.linkedin.gms.factory.common.SystemMetadataServiceFactory;
 import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.gms.factory.search.EntitySearchServiceFactory;
 import com.linkedin.gms.factory.timeseries.TimeseriesAspectServiceFactory;
@@ -25,6 +26,7 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
+import com.linkedin.metadata.systemmetadata.SystemMetadataService;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.timeseries.transformer.TimeseriesAspectTransformer;
 import com.linkedin.metadata.utils.EntityKeyUtils;
@@ -33,6 +35,7 @@ import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.mxe.Topics;
+import com.linkedin.util.Pair;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -44,6 +47,7 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.jute.Record;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
@@ -52,30 +56,32 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-import static com.linkedin.metadata.search.utils.QueryUtils.newRelationshipFilter;
+import static com.linkedin.metadata.search.utils.QueryUtils.*;
 
 
 @Slf4j
 @Component
 @Conditional(MetadataChangeLogProcessorCondition.class)
 @Import({GraphServiceFactory.class, EntitySearchServiceFactory.class, TimeseriesAspectServiceFactory.class,
-    EntityRegistryFactory.class})
+    EntityRegistryFactory.class, SystemMetadataServiceFactory.class})
 @EnableKafka
 public class MetadataChangeLogProcessor {
 
   private final GraphService _graphService;
   private final EntitySearchService _entitySearchService;
   private final TimeseriesAspectService _timeseriesAspectService;
+  private final SystemMetadataService _systemMetadataService;
   private final EntityRegistry _entityRegistry;
 
   private final Histogram kafkaLagStats = MetricUtils.get().histogram(MetricRegistry.name(this.getClass(), "kafkaLag"));
 
   @Autowired
   public MetadataChangeLogProcessor(GraphService graphService, EntitySearchService entitySearchService,
-      TimeseriesAspectService timeseriesAspectService, EntityRegistry entityRegistry) {
+      TimeseriesAspectService timeseriesAspectService, SystemMetadataService systemMetadataService, EntityRegistry entityRegistry) {
     _graphService = graphService;
     _entitySearchService = entitySearchService;
     _timeseriesAspectService = timeseriesAspectService;
+    _systemMetadataService = systemMetadataService;
     _entityRegistry = entityRegistry;
 
     _timeseriesAspectService.configure();
@@ -99,16 +105,16 @@ public class MetadataChangeLogProcessor {
       return;
     }
 
-    if (event.getChangeType() == ChangeType.UPSERT) {
-      EntitySpec entitySpec;
-      try {
-        entitySpec = _entityRegistry.getEntitySpec(event.getEntityType());
-      } catch (IllegalArgumentException e) {
-        log.error("Error while processing entity type {}: {}", event.getEntityType(), e.toString());
-        return;
-      }
+    EntitySpec entitySpec;
+    try {
+      entitySpec = _entityRegistry.getEntitySpec(event.getEntityType());
+    } catch (IllegalArgumentException e) {
+      log.error("Error while processing entity type {}: {}", event.getEntityType(), e.toString());
+      return;
+    }
+    Urn urn = EntityKeyUtils.getUrnFromLog(event, entitySpec.getKeyAspectSpec());
 
-      Urn urn = EntityKeyUtils.getUrnFromLog(event, entitySpec.getKeyAspectSpec());
+    if (event.getChangeType() == ChangeType.UPSERT) {
 
       if (!event.hasAspectName() || !event.hasAspect()) {
         log.error("Aspect or aspect name is missing");
@@ -130,14 +136,35 @@ public class MetadataChangeLogProcessor {
       } else {
         updateSearchService(entitySpec.getName(), urn, aspectSpec, aspect);
         updateGraphService(urn, aspectSpec, aspect);
+        updateSystemMetadata(event.getSystemMetadata(), urn, aspectSpec);
+      }
+    }
+    if (event.getChangeType() == ChangeType.DELETE) {
+      if (!event.hasAspectName() || !event.hasAspect()) {
+        log.error("Aspect or aspect name is missing");
+        return;
+      }
+
+      AspectSpec aspectSpec = entitySpec.getAspectSpec(event.getAspectName());
+      if (aspectSpec == null) {
+        log.error("Unrecognized aspect name {} for entity {}", event.getAspectName(), event.getEntityType());
+        return;
+      }
+
+      RecordTemplate aspect =
+          GenericAspectUtils.deserializeAspect(event.getAspect().getValue(), event.getAspect().getContentType(),
+              aspectSpec);
+      Boolean isDeletingKey = event.getAspectName().equals(entitySpec.getKeyAspectName());
+
+      if (!aspectSpec.isTimeseries()) {
+        deleteSystemMetadata(urn, aspectSpec, isDeletingKey);
+        deleteGraphData(urn, aspectSpec, aspect, isDeletingKey);
+        deleteSearchData(urn, entitySpec.getName(), aspectSpec, aspect, isDeletingKey);
       }
     }
   }
 
-  /**
-   * Process snapshot and update graph index
-   */
-  private void updateGraphService(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
+  private Pair<List<Edge>, Set<String>> getEdgesAndRelationshipTypesFromAspect(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
     final Set<String> relationshipTypesBeingAdded = new HashSet<>();
     final List<Edge> edgesToAdd = new ArrayList<>();
 
@@ -155,6 +182,19 @@ public class MetadataChangeLogProcessor {
         }
       }
     }
+    return Pair.of(edgesToAdd, relationshipTypesBeingAdded);
+  }
+
+  /**
+   * Process snapshot and update graph index
+   */
+  private void updateGraphService(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
+    Pair<List<Edge>, Set<String>> edgeAndRelationTypes =
+        getEdgesAndRelationshipTypesFromAspect(urn, aspectSpec, aspect);
+
+    final List<Edge> edgesToAdd = edgeAndRelationTypes.getFirst();
+    final Set<String> relationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
+
     log.info(String.format("Here's the relationship types found %s", relationshipTypesBeingAdded));
     if (relationshipTypesBeingAdded.size() > 0) {
       new Thread(() -> {
@@ -171,7 +211,7 @@ public class MetadataChangeLogProcessor {
   private void updateSearchService(String entityName, Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
     Optional<String> searchDocument;
     try {
-      searchDocument = SearchDocumentTransformer.transformAspect(urn, aspect, aspectSpec);
+      searchDocument = SearchDocumentTransformer.transformAspect(urn, aspect, aspectSpec, false);
     } catch (Exception e) {
       log.error("Error in getting documents from aspect: {} for aspect {}", e, aspectSpec.getName());
       return;
@@ -207,5 +247,61 @@ public class MetadataChangeLogProcessor {
     documents.entrySet().forEach(document -> {
       _timeseriesAspectService.upsertDocument(entityType, aspectName, document.getKey(), document.getValue());
     });
+  }
+
+  private void updateSystemMetadata(SystemMetadata systemMetadata, Urn urn, AspectSpec aspectSpec) {
+    _systemMetadataService.insert(systemMetadata, urn.toString(), aspectSpec.getName());
+  }
+
+  private void deleteSystemMetadata(Urn urn, AspectSpec aspectSpec, Boolean isKeyAspect) {
+    if (isKeyAspect) {
+      _systemMetadataService.deleteUrn(urn.toString());
+    }
+    _systemMetadataService.delete(urn.toString(), aspectSpec.getName());
+  }
+
+  private void deleteGraphData(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect, Boolean isKeyAspect) {
+    if (isKeyAspect) {
+      _graphService.removeNode(urn);
+      return;
+    }
+
+    Pair<List<Edge>, Set<String>> edgeAndRelationTypes =
+        getEdgesAndRelationshipTypesFromAspect(urn, aspectSpec, aspect);
+
+    final Set<String> relationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
+    if (relationshipTypesBeingAdded.size() > 0) {
+      _graphService.removeEdgesFromNode(urn, new ArrayList<>(relationshipTypesBeingAdded),
+          createRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+    }
+  }
+
+  private void deleteSearchData(Urn urn, String entityName, AspectSpec aspectSpec, RecordTemplate aspect, Boolean isKeyAspect) {
+    String docId;
+    try {
+      docId = URLEncoder.encode(urn.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      log.error("Failed to encode the urn with error: {}", e.toString());
+      return;
+    }
+
+    if (isKeyAspect) {
+      _entitySearchService.deleteDocument(entityName, docId);
+      return;
+    }
+
+    Optional<String> searchDocument;
+    try {
+      searchDocument = SearchDocumentTransformer.transformAspect(urn, aspect, aspectSpec, true);
+    } catch (Exception e) {
+      log.error("Error in getting documents from aspect: {} for aspect {}", e, aspectSpec.getName());
+      return;
+    }
+
+    if (!searchDocument.isPresent()) {
+      return;
+    }
+
+    _entitySearchService.upsertDocument(entityName, searchDocument.get(), docId);
   }
 }


### PR DESCRIPTION
Historically, deletes were only processed by the MAE processor. This meant only aspects that existed within the universe of Snapshots could be deleted. This presents an issue as Datahub moves away from the snapshot model. This PR:

1) removes deletion logic from MAE processor
2) adds deletion logic for non-timeseries aspects to MCLProcessor

Test plan:
- ingest snapshot aspects
- revert the snapshot aspects
- verify the data is gone from search, entity, and graph services

- ingest mcp only aspects
- revert mcp only aspects
- verify the data is gone from search, entity, and graph services

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
