### PR TITLE
fix(autocomplete): fix case where autocomplete interferes with search

### DIFF
--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -135,7 +135,10 @@ export const SearchBar = ({
             >
                 <StyledSearchBar
                     placeholder={placeholderText}
-                    onPressEnter={() => onSearch(filterSearchQuery(searchQuery || ''))}
+                    onPressEnter={(e) => {
+                        e.stopPropagation();
+                        onSearch(filterSearchQuery(searchQuery || ''));
+                    }}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     data-testid="search-input"


### PR DESCRIPTION
If a user presses Enter while their search query matches an autocomplete suggestion, both `onPressEnter` of the search bar and `onSelect` are triggered. Adding a `stopPropogation` call to prevent the autocomplete component's method from getting fired.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
