### PR TITLE
Run metadata-io tests in parallel

### DIFF
--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -44,6 +44,11 @@ dependencies {
   testCompile project(':test-models')
 }
 
+test {
+  // https://docs.gradle.org/current/userguide/performance.html
+  maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+}
+
 tasks.withType(Test) {
     enableAssertions = false
 }


### PR DESCRIPTION
This repeats #3358. This has been reverted accidentally by #3379.