### PR TITLE
fix(ingestion): Add config to specify ca certificate path for datahub-rest sink

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/rest_emitter.py
+++ b/metadata-ingestion/src/datahub/emitter/rest_emitter.py
@@ -59,6 +59,7 @@ class DatahubRestEmitter:
         connect_timeout_sec: Optional[float] = None,
         read_timeout_sec: Optional[float] = None,
         extra_headers: Optional[Dict[str, str]] = None,
+        ca_certificate_path: Optional[str] = None,
     ):
         if ":9002" in gms_server:
             logger.warning(
@@ -83,6 +84,9 @@ class DatahubRestEmitter:
 
         if extra_headers:
             self._session.headers.update(extra_headers)
+
+        if ca_certificate_path:
+            self._session.verify = ca_certificate_path
 
         if connect_timeout_sec:
             self._connect_timeout_sec = connect_timeout_sec

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -21,6 +21,7 @@ class DatahubClientConfig(ConfigModel):
     token: Optional[str]
     timeout_sec: Optional[int]
     extra_headers: Optional[Dict[str, str]]
+    ca_certificate_path: Optional[str]
     max_threads: int = 1
 
 
@@ -33,6 +34,7 @@ class DataHubGraph(DatahubRestEmitter):
             connect_timeout_sec=self.config.timeout_sec,  # reuse timeout_sec for connect timeout
             read_timeout_sec=self.config.timeout_sec,
             extra_headers=self.config.extra_headers,
+            ca_certificate_path=self.config.ca_certificate_path,
         )
         self.test_connection()
         self.g_session = Session()

--- a/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
+++ b/metadata-ingestion/src/datahub/ingestion/sink/datahub_rest.py
@@ -41,6 +41,7 @@ class DatahubRestSink(Sink):
             connect_timeout_sec=self.config.timeout_sec,  # reuse timeout_sec for connect timeout
             read_timeout_sec=self.config.timeout_sec,
             extra_headers=self.config.extra_headers,
+            ca_certificate_path=self.config.ca_certificate_path,
         )
         self.emitter.test_connection()
         self.executor = concurrent.futures.ThreadPoolExecutor(


### PR DESCRIPTION
Add config to specify ca certificate path for datahub-rest sink

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
