### PR TITLE
fix(search): Fix issue when query is empty

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
@@ -1,6 +1,5 @@
 package com.linkedin.datahub.graphql.resolvers.search;
 
-import com.linkedin.datahub.graphql.exception.ValidationException;
 import com.linkedin.datahub.graphql.generated.SearchInput;
 import com.linkedin.datahub.graphql.generated.SearchResults;
 import com.linkedin.datahub.graphql.resolvers.EntityTypeMapper;
@@ -14,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.datahub.graphql.resolvers.ResolverUtils.bindArgument;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 
 /**

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
@@ -35,10 +35,6 @@ public class SearchResolver implements DataFetcher<CompletableFuture<SearchResul
     final String entityName = EntityTypeMapper.getName(input.getType());
     // escape forward slash since it is a reserved character in Elasticsearch
     final String sanitizedQuery = ResolverUtils.escapeForwardSlash(input.getQuery());
-    if (isBlank(sanitizedQuery)) {
-      log.error("'query' parameter cannot was null or empty");
-      throw new ValidationException("'query' parameter cannot be null or empty");
-    }
 
     final int start = input.getStart() != null ? input.getStart() : DEFAULT_START;
     final int count = input.getCount() != null ? input.getCount() : DEFAULT_COUNT;

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
@@ -84,7 +84,8 @@ public class SearchService {
     log.debug(String.format(
         "Searching Search documents entities: %s, input: %s, postFilters: %s, sortCriterion: %s, from: %s, size: %s",
         entities, input, postFilters, sortCriterion, from, size));
-    return _allEntitiesSearchAggregatorCache.getSearcher(entities, input, postFilters, sortCriterion)
+    final String finalInput = input.isEmpty() ? "*" : input;
+    return _allEntitiesSearchAggregatorCache.getSearcher(entities, finalInput, postFilters, sortCriterion)
         .getSearchResults(from, size);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
@@ -56,7 +56,8 @@ public class SearchService {
   @Nonnull
   public SearchResult search(@Nonnull String entityName, @Nonnull String input, @Nullable Filter postFilters,
       @Nullable SortCriterion sortCriterion, int from, int size) {
-    SearchResult result = _entitySearchServiceCache.getSearcher(entityName, input, postFilters, sortCriterion)
+    final String finalInput = input.isEmpty() ? "*" : input;
+    SearchResult result = _entitySearchServiceCache.getSearcher(entityName, finalInput, postFilters, sortCriterion)
         .getSearchResults(from, size);
     try {
       return result.copy().setEntities(new SearchEntityArray(_searchRanker.rank(result.getEntities())));

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/SearchService.java
@@ -56,8 +56,7 @@ public class SearchService {
   @Nonnull
   public SearchResult search(@Nonnull String entityName, @Nonnull String input, @Nullable Filter postFilters,
       @Nullable SortCriterion sortCriterion, int from, int size) {
-    final String finalInput = input.isEmpty() ? "*" : input;
-    SearchResult result = _entitySearchServiceCache.getSearcher(entityName, finalInput, postFilters, sortCriterion)
+    SearchResult result = _entitySearchServiceCache.getSearcher(entityName, input, postFilters, sortCriterion)
         .getSearchResults(from, size);
     try {
       return result.copy().setEntities(new SearchEntityArray(_searchRanker.rank(result.getEntities())));
@@ -85,8 +84,7 @@ public class SearchService {
     log.debug(String.format(
         "Searching Search documents entities: %s, input: %s, postFilters: %s, sortCriterion: %s, from: %s, size: %s",
         entities, input, postFilters, sortCriterion, from, size));
-    final String finalInput = input.isEmpty() ? "*" : input;
-    return _allEntitiesSearchAggregatorCache.getSearcher(entities, finalInput, postFilters, sortCriterion)
+    return _allEntitiesSearchAggregatorCache.getSearcher(entities, input, postFilters, sortCriterion)
         .getSearchResults(from, size);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESSearchDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESSearchDAO.java
@@ -80,11 +80,12 @@ public class ESSearchDAO {
   @Nonnull
   public SearchResult search(@Nonnull String entityName, @Nonnull String input, @Nullable Filter postFilters,
       @Nullable SortCriterion sortCriterion, int from, int size) {
+    final String finalInput = input.isEmpty() ? "*" : input;
     Timer.Context searchRequestTimer = MetricUtils.timer(this.getClass(), "searchRequest").time();
     EntitySpec entitySpec = entityRegistry.getEntitySpec(entityName);
     // Step 1: construct the query
     final SearchRequest searchRequest =
-        SearchRequestHandler.getBuilder(entitySpec).getSearchRequest(input, postFilters, sortCriterion, from, size);
+        SearchRequestHandler.getBuilder(entitySpec).getSearchRequest(finalInput, postFilters, sortCriterion, from, size);
     searchRequest.indices(indexConvention.getIndexName(entitySpec));
     searchRequestTimer.stop();
     // Step 2: execute the query and extract results, validated against document model as well

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -243,9 +243,8 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
       @ActionParam(PARAM_COUNT) int count) {
     List<String> entityList = entities == null ? Collections.emptyList() : Arrays.asList(entities);
     log.info("GET SEARCH RESULTS ACROSS ENTITIES for {} with query {}", entityList, input);
-    final String finalInput = input.isEmpty() ? "*" : input;
     return RestliUtil.toTask(
-        () -> _searchService.searchAcrossEntities(entityList, finalInput, filter, sortCriterion, start, count),
+        () -> _searchService.searchAcrossEntities(entityList, input, filter, sortCriterion, start, count),
         "searchAcrossEntities");
   }
 

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -350,6 +350,7 @@ def test_frontend_search_datasets(frontend_session, query, min_expected_results)
     [
         ("covid", 1),
         ("sample", 3),
+        ("", 1),
     ],
 )
 @pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -300,6 +300,7 @@ def test_frontend_browse_datasets(frontend_session):
     [
         ("covid", 1),
         ("sample", 3),
+        ("", 1),
     ],
 )
 @pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])


### PR DESCRIPTION
Logic in EntityResource was bypassed as we moved to using JavaClient which did not have this logic. 
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
