### PR TITLE
fix(java client): Fix Profiling NPE + misc improvements

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/TimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/TimeseriesAspectService.java
@@ -19,7 +19,7 @@ public interface TimeseriesAspectService {
   void upsertDocument(@Nonnull String entityName, @Nonnull String aspectName, @Nonnull String docId, @Nonnull JsonNode document);
 
   List<EnvelopedAspect> getAspectValues(@Nonnull final Urn urn, @Nonnull String entityName, @Nonnull String aspectName,
-      @Nullable Long startTimeMillis, Long endTimeMillis, int limit);
+      @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, @Nullable Integer limit);
 
   /**
    * Get the aggregated metrics for the given dataset or column from a time series aspect.

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -58,6 +58,7 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String TIMESTAMP_FIELD = "timestampMillis";
   private static final String EVENT_FIELD = "event";
+  private static final Integer DEFAULT_LIMIT = 10000;
 
   private final IndexConvention _indexConvention;
   private final BulkProcessor _bulkProcessor;
@@ -127,8 +128,13 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
   }
 
   @Override
-  public List<EnvelopedAspect> getAspectValues(@Nonnull final Urn urn, @Nonnull String entityName,
-      @Nonnull String aspectName, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis, int limit) {
+  public List<EnvelopedAspect> getAspectValues(
+      @Nonnull final Urn urn,
+      @Nonnull String entityName,
+      @Nonnull String aspectName,
+      @Nullable Long startTimeMillis,
+      @Nullable Long endTimeMillis,
+      @Nullable Integer limit) {
     final BoolQueryBuilder filterQueryBuilder = ESUtils.buildFilterQuery(null);
     filterQueryBuilder.must(QueryBuilders.matchQuery("urn", urn.toString()));
     // NOTE: We are interested only in the un-exploded rows as only they carry the `event` payload.
@@ -147,7 +153,7 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
     }
     final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
     searchSourceBuilder.query(filterQueryBuilder);
-    searchSourceBuilder.size(limit);
+    searchSourceBuilder.size(limit != null ? limit : DEFAULT_LIMIT);
     searchSourceBuilder.sort(SortBuilders.fieldSort("@timestamp").order(SortOrder.DESC));
 
     final SearchRequest searchRequest = new SearchRequest();

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/EntityClient.java
@@ -166,7 +166,7 @@ public interface EntityClient {
    */
   @Nonnull
   public SearchResult searchAcrossEntities(
-      @Nullable List<String> entities,
+      @Nonnull List<String> entities,
       @Nonnull String input,
       @Nullable Filter filter,
       int start,

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -338,7 +338,6 @@ public class JavaEntityClient implements EntityClient {
         if (endTimeMillis != null) {
             response.setEndTimeMillis(endTimeMillis);
         }
-        response.setLimit(limit);
         response.setValues(new EnvelopedAspectArray(
             _timeseriesAspectService.getAspectValues(Urn.createFromString(urn), entity, aspect, startTimeMillis, endTimeMillis,
                 limit)));

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -250,7 +250,7 @@ public class JavaEntityClient implements EntityClient {
      */
     @Nonnull
     public SearchResult searchAcrossEntities(
-        @Nullable List<String> entities,
+        @Nonnull List<String> entities,
         @Nonnull String input,
         @Nullable Filter filter,
         int start,
@@ -273,7 +273,6 @@ public class JavaEntityClient implements EntityClient {
 
     public void setWritable(boolean canWrite, @Nonnull final Authentication authentication) throws RemoteInvocationException {
         _entityService.setWritable(canWrite);
-        return;
     }
 
     @Nonnull

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/RestliEntityClient.java
@@ -321,7 +321,7 @@ public class RestliEntityClient extends BaseClient implements EntityClient {
      */
     @Nonnull
     public SearchResult searchAcrossEntities(
-        @Nullable List<String> entities,
+        @Nonnull List<String> entities,
         @Nonnull String input,
         @Nullable Filter filter,
         int start,


### PR DESCRIPTION
Profiling NPE was thrown due to the nullability of the "limit" argument when fetching timeseries aspects. This bug was recently introduced (since prev release) when we ported from RestliEntityClient to JavaEntityClient

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
