### PR TITLE
fix(ingest): restrict botocore version to fix urllib3 build issue

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -64,7 +64,10 @@ sql_common = {
 
 aws_common = {
     # AWS Python SDK
-    "boto3"
+    "boto3",
+    # Deal with a version incompatibility between botocore (used by boto3) and urllib3.
+    # See https://github.com/boto/botocore/pull/2563.
+    "botocore!=1.23.0",
 }
 
 looker_common = {
@@ -103,7 +106,7 @@ plugins: Dict[str, Set[str]] = {
         "acryl-pyhive[hive]>=0.6.11"
     },
     "kafka": kafka_common,
-    "kafka-connect": sql_common | {"requests","JPype1"},
+    "kafka-connect": sql_common | {"requests", "JPype1"},
     "ldap": {"python-ldap>=2.4"},
     "looker": looker_common,
     "lookml": looker_common | {"lkml>=1.1.0", "sql-metadata==2.2.2"},
@@ -219,7 +222,7 @@ dev_requirements_airflow_1 = {
     "apache-airflow==1.10.15",
     "apache-airflow-backport-providers-snowflake",
     "snowflake-sqlalchemy<=1.2.4",  # make constraint consistent with extras
-    "WTForms==2.3.3", # make constraint consistent with extras
+    "WTForms==2.3.3",  # make constraint consistent with extras
 }
 
 full_test_dev_requirements = {
@@ -236,7 +239,7 @@ full_test_dev_requirements = {
             "mariadb",
             "snowflake",
             "redash",
-            "kafka-connect"
+            "kafka-connect",
         ]
         for dependency in plugins[plugin]
     ),


### PR DESCRIPTION
A recent change in botocore causes issues with older versions of urllib3. A fix has already been merged into the library here https://github.com/boto/botocore/pull/2563, so we simply need to restrict the versions we allow in our requirements.

This should fix the build, which is currently broken on master.

Also fixes setup.py formatting issues.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
