### PR TITLE
fix(graphql): making glossaryTermInfo nullable in glossaryTerm.

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -685,7 +685,7 @@ type GlossaryTerm implements Entity {
     Deprecated, use properties field instead
     Details of the Glossary Term
     """
-    glossaryTermInfo: GlossaryTermInfo!
+    glossaryTermInfo: GlossaryTermInfo
 
     """
     Edges extending from this entity

--- a/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryTermProfile.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/profile/GlossaryTermProfile.tsx
@@ -90,7 +90,7 @@ export default function GlossaryTermProfile() {
             <GlossaryTermHeader
                 sourceRef={glossaryTermInfo?.sourceRef || ''}
                 sourceUrl={glossaryTermInfo?.sourceUrl as string}
-                definition={glossaryTermInfo.definition}
+                definition={glossaryTermInfo?.definition as string}
                 ownership={ownership}
             />
         );


### PR DESCRIPTION
Making the GlossaryTermInfo Nullable within GlossaryTerm. This is to make sure when there is no info returned we are not constrained to always set GlossaryTermInfo. reference: https://github.com/linkedin/datahub/blob/master/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/glossary/mappers/GlossaryTermSnapshotMapper.java#L36
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
