### PR TITLE
feat(cli): add support for deletion based on filters, soft deletes an…

### DIFF
--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -1,7 +1,12 @@
 # Removing Metadata from DataHub
 
-There are a two ways to delete data from DataHub.
+There are a two ways to delete metadata from DataHub. 
+- Delete metadata attached to entities by providing a specific urn or a filter that identifies a set of entities
+- Delete metadata affected by a single ingestion run
 
+Read on to find out how to perform these kinds of deletes.
+
+_Note: Deleting metadata should only be done with care. Always use `--dry-run` to understand what will be deleted before proceeding. Prefer soft-deletes (`--soft`) unless you really want to nuke metadata rows. Hard deletes will actually delete rows in the primary store and recovering them will require using backups of the primary metadata store. Make sure you understand the implications of issuing soft-deletes versus hard-deletes before proceeding._ 
 
 ## Configuring DataHub CLI
 
@@ -28,17 +33,49 @@ The env variables take precendence over what is in the config.
 
 To delete all the data related to a single entity, run
 
+### Soft Delete
+```
+datahub delete --urn "<my urn>" --soft
+```
+
+### Hard Delete
 ```
 datahub delete --urn "<my urn>"
 ```
 
+You can optionally add `-n` or `--dry-run` to execute a dry run before issuing the final delete command.
 You can optionally add `-f` or `--force` to skip confirmations
 
 _Note: make sure you surround your urn with quotes! If you do not include the quotes, your terminal may misinterpret the command._
 
+## Delete using Broader Filters
+
+_Note: All these commands below support the soft-delete option (`-s/--soft`) as well as the dry-run option (`-n/--dry-run`)._ 
+
+### Delete all datasets in the DEV environment
+```
+datahub delete --env DEV --entity_type dataset
+```
+
+### Delete all bigquery datasets in the PROD environment
+```
+datahub delete --env PROD --entity_type dataset --platform bigquery
+```
+
+### Delete all looker dashboards and charts
+```
+datahub delete --entity_type dashboard --platform looker
+datahub delete --entity_type chart --platform looker
+```
+
+### Delete all datasets that match a query
+```
+datahub delete --entity_type dataset --query "_tmp" -n
+```
+
 ## Rollback Ingestion Batch Run
 
-Whenever you run `datahub ingest -c ...`, all the metadata ingested with that run will have the same run id.
+The second way to delete metadata is to identify entities (and the aspects affected) by using an ingestion `run-id`. Whenever you run `datahub ingest -c ...`, all the metadata ingested with that run will have the same run id.
 
 To view the ids of the most recent set of ingestion batches, execute
 

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -43,6 +43,7 @@ framework_common = {
     "python-dateutil>=2.8.0",
     "stackprinter",
     "tabulate",
+    "progressbar2",
 }
 
 kafka_common = {

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -219,6 +219,7 @@ dev_requirements_airflow_1 = {
     "apache-airflow==1.10.15",
     "apache-airflow-backport-providers-snowflake",
     "snowflake-sqlalchemy<=1.2.4",  # make constraint consistent with extras
+    "WTForms==2.3.3", # make constraint consistent with extras
 }
 
 full_test_dev_requirements = {

--- a/metadata-ingestion/src/datahub/cli/delete_cli.py
+++ b/metadata-ingestion/src/datahub/cli/delete_cli.py
@@ -1,8 +1,18 @@
 import logging
+import sys
+import time
+from dataclasses import dataclass
+from random import choices
+from typing import Optional, Tuple
 
 import click
+import progressbar
+from requests import sessions
 
 from datahub.cli import cli_utils
+from datahub.emitter import rest_emitter
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import ChangeTypeClass, StatusClass
 
 logger = logging.getLogger(__name__)
 
@@ -11,25 +21,205 @@ ELASTIC_MAX_PAGE_SIZE = 10000
 RUNS_TABLE_COLUMNS = ["runId", "rows", "created at"]
 RUN_TABLE_COLUMNS = ["urn", "aspect name", "created at"]
 
+UNKNOWN_NUM_RECORDS = -1
+
+
+@dataclass
+class DeletionResult:
+    start_time_millis: int = int(time.time() * 1000.0)
+    end_time_millis: int = 0
+    num_records: int = 0
+    num_entities: int = 0
+
+    def start(self) -> None:
+        self.start_time_millis = int(time.time() * 1000.0)
+
+    def end(self) -> None:
+        self.end_time_millis = int(time.time() * 1000.0)
+
+    def merge(self, another_result: "DeletionResult") -> None:
+        self.end_time_millis = another_result.end_time_millis
+        self.num_records = (
+            self.num_records + another_result.num_records
+            if another_result.num_records != UNKNOWN_NUM_RECORDS
+            else UNKNOWN_NUM_RECORDS
+        )
+        self.num_entities += another_result.num_entities
+
 
 @click.command()
-@click.option("--urn", required=True, type=str)
-@click.option("-f", "--force", required=False, type=bool, default=False)
-def delete(urn: str, force: bool) -> None:
+@click.option("--urn", required=False, type=str)
+@click.option("-f", "--force", required=False, is_flag=True)
+@click.option("--soft", required=False, is_flag=True)
+@click.option("-e", "--env", required=False, type=str)
+@click.option("-p", "--platform", required=False, type=str)
+@click.option("--entity_type", required=False, type=str, default="dataset")
+@click.option("--query", required=False, type=str)
+@click.option("-n", "--dry", required=False, is_flag=True)
+def delete(
+    urn: str,
+    force: bool,
+    soft: bool,
+    env: str,
+    platform: str,
+    entity_type: str,
+    query: str,
+    dry: bool,
+) -> None:
     """Delete a provided URN from datahub"""
-    if not force:
+
+    # First test connectivity
+    try:
+        cli_utils.test_connection()
+    except Exception as e:
+        click.echo(
+            f"Failed to connect to DataHub server at {cli_utils.get_session_and_host()[1]}. Run with datahub --debug delete ... to get more information."
+        )
+        logger.debug(f"Failed to connect with {e}")
+        sys.exit(1)
+
+    # one of urn / platform / env / query must be provided
+    if not urn and not platform and not env and not query:
+        raise click.UsageError(
+            "You must provide either an urn or a platform or an env or a query for me to delete anything"
+        )
+
+    # default query is set to "*" if not provided
+    query = "*" if query is None else query
+
+    if not force and not soft and not dry:
         click.confirm(
             "This will permanently delete data from DataHub. Do you want to continue?",
             abort=True,
         )
 
-    payload_obj = {"urn": urn}
+    if urn:
+        # Single urn based delete
+        session, host = cli_utils.get_session_and_host()
+        logger.info(f"DataHub configured with {host}")
+        deletion_result: DeletionResult = delete_one_urn(
+            urn,
+            soft=soft,
+            dry_run=dry,
+            cached_session_host=(session, host),
+        )
 
-    urn, rows_affected = cli_utils.post_delete_endpoint(
-        payload_obj, "/entities?action=delete"
-    )
-
-    if rows_affected == 0:
-        click.echo(f"Nothing deleted for {urn}")
+        if not dry:
+            if deletion_result.num_records == 0:
+                click.echo(f"Nothing deleted for {urn}")
+            else:
+                click.echo(
+                    f"Successfully deleted {urn}. {deletion_result.num_records} rows deleted"
+                )
     else:
-        click.echo(f"Successfully deleted {urn}. {rows_affected} rows deleted")
+        # Filter based delete
+        deletion_result = delete_with_filters(
+            env=env,
+            platform=platform,
+            dry_run=dry,
+            soft=soft,
+            entity_type=entity_type,
+            search_query=query,
+            force=force,
+        )
+
+    if not dry:
+        message = "soft delete" if soft else "delete"
+        click.echo(
+            f"Took {(deletion_result.end_time_millis-deletion_result.start_time_millis)/1000.0} seconds to {message} {deletion_result.num_records} rows for {deletion_result.num_entities} entities"
+        )
+    else:
+        click.echo(
+            f"{deletion_result.num_entities} entities with {deletion_result.num_records if deletion_result.num_records != UNKNOWN_NUM_RECORDS else 'unknown'} rows will be affected. Took {(deletion_result.end_time_millis-deletion_result.start_time_millis)/1000.0} seconds to evaluate."
+        )
+
+
+def delete_with_filters(
+    dry_run: bool,
+    soft: bool,
+    force: bool,
+    search_query: str = "*",
+    entity_type: str = "dataset",
+    env: Optional[str] = None,
+    platform: Optional[str] = None,
+) -> DeletionResult:
+    session, gms_host = cli_utils.get_session_and_host()
+    logger.info(f"datahub configured with {gms_host}")
+    emitter = rest_emitter.DatahubRestEmitter(gms_server=gms_host)
+    batch_deletion_result = DeletionResult()
+    urns = [
+        u
+        for u in cli_utils.get_urns_by_filter(
+            env=env,
+            platform=platform,
+            search_query=search_query,
+            entity_type=entity_type,
+        )
+    ]
+    logger.info(
+        f"Filter matched {len(urns)} entities. Sample: {choices(urns, k=min(5, len(urns)))}"
+    )
+    if not force:
+        click.confirm(
+            f"This will delete {len(urns)} entities. Are you sure?", abort=True
+        )
+
+    for urn in progressbar.progressbar(urns, redirect_stdout=True):
+        one_result = delete_one_urn(
+            urn,
+            soft=soft,
+            dry_run=dry_run,
+            cached_session_host=(session, gms_host),
+            cached_emitter=emitter,
+        )
+        batch_deletion_result.merge(one_result)
+    batch_deletion_result.end()
+
+    return batch_deletion_result
+
+
+def delete_one_urn(
+    urn: str,
+    soft: bool = False,
+    dry_run: bool = False,
+    cached_session_host: Optional[Tuple[sessions.Session, str]] = None,
+    cached_emitter: Optional[rest_emitter.DatahubRestEmitter] = None,
+) -> DeletionResult:
+    deletion_result = DeletionResult()
+    deletion_result.num_entities = 1
+    deletion_result.num_records = UNKNOWN_NUM_RECORDS  # Default is unknown
+
+    if soft:
+        # Add removed aspect
+        if not cached_emitter:
+            _, gms_host = cli_utils.get_session_and_host()
+            emitter = rest_emitter.DatahubRestEmitter(gms_server=gms_host)
+        else:
+            emitter = cached_emitter
+        if not dry_run:
+            emitter.emit_mcp(
+                MetadataChangeProposalWrapper(
+                    entityType="dataset",
+                    changeType=ChangeTypeClass.UPSERT,
+                    entityUrn=urn,
+                    aspectName="status",
+                    aspect=StatusClass(removed=True),
+                )
+            )
+        else:
+            logger.info(f"[Dry-run] Would soft-delete {urn}")
+    else:
+        if not dry_run:
+            payload_obj = {"urn": urn}
+            urn, rows_affected = cli_utils.post_delete_endpoint(
+                payload_obj,
+                "/entities?action=delete",
+                cached_session_host=cached_session_host,
+            )
+            deletion_result.num_records = rows_affected
+        else:
+            logger.info(f"[Dry-run] Would hard-delete {urn}")
+            deletion_result.num_records = UNKNOWN_NUM_RECORDS  # since we don't know how many rows will be affected
+
+    deletion_result.end()
+    return deletion_result

--- a/metadata-ingestion/src/datahub/cli/get_cli.py
+++ b/metadata-ingestion/src/datahub/cli/get_cli.py
@@ -1,0 +1,26 @@
+import json
+import logging
+from typing import Any, List, Optional
+
+import click
+
+from datahub.cli.cli_utils import get_entity
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(
+    name="get",
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    ),
+)
+@click.option("--urn", required=False, type=str)
+@click.option("-a", "--aspect", required=False, multiple=True, type=str)
+@click.pass_context
+def get(ctx: Any, urn: Optional[str], aspect: List[str]) -> None:
+    if urn is None:
+        urn = ctx.args[0]
+        logger.debug(f"Using urn from args {urn}")
+    click.echo(json.dumps(get_entity(urn=urn, aspect=aspect), sort_keys=True, indent=2))

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -10,6 +10,7 @@ from datahub.cli.check_cli import check
 from datahub.cli.cli_utils import DATAHUB_CONFIG_PATH, write_datahub_config
 from datahub.cli.delete_cli import delete
 from datahub.cli.docker import docker
+from datahub.cli.get_cli import get
 from datahub.cli.ingest_cli import ingest
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,7 @@ datahub.add_command(check)
 datahub.add_command(docker)
 datahub.add_command(ingest)
 datahub.add_command(delete)
+datahub.add_command(get)
 
 
 def main(**kwargs):

--- a/metadata-service/README.md
+++ b/metadata-service/README.md
@@ -429,9 +429,7 @@ curl 'http://localhost:8080/entities?action=ingest' -X POST --data '{
 }'
 ```
 
-To issue a hard delete, or undo a particular ingestion run, you can use the [DataHub CLI](../docs/how/delete-metadata.md). 
-
-*Note that soft deletes are coming soon to the DataHub CLI. 
+To issue a hard delete or soft-delete, or undo a particular ingestion run, you can use the [DataHub CLI](../docs/how/delete-metadata.md). 
 
 
 #### Retrieving Entities


### PR DESCRIPTION
…d dry runs

Adds support for

- soft deletes (adds removed-status)
- env deletes (delete all datasets from an env)
- search query based deletes (delete all datasets based on query match)
- dry run (don't issue the delete, just do a dry run)

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
