### PR TITLE
feat(profiler): dynamically combine queries

### DIFF
--- a/metadata-ingestion/setup.cfg
+++ b/metadata-ingestion/setup.cfg
@@ -6,7 +6,9 @@ ignore =
     # Ignore: 1 blank line required before class docstring.
     D203,
     # See https://stackoverflow.com/a/57074416.
-    W503
+    W503,
+    # See https://github.com/psf/black/issues/315.
+    E203
 exclude =
     .git,
     src/datahub/metadata,

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -59,7 +59,9 @@ kafka_common = {
 sql_common = {
     # Required for all SQL sources.
     "sqlalchemy==1.3.24",
+    # Required for SQL profiling.
     "great-expectations",
+    "greenlet",
 }
 
 aws_common = {

--- a/metadata-ingestion/source_docs/sql_profiles.md
+++ b/metadata-ingestion/source_docs/sql_profiles.md
@@ -74,23 +74,24 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `profiling.enabled`                                 |          | `False`                     | Whether profiling should be done.                                                    |
 | `profiling.limit`                                   |          |                             | Max number of documents to profile. By default, profiles all documents.              |
 | `profiling.offset`                                  |          |                             | Offset in documents to profile. By default, uses no offset.                          |
-| `profiling.max_workers`                             |          | `5 * (os.cpu_count() or 4)` | Number of worker threads to use for profiling. Set to 1 to disable.                  |
+| `profiling.max_workers`                             |          | `5 * os.cpu_count()` | Number of worker threads to use for profiling. Set to 1 to disable.                  |
+| `profiling.query_combiner_enabled`      |          | `True`                       | *This feature is still experimental and can be disabled if it causes issues.* Reduces the total number of queries issued and speeds up profiling by dynamically combining SQL queries where possible. |
 | `profile_pattern.allow`                             |          | `*`                         | List of regex patterns for tables or table columns to profile. Defaults to all.      |
 | `profile_pattern.deny`                              |          |                             | List of regex patterns for tables or table columns to not profile. Defaults to none. |
 | `profile_pattern.ignoreCase`                        |          | `True`                      | Whether to ignore case sensitivity during pattern matching.                          |
-| `profile.turn_off_expensive_profiling_metrics`      |          | False                       | Whether to turn off expensive profiling or not. This turns off profiling for quantiles, distinct_value_frequencies, histogram & sample_values. This also limits maximum number of fields being profiled to 10.|
-| `profile.max_number_of_fields_to_profile`           |          | `None`                      | A positive integer that specifies the maximum number of columns to profile for any table. `None` implies all columns. The cost of profiling goes up significantly as the number of columns to profile goes up.|
-| `profile.profile_table_level_only`                  |          | False                       | Whether to perform profiling at table-level only, or include column-level profiling as well.|
-| `profile.include_field_null_count`                  |          | `True`                      | Whether to profile for the number of nulls for each column.                          |
-| `profile.include_field_min_value`                   |          | `True`                      | Whether to profile for the min value of numeric columns.                             |
-| `profile.include_field_max_value`                   |          | `True`                      | Whether to profile for the max value of numeric columns.                             |
-| `profile.include_field_mean_value`                  |          | `True`                      | Whether to profile for the mean value of numeric columns.                            |
-| `profile.include_field_median_value`                |          | `True`                      | Whether to profile for the median value of numeric columns.                          |
-| `profile.include_field_stddev_value`                |          | `True`                      | Whether to profile for the standard deviation of numeric columns.                    |
-| `profile.include_field_quantiles`                   |          | `True`                      | Whether to profile for the quantiles of numeric columns.                             |
-| `profile.include_field_distinct_value_frequencies`  |          | `True`                      | Whether to profile for distinct value frequencies.                                   |
-| `profile.include_field_histogram`                   |          | `True`                      | Whether to profile for the histogram for numeric fields.                             |
-| `profile.include_field_sample_values`               |          | `True`                      | Whether to profile for the sample values for all columns.                            |
+| `profiling.turn_off_expensive_profiling_metrics`      |          | False                       | Whether to turn off expensive profiling or not. This turns off profiling for quantiles, distinct_value_frequencies, histogram & sample_values. This also limits maximum number of fields being profiled to 10.|
+| `profiling.max_number_of_fields_to_profile`           |          | `None`                      | A positive integer that specifies the maximum number of columns to profile for any table. `None` implies all columns. The cost of profiling goes up significantly as the number of columns to profile goes up.|
+| `profiling.profile_table_level_only`                  |          | False                       | Whether to perform profiling at table-level only, or include column-level profiling as well.|
+| `profiling.include_field_null_count`                  |          | `True`                      | Whether to profile for the number of nulls for each column.                          |
+| `profiling.include_field_min_value`                   |          | `True`                      | Whether to profile for the min value of numeric columns.                             |
+| `profiling.include_field_max_value`                   |          | `True`                      | Whether to profile for the max value of numeric columns.                             |
+| `profiling.include_field_mean_value`                  |          | `True`                      | Whether to profile for the mean value of numeric columns.                            |
+| `profiling.include_field_median_value`                |          | `True`                      | Whether to profile for the median value of numeric columns.                          |
+| `profiling.include_field_stddev_value`                |          | `True`                      | Whether to profile for the standard deviation of numeric columns.                    |
+| `profiling.include_field_quantiles`                   |          | `True`                      | Whether to profile for the quantiles of numeric columns.                             |
+| `profiling.include_field_distinct_value_frequencies`  |          | `True`                      | Whether to profile for distinct value frequencies.                                   |
+| `profiling.include_field_histogram`                   |          | `True`                      | Whether to profile for the histogram for numeric fields.                             |
+| `profiling.include_field_sample_values`               |          | `True`                      | Whether to profile for the sample values for all columns.                            |
 
 ## Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -246,6 +246,7 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
         nonnull_count = self.dataset.get_column_nonnull_count(column)
         pct_unique = float(num_unique) / nonnull_count
 
+        # Adopted from Great Expectations.
         cardinality = None
         if num_unique is None or num_unique == 0 or pct_unique is None:
             cardinality = OrderedProfilerCardinality.NONE

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -2,7 +2,6 @@ import concurrent.futures
 import contextlib
 import dataclasses
 import functools
-import itertools
 import logging
 import os
 import threading
@@ -259,19 +258,14 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
             )
 
         if self.config.max_number_of_fields_to_profile is not None:
-            columns_being_dropped: List[str] = list(
-                itertools.islice(
-                    columns_to_profile,
-                    self.config.max_number_of_fields_to_profile,
-                    None,
-                )
-            )
-            columns_to_profile = list(
-                itertools.islice(
-                    columns_to_profile, self.config.max_number_of_fields_to_profile
-                )
-            )
-            if columns_being_dropped:
+            if len(columns_to_profile) > self.config.max_number_of_fields_to_profile:
+                columns_being_dropped = columns_to_profile[
+                    self.config.max_number_of_fields_to_profile :
+                ]
+                columns_to_profile = columns_to_profile[
+                    : self.config.max_number_of_fields_to_profile
+                ]
+
                 self.report.report_dropped(
                     f"The max_number_of_fields_to_profile={self.config.max_number_of_fields_to_profile} reached. Profile of columns {self.dataset_name}({', '.join(sorted(columns_being_dropped))})"
                 )

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -112,6 +112,8 @@ class GEProfilingConfig(ConfigModel):
     # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
     max_workers: int = 5 * (os.cpu_count() or 4)
 
+    query_combiner_enabled: bool = True
+
     # Hidden option - used for debugging purposes.
     catch_exceptions: bool = True
 
@@ -569,7 +571,8 @@ class DatahubGEProfiler:
         self, requests: List[GEProfilerRequest], max_workers: int
     ) -> Iterable[Tuple[GEProfilerRequest, Optional[DatasetProfileClass]]]:
         with PerfTimer() as timer, SQLAlchemyQueryCombiner(
-            catch_exceptions=self.config.catch_exceptions
+            enabled=self.config.query_combiner_enabled,
+            catch_exceptions=self.config.catch_exceptions,
         ).activate() as query_combiner:
             max_workers = min(max_workers, len(requests))
             logger.info(

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -112,6 +112,8 @@ class GEProfilingConfig(ConfigModel):
     # https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor
     max_workers: int = 5 * (os.cpu_count() or 4)
 
+    # The query combiner enables us to combine multiple queries into a single query,
+    # reducing the number of round-trips to the database and speeding up profiling.
     query_combiner_enabled: bool = True
 
     # Hidden option - used for debugging purposes.
@@ -314,6 +316,7 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
         column_spec.nonnull_count = nonnull_count
 
         unique_count = None
+        pct_unique = None
         try:
             unique_count = self.dataset.get_column_unique_count(column)
             pct_unique = float(unique_count) / nonnull_count

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -315,6 +315,8 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
     ) -> None:
         if self.config.include_field_quantiles:
             # FIXME: Eventually we'd like to switch to using the quantile method directly.
+            # However, that method seems to be throwing an error in some cases whereas
+            # this does not.
             # values = dataset.get_column_quantiles(column, tuple(quantiles))
 
             self.dataset.set_config_value("interactive_evaluation", True)

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -167,7 +167,7 @@ def _run_with_query_combiner(  # type: ignore
     def inner(
         self: "_SingleDatasetProfiler", *args: P.args, **kwargs: P.kwargs  # type: ignore
     ) -> None:
-        return self.query_combiner.run(method, *args, **kwargs)
+        return self.query_combiner.run(lambda: method(self, *args, **kwargs))
 
     return inner
 

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -5,14 +5,11 @@ import itertools
 import logging
 import os
 import threading
-import traceback
 import unittest.mock
 import uuid
-from typing import Any, ClassVar, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
-import greenlet
 import pydantic
-import sqlalchemy.engine
 from great_expectations.data_context import BaseDataContext
 from great_expectations.data_context.types.base import (
     DataContextConfig,
@@ -37,6 +34,7 @@ from datahub.metadata.schema_classes import (
     ValueFrequencyClass,
 )
 from datahub.utilities.perf_timer import PerfTimer
+from datahub.utilities.sqlalchemy_query_combiner import SQLAlchemyQueryCombiner
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -155,146 +153,6 @@ class GEProfilingConfig(ConfigModel):
                 values[max_num_fields_to_profile_key] = 10
 
         return values
-
-
-@dataclasses.dataclass
-class _QueryFuture:
-    conn: Connection
-    query: Any
-    multiparams: Any
-    params: Any
-
-    done: bool = False
-    res: Any = None
-
-
-@dataclasses.dataclass
-class _SQLAlchemyQueryCoalescenceManager:
-    # TODO this must be a singleton, should not be set up per-thread
-
-    # Without the staticmethod decorator, Python thinks that this is an instance
-    # method and attempts to bind self to it.
-    _underlying_sa_execute_method: ClassVar = staticmethod(
-        sqlalchemy.engine.Connection.execute
-    )
-
-    _allowed_single_row_query_methods: ClassVar = [
-        (
-            "great_expectations/dataset/sqlalchemy_dataset.py",
-            {
-                "get_row_count",
-                "get_column_min",
-                "get_column_max",
-                "get_column_mean",
-                "get_column_median",
-                "get_column_stdev",
-                "get_column_stdev",
-                "get_column_nonnull_count",
-                "get_column_unique_count",
-            },
-        ),
-    ]
-
-    catch_exceptions: bool
-
-    # There will be one main greenlet per thread. As such, queries will be
-    # queued according to the main greenlet's thread ID.
-    _queries_by_thread: Dict[greenlet.greenlet, List[_QueryFuture]] = {}
-
-    def _is_single_row_query_method(
-        self, stack: traceback.StackSummary, query: Any
-    ) -> bool:
-        # We'll do this the inefficient way since the arrays are pretty small.
-        for frame in stack:
-            for file_suffix, allowed_methods in self._allowed_single_row_query_methods:
-                if not frame.filename.endswith(file_suffix):
-                    continue
-                if frame.name in allowed_methods:
-                    return True
-        return False
-
-    def _get_main_greenlet(self) -> greenlet.greenlet:
-        let = greenlet.getcurrent()
-        while let.parent is not None:
-            let = let.parent
-        return let
-
-    def _get_queue(self, main_greenlet: greenlet.greenlet) -> List[_QueryFuture]:
-        assert main_greenlet.parent is None
-
-        # Because of the GIL, this operation is thread-safe. Hence, we can
-        # just add the main greenlet here without any special consideration.
-        # https://stackoverflow.com/a/6953515/5004662
-        # https://docs.python.org/3/glossary.html#term-global-interpreter-lock
-
-        return self._queries_by_thread.setdefault(main_greenlet, [])
-
-    def _handle_execute(
-        self, conn: Connection, query: Any, multiparams: Any, params: Any
-    ) -> Tuple[bool, Any]:
-        # Returns True with result if the query was handled, False if it
-        # should be executed normally using the fallback method.
-
-        # Must handle synchronously if the query was issued from the main greenlet.
-        main_greenlet = self._get_main_greenlet()
-        if greenlet.getcurrent() == main_greenlet:
-            breakpoint()
-            return False, None
-
-        # Don't attempt to handle if these are set.
-        if multiparams or params:
-            return False, None
-
-        # Attempt to match against the known single-row query methods.
-        stack = traceback.extract_stack()
-        if not self._is_single_row_query_method(stack, query):
-            return False, None
-
-        # Figure out how many columns this query returns.
-        # TODO add escape hatch
-        if not hasattr(query, "columns"):
-            return False, None
-        columns = list(query.columns)
-        assert len(columns) > 0
-
-        # Add query to the queue.
-        queue = self._get_queue(main_greenlet)
-        query_future = _QueryFuture(conn, query, multiparams, params)
-        queue.append(query_future)
-
-        # Yield control back to the main greenlet until the query is done.
-        # We assume that the main greenlet will be the one that actually executes the query.
-        while not query_future.done:
-            main_greenlet.switch()
-
-        return True, query_future.res
-
-    @contextlib.contextmanager
-    def activate(self) -> Iterator["_SQLAlchemyQueryCoalescenceManager"]:
-        def _sa_execute_fake(conn, query, *args, **kwargs):
-            try:
-                handled, result = self._handle_execute(conn, query, args, kwargs)
-            except Exception as e:
-                if not self.catch_exceptions:
-                    raise e
-                logger.exception(
-                    f"Failed to execute query normally, using fallback: {str(query)}"
-                )
-                return self._underlying_sa_execute_method(conn, query, *args, **kwargs)
-            else:
-                if handled:
-                    logger.info(f"Query was handled: {str(query)}")
-                    return result
-                else:
-                    logger.info(f"Executing query normally: {str(query)}")
-                    return self._underlying_sa_execute_method(
-                        conn, query, *args, **kwargs
-                    )
-
-        with unittest.mock.patch(
-            "sqlalchemy.engine.Connection.execute", _sa_execute_fake
-        ):
-            yield self
 
 
 @dataclasses.dataclass
@@ -652,7 +510,7 @@ class DatahubGEProfiler:
     def generate_profiles(
         self, requests: List[GEProfilerRequest], max_workers: int
     ) -> Iterable[Tuple[GEProfilerRequest, Optional[DatasetProfileClass]]]:
-        with PerfTimer() as timer, _SQLAlchemyQueryCoalescenceManager(
+        with PerfTimer() as timer, SQLAlchemyQueryCombiner(
             catch_exceptions=self.config.catch_exceptions
         ).activate() as query_combiner:
             max_workers = min(max_workers, len(requests))
@@ -683,7 +541,7 @@ class DatahubGEProfiler:
 
     def _generate_profile_from_request(
         self,
-        query_combiner: _SQLAlchemyQueryCoalescenceManager,
+        query_combiner: SQLAlchemyQueryCombiner,
         request: GEProfilerRequest,
     ) -> Tuple[GEProfilerRequest, Optional[DatasetProfileClass]]:
         return request, self._generate_single_profile(
@@ -694,7 +552,7 @@ class DatahubGEProfiler:
 
     def _generate_single_profile(
         self,
-        query_combiner: _SQLAlchemyQueryCoalescenceManager,
+        query_combiner: SQLAlchemyQueryCombiner,
         pretty_name: str,
         schema: str = None,
         table: str = None,

--- a/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/ge_data_profiler.py
@@ -68,8 +68,6 @@ def _inject_connection_into_datasource(conn: Connection) -> Iterator[None]:
         with unittest.mock.patch(
             "great_expectations.datasource.sqlalchemy_datasource.SqlAlchemyDatasource.__init__",
             sqlalchemy_datasource_init,
-        ), unittest.mock.patch(
-            "great_expectations.data_context.store.validations_store.ValidationsStore.set"
         ):
             yield
 
@@ -335,7 +333,9 @@ class _SingleDatasetProfiler(BasicDatasetProfilerBase):
                 type_ = self._get_column_type(column)
                 cardinality = self._get_column_cardinality(column)
 
-                columns_profiling_queue.append((column, column_profile, type_, cardinality))
+                columns_profiling_queue.append(
+                    (column, column_profile, type_, cardinality)
+                )
 
         row_count = self.dataset.get_row_count()
         profile.rowCount = row_count
@@ -519,7 +519,7 @@ class DatahubGEProfiler:
             ) as async_executor:
                 async_profiles = [
                     async_executor.submit(
-                        self.generate_profile_from_request,
+                        self._generate_profile_from_request,
                         request,
                     )
                     for request in requests
@@ -535,15 +535,15 @@ class DatahubGEProfiler:
                 f"Profiling {len(requests)} table(s) finished in {(timer.elapsed_seconds()):.3f} seconds"
             )
 
-    def generate_profile_from_request(
+    def _generate_profile_from_request(
         self, request: GEProfilerRequest
     ) -> Tuple[GEProfilerRequest, Optional[DatasetProfileClass]]:
-        return request, self.generate_profile(
+        return request, self._generate_single_profile(
             request.pretty_name,
             **request.batch_kwargs,
         )
 
-    def generate_profile(
+    def _generate_single_profile(
         self,
         pretty_name: str,
         schema: str = None,

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -120,7 +120,7 @@ class SQLAlchemyQueryCombiner:
     enabled: bool
     catch_exceptions: bool
     is_single_row_query_method: Callable[[Any], bool]
-    serial_execution_fallback_enabled: bool = True
+    serial_execution_fallback_enabled: bool
 
     # There will be one main greenlet per thread. As such, queries will be
     # queued according to the main greenlet's thread ID. We also keep track
@@ -218,10 +218,10 @@ class SQLAlchemyQueryCombiner:
                 return _sa_execute_underlying_method(conn, query, *args, **kwargs)
             else:
                 if handled:
-                    logger.info(f"Query was handled: {str(query)}")
+                    logger.debug(f"Query was handled: {str(query)}")
                     return result
                 else:
-                    logger.info(f"Executing query normally: {str(query)}")
+                    logger.debug(f"Executing query normally: {str(query)}")
                     return _sa_execute_underlying_method(conn, query, *args, **kwargs)
 
         with _sa_execute_method_patching_lock:
@@ -271,7 +271,7 @@ class SQLAlchemyQueryCombiner:
             for cte in ctes.values():
                 combined_query.append_from(cte)
 
-            logger.info(f"Executing combined query: {str(combined_query)}")
+            logger.debug(f"Executing combined query: {str(combined_query)}")
             sa_res = _sa_execute_underlying_method(queue_item.conn, combined_query)
 
             # Fetch the results and ensure that exactly one row is returned.
@@ -304,7 +304,7 @@ class SQLAlchemyQueryCombiner:
             if query_future.done:
                 continue
 
-            logger.info(f"Executing query via fallback: {str(query_future.query)}")
+            logger.debug(f"Executing query via fallback: {str(query_future.query)}")
             try:
                 res = _sa_execute_underlying_method(
                     query_future.conn,

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -1,0 +1,154 @@
+import contextlib
+import dataclasses
+import logging
+import traceback
+import unittest.mock
+from typing import Any, ClassVar, Dict, Iterator, List, Tuple
+
+import greenlet
+import sqlalchemy.engine
+from sqlalchemy.engine import Connection
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class _QueryFuture:
+    conn: Connection
+    query: Any
+    multiparams: Any
+    params: Any
+
+    done: bool = False
+    res: Any = None
+
+
+@dataclasses.dataclass
+class SQLAlchemyQueryCombiner:
+    # TODO this must be a singleton, should not be set up per-thread
+
+    # Without the staticmethod decorator, Python thinks that this is an instance
+    # method and attempts to bind self to it.
+    _underlying_sa_execute_method: ClassVar = staticmethod(
+        sqlalchemy.engine.Connection.execute
+    )
+
+    _allowed_single_row_query_methods: ClassVar = [
+        (
+            "great_expectations/dataset/sqlalchemy_dataset.py",
+            {
+                "get_row_count",
+                "get_column_min",
+                "get_column_max",
+                "get_column_mean",
+                "get_column_median",
+                "get_column_stdev",
+                "get_column_stdev",
+                "get_column_nonnull_count",
+                "get_column_unique_count",
+            },
+        ),
+    ]
+
+    catch_exceptions: bool
+
+    # There will be one main greenlet per thread. As such, queries will be
+    # queued according to the main greenlet's thread ID.
+    _queries_by_thread: Dict[greenlet.greenlet, List[_QueryFuture]] = {}
+
+    def _is_single_row_query_method(
+        self, stack: traceback.StackSummary, query: Any
+    ) -> bool:
+        # We'll do this the inefficient way since the arrays are pretty small.
+        for frame in stack:
+            for file_suffix, allowed_methods in self._allowed_single_row_query_methods:
+                if not frame.filename.endswith(file_suffix):
+                    continue
+                if frame.name in allowed_methods:
+                    return True
+        return False
+
+    def _get_main_greenlet(self) -> greenlet.greenlet:
+        let = greenlet.getcurrent()
+        while let.parent is not None:
+            let = let.parent
+        return let
+
+    def _get_queue(self, main_greenlet: greenlet.greenlet) -> List[_QueryFuture]:
+        assert main_greenlet.parent is None
+
+        # Because of the GIL, this operation is thread-safe. Hence, we can
+        # just add the main greenlet here without any special consideration.
+        # https://stackoverflow.com/a/6953515/5004662
+        # https://docs.python.org/3/glossary.html#term-global-interpreter-lock
+
+        return self._queries_by_thread.setdefault(main_greenlet, [])
+
+    def _handle_execute(
+        self, conn: Connection, query: Any, multiparams: Any, params: Any
+    ) -> Tuple[bool, Any]:
+        # Returns True with result if the query was handled, False if it
+        # should be executed normally using the fallback method.
+
+        # Must handle synchronously if the query was issued from the main greenlet.
+        main_greenlet = self._get_main_greenlet()
+        if greenlet.getcurrent() == main_greenlet:
+            breakpoint()
+            return False, None
+
+        # Don't attempt to handle if these are set.
+        if multiparams or params:
+            return False, None
+
+        # Attempt to match against the known single-row query methods.
+        stack = traceback.extract_stack()
+        if not self._is_single_row_query_method(stack, query):
+            return False, None
+
+        # Figure out how many columns this query returns.
+        # TODO add escape hatch
+        if not hasattr(query, "columns"):
+            return False, None
+        columns = list(query.columns)
+        assert len(columns) > 0
+
+        # Add query to the queue.
+        queue = self._get_queue(main_greenlet)
+        query_future = _QueryFuture(conn, query, multiparams, params)
+        queue.append(query_future)
+
+        # Yield control back to the main greenlet until the query is done.
+        # We assume that the main greenlet will be the one that actually executes the query.
+        while not query_future.done:
+            main_greenlet.switch()
+
+        return True, query_future.res
+
+    @contextlib.contextmanager
+    def activate(self) -> Iterator["SQLAlchemyQueryCombiner"]:
+        def _sa_execute_fake(
+            conn: Connection, query: Any, *args: Any, **kwargs: Any
+        ) -> Any:
+            try:
+                handled, result = self._handle_execute(conn, query, args, kwargs)
+            except Exception as e:
+                if not self.catch_exceptions:
+                    raise e
+                logger.exception(
+                    f"Failed to execute query normally, using fallback: {str(query)}"
+                )
+                return self._underlying_sa_execute_method(conn, query, *args, **kwargs)
+            else:
+                if handled:
+                    logger.info(f"Query was handled: {str(query)}")
+                    return result
+                else:
+                    logger.info(f"Executing query normally: {str(query)}")
+                    return self._underlying_sa_execute_method(
+                        conn, query, *args, **kwargs
+                    )
+
+        with unittest.mock.patch(
+            "sqlalchemy.engine.Connection.execute", _sa_execute_fake
+        ):
+            yield self

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -3,13 +3,16 @@ import dataclasses
 import logging
 import traceback
 import unittest.mock
-from typing import Any, ClassVar, Dict, Iterator, List, Tuple
+from typing import Any, Callable, ClassVar, Dict, Iterator, List, Tuple
 
 import greenlet
 import sqlalchemy.engine
 from sqlalchemy.engine import Connection
+from typing_extensions import ParamSpec
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")  # type: ignore
 
 
 @dataclasses.dataclass
@@ -33,6 +36,7 @@ class SQLAlchemyQueryCombiner:
         sqlalchemy.engine.Connection.execute
     )
 
+    # TODO refactor this into argument
     _allowed_single_row_query_methods: ClassVar = [
         (
             "great_expectations/dataset/sqlalchemy_dataset.py",
@@ -152,3 +156,7 @@ class SQLAlchemyQueryCombiner:
             "sqlalchemy.engine.Connection.execute", _sa_execute_fake
         ):
             yield self
+
+    # mypy does not yet support ParamSpec. See https://github.com/python/mypy/issues/8645.
+    def run(self, method: Callable[P, None], *args: P.args, **kwargs: P.kwargs) -> None:  # type: ignore
+        pass

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -299,9 +299,12 @@ class SQLAlchemyQueryCombiner:
             logger.info(f"Executing combined query: {str(combined_query)}")
             sa_res = _sa_execute_underlying_method(queue_item.conn, combined_query)
 
-            row = sa_res.fetchone()
-            # TODO verify that only one row is returned
+            # Fetch the results and ensure that exactly one row is returned.
+            results = sa_res.fetchall()
+            assert len(results) == 1
+            row = results[0]
 
+            # Extract the results into a result for each query.
             index = 0
             for _, query_future in pending_queue.items():
                 cols = query_future.query.columns

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -169,7 +169,10 @@ class SQLAlchemyQueryCombiner:
         if greenlet.getcurrent() == main_greenlet:
             return False, None
 
-        # Don't attempt to handle if these are set.
+        # It's unclear what the expected behavior of the query combiner should
+        # be if the query has one of these set. As such, we'll just serialize these
+        # queries for now. This clause was not hit during my testing and probably
+        # doesn't do anything, but it's better to ensure correct behavior.
         if multiparams or params:
             return False, None
 

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -149,7 +149,7 @@ class SQLAlchemyQueryCombiner:
     _greenlets_by_thread: Dict[
         greenlet.greenlet, Set[greenlet.greenlet]
     ] = dataclasses.field(default_factory=lambda: collections.defaultdict(set))
-    _thread_unsafe_operation_lock = dataclasses.field(
+    _thread_unsafe_operation_lock: threading.Lock = dataclasses.field(
         default_factory=lambda: threading.Lock()
     )
 

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -193,14 +193,12 @@ class SQLAlchemyQueryCombiner:
             if query_future.done:
                 continue
 
-            breakpoint()
             res = self._underlying_sa_execute_method(
                 query_future.conn,
                 query_future.query,
-                *query_future.args,  # type: ignore
-                **query_future.kwargs,  # type: ignore
+                *query_future.multiparams,
+                **query_future.params,
             )
-            # TODO figure out typing later
 
             query_future.res = res
             query_future.done = True
@@ -214,7 +212,7 @@ class SQLAlchemyQueryCombiner:
         while pool:
             self._execute_queue(main_greenlet)
 
-            for let in pool:
+            for let in list(pool):
                 if let.dead:
                     pool.remove(let)
                 else:

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -193,6 +193,7 @@ class SQLAlchemyQueryCombiner:
             if query_future.done:
                 continue
 
+            breakpoint()
             res = self._underlying_sa_execute_method(
                 query_future.conn,
                 query_future.query,


### PR DESCRIPTION
The GE profiler issues a ton of queries that each return a single number or a single row. This PR adds support for dynamically combining these queries together at runtime, which reduces the total number of queries issued.

## Performance

Using the same testing setup as #3369 and #3510.

Small table - 9 columns, 500 rows
- previous: 8.8-10.2 seconds
- with changes: 5.4-6.4 seconds

Medium table - 16 columns, 60k rows
- previous: 17.4-18.5 seconds
- with changes: 12.2-14 seconds 

These changes really shine when `turn_off_expensive_profiling_metrics` is enabled, where it yields a 2-3x speedup.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
