### PR TITLE
fix(description): fix issue where markdown links are unclickable

### DIFF
--- a/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
+++ b/datahub-web-react/src/app/entity/dataset/profile/schema/components/SchemaDescriptionField.tsx
@@ -116,12 +116,7 @@ export default function DescriptionField({
     const showAddDescription = editable && !description;
 
     return (
-        <DescriptionContainer
-            onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-            }}
-        >
+        <DescriptionContainer>
             {expanded ? (
                 <>
                     {!!description && <DescriptionText source={description} />}


### PR DESCRIPTION
Added in https://github.com/linkedin/datahub/pull/2707. This stopProp & preventDefault does not appear do anything productive- tested a few scenarios of expanding/contracting, editing/unediting, etc. All seemed to function with these lines removed. This also allows links to work again!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
