### PR TITLE
fix(users): fix ownership count on user page

### DIFF
--- a/datahub-web-react/src/graphql/user.graphql
+++ b/datahub-web-react/src/graphql/user.graphql
@@ -34,6 +34,11 @@ query getUser($urn: String!, $groupsCount: Int!) {
                             description
                             email
                         }
+                        relationships(input: { types: ["IsMemberOfGroup"], direction: INCOMING }) {
+                            start
+                            count
+                            total
+                        }
                     }
                 }
             }
@@ -58,6 +63,11 @@ query getUserGroups($urn: String!, $start: Int!, $count: Int!) {
                             description
                             email
                         }
+                    }
+                    relationships(input: { types: ["IsMemberOfGroup"], direction: INCOMING }) {
+                        start
+                        count
+                        total
                     }
                 }
             }


### PR DESCRIPTION
Ownership count was not being fetched in the user graphql query.

Long term fix:
- we should make sure to cover this case in the upcoming cypress test pass on the UI

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
