### PR TITLE
fix(glossary terms): Fix 'Glossary Term on Dataset Columns doesn't show in Related Entities'

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryTermProfile.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryTermProfile.tsx
@@ -35,7 +35,7 @@ export default function GlossaryTermProfile() {
     const glossaryTermHierarchicalName = data?.glossaryTerm?.hierarchicalName;
     const entitySearchResult = useGetEntitySearchResults(
         {
-            query: `glossaryTerms:"${glossaryTermHierarchicalName}" OR fieldGlossaryTerms:"${glossaryTermHierarchicalName}"`,
+            query: `glossaryTerms:"${glossaryTermHierarchicalName}" OR fieldGlossaryTerms:"${glossaryTermHierarchicalName}" OR editedFieldGlossaryTerms:"${glossaryTermHierarchicalName}"`,
         },
         searchTypes,
     );


### PR DESCRIPTION
Addressing https://github.com/linkedin/datahub/issues/3540


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
