### PR TITLE
fix(kafka-producer): fix debug logging

### DIFF
--- a/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/EntityKafkaMetadataEventProducer.java
+++ b/metadata-dao-impl/kafka-producer/src/main/java/com/linkedin/metadata/dao/producer/EntityKafkaMetadataEventProducer.java
@@ -88,7 +88,8 @@ public class EntityKafkaMetadataEventProducer implements EntityEventProducer {
 
     GenericRecord record;
     try {
-      log.debug(String.format(String.format("Converting Pegasus snapshot to Avro snapshot urn %s", urn),
+      log.debug(String.format("Converting Pegasus snapshot to Avro snapshot urn %s\nMetadataAuditEvent: %s",
+          urn,
           metadataAuditEvent.toString()));
       record = EventUtils.pegasusToAvroMAE(metadataAuditEvent);
     } catch (IOException e) {
@@ -121,7 +122,8 @@ public class EntityKafkaMetadataEventProducer implements EntityEventProducer {
       @Nonnull final MetadataChangeLog metadataChangeLog) {
     GenericRecord record;
     try {
-      log.debug(String.format(String.format("Converting Pegasus snapshot to Avro snapshot urn %s", urn),
+      log.debug(String.format("Converting Pegasus snapshot to Avro snapshot urn %s\nMetadataChangeLog: %s",
+          urn,
           metadataChangeLog.toString()));
       record = EventUtils.pegasusToAvroMCL(metadataChangeLog);
     } catch (IOException e) {


### PR DESCRIPTION
remove double string formatting to prevent `IllegalFormatConversionException`
when aspect urn contains formatting strings

closes: https://github.com/linkedin/datahub/issues/3625

This is just a possible proposal. Let me know if you prefer a different logging format and if you think that tests are necessary

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
