### PR TITLE
fix(docs): Add docs on accessing datahub CLI

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -23,6 +23,7 @@ You can easily download and run all these images and their dependencies with our
 
 DataHub Docker Images:
 
+* [linkedin/datahub-ingestion](https://hub.docker.com/r/linkedin/datahub-ingestion)
 * [linkedin/datahub-gms](https://cloud.docker.com/repository/docker/linkedin/datahub-gms/)
 * [linkedin/datahub-frontend-react](https://cloud.docker.com/repository/docker/linkedin/datahub-frontend-react/)
 * [linkedin/datahub-mae-consumer](https://cloud.docker.com/repository/docker/linkedin/datahub-mae-consumer/)

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -8,6 +8,10 @@ Read on to find out how to perform these kinds of deletes.
 
 _Note: Deleting metadata should only be done with care. Always use `--dry-run` to understand what will be deleted before proceeding. Prefer soft-deletes (`--soft`) unless you really want to nuke metadata rows. Hard deletes will actually delete rows in the primary store and recovering them will require using backups of the primary metadata store. Make sure you understand the implications of issuing soft-deletes versus hard-deletes before proceeding._ 
 
+## Accessing datahub CLI
+
+To use the datahub CLI you need to have the datahub Python package installed as explained in [Metadata Ingestion](../../metadata-ingestion/README.md) or you can use the `metadata-ingestion` docker image as explained in [Docker Images](../../docker/README.MD). In case you are using Kubernetes you can start a pod with the metadata-ingestion docker image, get in the shell of the pod and you will have the access to datahub CLI in your kubernetes cluster.
+
 ## Configuring DataHub CLI
 
 The CLI will point to localhost DataHub by default. Running

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -10,7 +10,7 @@ _Note: Deleting metadata should only be done with care. Always use `--dry-run` t
 
 ## Accessing datahub CLI
 
-To use the datahub CLI you need to have the datahub Python package installed as explained in [Metadata Ingestion](../../metadata-ingestion/README.md) or you can use the `metadata-ingestion` docker image as explained in [Docker Images](../../docker/README.md). In case you are using Kubernetes you can start a pod with the metadata-ingestion docker image, get in the shell of the pod and you will have the access to datahub CLI in your kubernetes cluster.
+To use the datahub CLI you need to have the datahub Python package installed as explained in [Metadata Ingestion](../../metadata-ingestion/README.md) or you can use the `datahub-ingestion` docker image as explained in [Docker Images](../../docker/README.md). In case you are using Kubernetes you can start a pod with the `datahub-ingestion` docker image, get in the shell of the pod and you will have the access to datahub CLI in your kubernetes cluster.
 
 ## Configuring DataHub CLI
 

--- a/docs/how/delete-metadata.md
+++ b/docs/how/delete-metadata.md
@@ -10,7 +10,7 @@ _Note: Deleting metadata should only be done with care. Always use `--dry-run` t
 
 ## Accessing datahub CLI
 
-To use the datahub CLI you need to have the datahub Python package installed as explained in [Metadata Ingestion](../../metadata-ingestion/README.md) or you can use the `metadata-ingestion` docker image as explained in [Docker Images](../../docker/README.MD). In case you are using Kubernetes you can start a pod with the metadata-ingestion docker image, get in the shell of the pod and you will have the access to datahub CLI in your kubernetes cluster.
+To use the datahub CLI you need to have the datahub Python package installed as explained in [Metadata Ingestion](../../metadata-ingestion/README.md) or you can use the `metadata-ingestion` docker image as explained in [Docker Images](../../docker/README.md). In case you are using Kubernetes you can start a pod with the metadata-ingestion docker image, get in the shell of the pod and you will have the access to datahub CLI in your kubernetes cluster.
 
 ## Configuring DataHub CLI
 


### PR DESCRIPTION
This is needed because it seems people don't know where the CLI is present for usage when datahub is deployed.

e.g. https://datahubspace.slack.com/archives/CUMUWQU66/p1637050607405700?thread_ts=1637043099.404900&cid=CUMUWQU66

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
