### PR TITLE
fix(bigquery_usage ingestion): add partition decorator to regex, move exception handling to after matching, add table snapshots

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
@@ -37,7 +37,7 @@ GCP_LOGGING_PAGE_SIZE = 1000
 
 # Handle yearly, monthly, daily, or hourly partitioning.
 # See https://cloud.google.com/bigquery/docs/partitioned-tables.
-PARTITIONED_TABLE_REGEX = re.compile(r"^(.+)_(\d{4}|\d{6}|\d{8}|\d{10})$")
+PARTITIONED_TABLE_REGEX = re.compile(r"^(.+)\$(\d{4}|\d{6}|\d{8}|\d{10})$")
 
 BQ_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 BQ_FILTER_RULE_TEMPLATE = """

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
@@ -39,6 +39,10 @@ GCP_LOGGING_PAGE_SIZE = 1000
 # See https://cloud.google.com/bigquery/docs/partitioned-tables.
 PARTITIONED_TABLE_REGEX = re.compile(r"^(.+)\$(\d{4}|\d{6}|\d{8}|\d{10})$")
 
+# Handle table snapshots
+# See https://cloud.google.com/bigquery/docs/table-snapshots-intro. 
+SNAPSHOT_TABLE_REGEX = re.compile(r"^(.+)@(\d{13})$")
+
 BQ_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 BQ_FILTER_RULE_TEMPLATE = """
 protoPayload.serviceName="bigquery.googleapis.com"
@@ -93,6 +97,15 @@ class BigQueryTableRef:
             table_name = matches.group(1)
             logger.debug(
                 f"Found partitioned table {self.table}. Using {table_name} as the table name."
+            )
+            return BigQueryTableRef(self.project, self.dataset, table_name)
+
+        # Handle table snapshots.
+        matches = SNAPSHOT_TABLE_REGEX.match(self.table)
+        if matches:
+            table_name = matches.group(1)
+            logger.debug(
+                f"Found table snapshot {self.table}. Using {table_name} as the table name."
             )
             return BigQueryTableRef(self.project, self.dataset, table_name)
         

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
@@ -87,14 +87,6 @@ class BigQueryTableRef:
         return self.dataset.startswith("_")
 
     def remove_extras(self) -> "BigQueryTableRef":
-        invalid_chars_in_table_name: List[str] = [
-            c for c in {"$", "@"} if c in self.table
-        ]
-        if invalid_chars_in_table_name:
-            raise ValueError(
-                f"Cannot handle {self} - poorly formatted table name, contains {invalid_chars_in_table_name}"
-            )
-
         # Handle partitioned and sharded tables.
         matches = PARTITIONED_TABLE_REGEX.match(self.table)
         if matches:
@@ -103,6 +95,15 @@ class BigQueryTableRef:
                 f"Found partitioned table {self.table}. Using {table_name} as the table name."
             )
             return BigQueryTableRef(self.project, self.dataset, table_name)
+        
+        # Handle exceptions
+        invalid_chars_in_table_name: List[str] = [
+            c for c in {"$", "@"} if c in self.table
+        ]
+        if invalid_chars_in_table_name:
+            raise ValueError(
+                f"Cannot handle {self} - poorly formatted table name, contains {invalid_chars_in_table_name}"
+            )
 
         return self
 

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
@@ -40,7 +40,7 @@ GCP_LOGGING_PAGE_SIZE = 1000
 PARTITIONED_TABLE_REGEX = re.compile(r"^(.+)\$(\d{4}|\d{6}|\d{8}|\d{10})$")
 
 # Handle table snapshots
-# See https://cloud.google.com/bigquery/docs/table-snapshots-intro. 
+# See https://cloud.google.com/bigquery/docs/table-snapshots-intro.
 SNAPSHOT_TABLE_REGEX = re.compile(r"^(.+)@(\d{13})$")
 
 BQ_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
@@ -108,7 +108,7 @@ class BigQueryTableRef:
                 f"Found table snapshot {self.table}. Using {table_name} as the table name."
             )
             return BigQueryTableRef(self.project, self.dataset, table_name)
-        
+
         # Handle exceptions
         invalid_chars_in_table_name: List[str] = [
             c for c in {"$", "@"} if c in self.table


### PR DESCRIPTION
## Summary
changes to bigquery_usage ingestion:
- fix: add partition decorator to partitioned table regex
- refactor: move invalid table exception handling to after regex matching
- feat: add bigquery table snapshot handling

### Details
#### fix(ingestion): add partition decorator to partitioned table regex
- Add partition decorator `$` to regex 
- Documentation: https://cloud.google.com/bigquery/docs/managing-partitioned-table-data

#### refactor(ingestion): move invalid table exception handling to after regex matching
- Check for partitioned table matching (and table snapshot matching) before handling exceptions that don't match

#### feat(ingestion): add bigquery table snapshot handling
- Add bigquery table snapshot regex and matching
- Documentation: https://cloud.google.com/bigquery/docs/table-snapshots-intro

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
