### PR TITLE
style(react-app): add default monospace font to font-family

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/ColumnStats.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Dataset/Stats/snapshot/ColumnStats.tsx
@@ -16,7 +16,7 @@ const StatSection = styled.div`
 `;
 
 const NameText = styled(Typography.Text)`
-    font-family: 'Roboto Mono';
+    font-family: 'Roboto Mono', monospace;
     font-weight: 600;
     font-size: 12px;
     color: ${ANTD_GRAY[9]};

--- a/datahub-web-react/src/app/entity/shared/tabs/Properties/PropertiesTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Properties/PropertiesTab.tsx
@@ -7,14 +7,14 @@ import { StyledTable } from '../../components/styled/StyledTable';
 import { useEntityData } from '../../EntityContext';
 
 const NameText = styled(Typography.Text)`
-    font-family: 'Roboto Mono';
+    font-family: 'Roboto Mono', monospace;
     font-weight: 600;
     font-size: 12px;
     color: ${ANTD_GRAY[9]};
 `;
 
 const ValueText = styled(Typography.Text)`
-    font-family: 'Roboto Mono';
+    font-family: 'Roboto Mono', monospace;
     font-weight: 400;
     font-size: 12px;
     color: ${ANTD_GRAY[8]};


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

## Description
This fixes style inconsistency where `Roboto Mono` isn't installed on the end-users machine. In this instance, it defaults to a serif font. It is defined properly in [other parts of the React App ](https://github.com/linkedin/datahub/blob/a36fefaa33df8c518faf2a9daf63c94e74bc33a1/datahub-web-react/src/app/entity/dataset/profile/schema/utils/schemaTitleRenderer.tsx#L27)codebase

`bad`
<img width="337" alt="Screen Shot 2021-11-19 at 15 16 35" src="https://user-images.githubusercontent.com/85527669/142566492-12b2af31-1cef-4383-8918-290867e84931.png">

`good`
<img width="189" alt="Screen Shot 2021-11-19 at 15 16 41" src="https://user-images.githubusercontent.com/85527669/142566488-19e3d74c-1642-4729-9cf9-cf92b82bd999.png">