### PR TITLE
fix(metadata-io) Adds docker engine configuration checks before running docker-based tests

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
@@ -7,10 +7,14 @@ public class DockerTestUtils {
     final private static int MIN_MEMORY_NEEDED_GB = 8;
 
     public static void checkContainerEngine(DockerClient dockerClient) {
-        final long dockerEngineMemory = dockerClient.infoCmd().exec().getMemTotal() /1024/1024/1024;
-        if ( dockerEngineMemory < MIN_MEMORY_NEEDED_GB) {
-            final String error = String.format("Total Docker memory configured: %s GB is below the minimum threshold of %d GB", dockerEngineMemory, MIN_MEMORY_NEEDED_GB);
+        final long dockerEngineMemory = dockerClient.infoCmd().exec().getMemTotal() / 1000 / 1000 / 1000;
+        if (dockerEngineMemory < MIN_MEMORY_NEEDED_GB) {
+            final String error = String.format("Total Docker memory configured: %s GB is below the minimum threshold "
+                    + "of %d GB", dockerEngineMemory, MIN_MEMORY_NEEDED_GB);
             throw new IllegalStateException(error);
         }
+    }
+
+    private DockerTestUtils() {
     }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
@@ -7,10 +7,11 @@ public class DockerTestUtils {
     final private static int MIN_MEMORY_NEEDED_GB = 8;
 
     public static void checkContainerEngine(DockerClient dockerClient) {
-        final long dockerEngineMemory = dockerClient.infoCmd().exec().getMemTotal() / 1000 / 1000 / 1000;
-        if (dockerEngineMemory < MIN_MEMORY_NEEDED_GB) {
-            final String error = String.format("Total Docker memory configured: %s GB is below the minimum threshold "
-                    + "of %d GB", dockerEngineMemory, MIN_MEMORY_NEEDED_GB);
+        final long dockerEngineMemoryBytes = dockerClient.infoCmd().exec().getMemTotal();
+        final long dockerEngineMemoryGB = dockerEngineMemoryBytes / 1000 / 1000 / 1000;
+        if (dockerEngineMemoryGB < MIN_MEMORY_NEEDED_GB) {
+            final String error = String.format("Total Docker memory configured: %s GB (%d bytes) is below the minimum threshold "
+                    + "of %d GB", dockerEngineMemoryGB, dockerEngineMemoryBytes, MIN_MEMORY_NEEDED_GB);
             throw new IllegalStateException(error);
         }
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
@@ -1,0 +1,16 @@
+package com.linkedin.metadata;
+
+import com.github.dockerjava.api.DockerClient;
+
+public class DockerTestUtils {
+
+    final private static int MIN_MEMORY_NEEDED_GB = 8;
+
+    public static void checkContainerEngine(DockerClient dockerClient) {
+        final long dockerEngineMemory = dockerClient.infoCmd().exec().getMemTotal() /1024/1024/1024;
+        if ( dockerEngineMemory < MIN_MEMORY_NEEDED_GB) {
+            final String error = String.format("Total Docker memory configured: %s GB is below the minimum threshold of %d GB", dockerEngineMemory, MIN_MEMORY_NEEDED_GB);
+            throw new IllegalStateException(error);
+        }
+    }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/DockerTestUtils.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 
 public class DockerTestUtils {
 
-    final private static int MIN_MEMORY_NEEDED_GB = 8;
+    final private static int MIN_MEMORY_NEEDED_GB = 7;
 
     public static void checkContainerEngine(DockerClient dockerClient) {
         final long dockerEngineMemoryBytes = dockerClient.infoCmd().exec().getMemTotal();

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/DgraphGraphServiceTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.search.utils.QueryUtils.EMPTY_FILTER;
 import static com.linkedin.metadata.search.utils.QueryUtils.newFilter;
 import static com.linkedin.metadata.search.utils.QueryUtils.newRelationshipFilter;
@@ -52,8 +53,8 @@ public class DgraphGraphServiceTest extends GraphServiceTestBase {
                 .withTmpFs(Collections.singletonMap("/dgraph", "rw,noexec,nosuid,size=1g"))
                 .withStartupTimeout(Duration.ofMinutes(1))
                 .withStartupAttempts(3);
+        checkContainerEngine(_container.getDockerClient());
         _container.start();
-
         Slf4jLogConsumer logConsumer = new Slf4jLogConsumer(log);
         _container.followOutput(logConsumer);
     }

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 
+import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static org.testng.Assert.assertEquals;
 
 import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.INDEX_NAME;
@@ -45,6 +46,7 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   @BeforeTest
   public void setup() {
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
     _client = buildService();

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/SearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/SearchServiceTest.java
@@ -32,6 +32,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
 import static org.testng.Assert.assertEquals;
 
@@ -57,6 +58,7 @@ public class SearchServiceTest {
     _indexConvention = new IndexConventionImpl(null);
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
     _settingsBuilder = new SettingsBuilder(Collections.emptyList());
+    checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
     _elasticSearchService = buildEntitySearchService();

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchServiceTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
 import static org.testng.Assert.assertEquals;
 
@@ -53,6 +54,7 @@ public class ElasticSearchServiceTest {
     _indexConvention = new IndexConventionImpl(null);
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
     _settingsBuilder = new SettingsBuilder(Collections.emptyList());
+    checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
     _elasticSearchService = buildService();

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
@@ -18,6 +18,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
 import static com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService.INDEX_NAME;
 import static org.testng.Assert.*;
@@ -36,6 +37,7 @@ public class ElasticSearchSystemMetadataServiceTest {
   @BeforeTest
   public void setup() {
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
     _client = buildService();

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
@@ -50,6 +50,7 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.ElasticSearchTestUtils.*;
 import static org.testng.Assert.*;
 
@@ -89,6 +90,7 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         TestEntityProfile.class.getClassLoader().getResourceAsStream("test-entity-registry.yml"));
     _indexConvention = new IndexConventionImpl(null);
     _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
     _searchClient = buildRestClient();
     _elasticSearchTimeseriesAspectService = buildService();


### PR DESCRIPTION
Adds docker engine check during docker-based tests in setup stage to validate that the system running the tests has sufficient memory resources for the successful execution of the test.

PR was tested and validated by manually changing docker engine configurations to not meeting 8GB requirements. Tests failed as expected:

<img width="1512" alt="Screenshot 2021-12-01 at 19 39 31" src="https://user-images.githubusercontent.com/3718654/144302310-c7d0ab4a-9847-4cb8-b965-b3fc51032ee4.png">

This follows a convention akin to https://github.com/linkedin/datahub/blob/2f6fca169a2bce24d5c0ccecd5a0bbe177286fdb/metadata-ingestion/src/datahub/cli/docker_check.py#L70

## Checklist
- [x ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
