### PR TITLE
[fix] Build frontend docker on build platform instead on target platform

### DIFF
--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -73,6 +73,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           file: ./docker/datahub-frontend/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/docker/datahub-frontend/Dockerfile
+++ b/docker/datahub-frontend/Dockerfile
@@ -9,7 +9,7 @@ RUN addgroup -S datahub && adduser -S datahub -G datahub
 RUN apk --no-cache --update-cache --available upgrade \
     && apk --no-cache add curl openjdk8-jre
 
-FROM node:16.13.0-alpine3.14 AS prod-build
+FROM --platform=$BUILDPLATFORM node:16.13.0-alpine3.14 AS prod-build
 
 # Upgrade Alpine and base packages
 RUN apk --no-cache --update-cache --available upgrade \


### PR DESCRIPTION
Build frontend docker on build platform instead on target platform

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
