### PR TITLE
feat(boot): Ingest datahub root user info on boot

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManagerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/BootstrapManagerFactory.java
@@ -5,6 +5,7 @@ import com.linkedin.gms.factory.entity.EntityServiceFactory;
 import com.linkedin.metadata.boot.steps.IngestDataPlatformInstancesStep;
 import com.linkedin.metadata.boot.steps.IngestDataPlatformsStep;
 import com.linkedin.metadata.boot.steps.IngestPoliciesStep;
+import com.linkedin.metadata.boot.steps.IngestRootUserStep;
 import com.linkedin.metadata.entity.EntityService;
 import io.ebean.EbeanServer;
 import javax.annotation.Nonnull;
@@ -32,11 +33,16 @@ public class BootstrapManagerFactory {
   @Scope("singleton")
   @Nonnull
   protected BootstrapManager createInstance() {
+    final IngestRootUserStep ingestRootUserStep = new IngestRootUserStep(_entityService);
     final IngestPoliciesStep ingestPoliciesStep = new IngestPoliciesStep(_entityService);
     final IngestDataPlatformsStep ingestDataPlatformsStep = new IngestDataPlatformsStep(_entityService);
     final IngestDataPlatformInstancesStep ingestDataPlatformInstancesStep =
         new IngestDataPlatformInstancesStep(_entityService, _server);
     return new BootstrapManager(
-        ImmutableList.of(ingestPoliciesStep, ingestDataPlatformsStep, ingestDataPlatformInstancesStep));
+        ImmutableList.of(
+            ingestRootUserStep,
+            ingestPoliciesStep,
+            ingestDataPlatformsStep,
+            ingestDataPlatformInstancesStep));
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRootUserStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRootUserStep.java
@@ -1,0 +1,70 @@
+package com.linkedin.metadata.boot.steps;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.identity.CorpUserInfo;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.boot.BootstrapStep;
+import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.metadata.entity.EntityService;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class IngestRootUserStep implements BootstrapStep {
+
+  private static final String USER_INFO_ASPECT_NAME = "corpUserInfo";
+
+  private final EntityService _entityService;
+
+  @Override
+  public String name() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public void execute() throws IOException, URISyntaxException {
+
+    final ObjectMapper mapper = new ObjectMapper();
+
+    // 1. Read from the file into JSON.
+    final JsonNode userObj = mapper.readTree(new ClassPathResource("./boot/root_user.json").getFile());
+
+    if (!userObj.isObject()) {
+      throw new RuntimeException(String.format("Found malformed root user file, expected an Object but found %s",
+          userObj.getNodeType()));
+    }
+
+    // 2. Ingest the user info if it does not yet exist.
+    final Urn urn;
+    try {
+      urn = Urn.createFromString(userObj.get("urn").asText());
+    } catch (URISyntaxException e) {
+      log.error("Malformed urn: {}", userObj.get("urn").asText());
+      throw new RuntimeException("Malformed urn", e);
+    }
+
+    if (!rootUserExists(urn)) {
+      final CorpUserInfo info =
+          RecordUtils.toRecordTemplate(CorpUserInfo.class, userObj.get("info").toString());
+      final AuditStamp aspectAuditStamp =
+          new AuditStamp().setActor(Urn.createFromString(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis());
+      _entityService.ingestAspect(urn, USER_INFO_ASPECT_NAME, info, aspectAuditStamp);
+    }
+  }
+
+  private boolean rootUserExists(Urn urn) {
+    RecordTemplate aspect = _entityService.getAspect(urn, USER_INFO_ASPECT_NAME, 0);
+    return aspect != null;
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRootUserStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRootUserStep.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
-import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.identity.CorpUserInfo;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.boot.BootstrapStep;
@@ -54,17 +53,10 @@ public class IngestRootUserStep implements BootstrapStep {
       throw new RuntimeException("Malformed urn", e);
     }
 
-    if (!rootUserExists(urn)) {
-      final CorpUserInfo info =
-          RecordUtils.toRecordTemplate(CorpUserInfo.class, userObj.get("info").toString());
-      final AuditStamp aspectAuditStamp =
-          new AuditStamp().setActor(Urn.createFromString(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis());
-      _entityService.ingestAspect(urn, USER_INFO_ASPECT_NAME, info, aspectAuditStamp);
-    }
-  }
-
-  private boolean rootUserExists(Urn urn) {
-    RecordTemplate aspect = _entityService.getAspect(urn, USER_INFO_ASPECT_NAME, 0);
-    return aspect != null;
+    final CorpUserInfo info =
+        RecordUtils.toRecordTemplate(CorpUserInfo.class, userObj.get("info").toString());
+    final AuditStamp aspectAuditStamp =
+        new AuditStamp().setActor(Urn.createFromString(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis());
+    _entityService.ingestAspect(urn, USER_INFO_ASPECT_NAME, info, aspectAuditStamp);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRootUserStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRootUserStep.java
@@ -44,7 +44,7 @@ public class IngestRootUserStep implements BootstrapStep {
           userObj.getNodeType()));
     }
 
-    // 2. Ingest the user info if it does not yet exist.
+    // 2. Ingest the user info
     final Urn urn;
     try {
       urn = Urn.createFromString(userObj.get("urn").asText());

--- a/metadata-service/war/src/main/resources/boot/root_user.json
+++ b/metadata-service/war/src/main/resources/boot/root_user.json
@@ -1,0 +1,8 @@
+{
+  "urn": "urn:li:corpuser:admin",
+  "info": {
+    "active": true,
+    "displayName": "Admin",
+    "title": "DataHub Root User"
+  }
+}

--- a/metadata-service/war/src/main/resources/boot/root_user.json
+++ b/metadata-service/war/src/main/resources/boot/root_user.json
@@ -1,8 +1,8 @@
 {
-  "urn": "urn:li:corpuser:admin",
+  "urn": "urn:li:corpuser:datahub",
   "info": {
     "active": true,
-    "displayName": "Admin",
+    "displayName": "DataHub",
     "title": "DataHub Root User"
   }
 }


### PR DESCRIPTION
This PR introduces a bootstrap step to ingest the DataHub root user, to make how we ingest the root user similar to how we ingest data platforms etc. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
