### PR TITLE
fix(search): Improve search and recs performance

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/EntityCountsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/group/EntityCountsResolver.java
@@ -8,6 +8,7 @@ import com.linkedin.datahub.graphql.resolvers.EntityTypeMapper;
 import com.linkedin.entity.client.EntityClient;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -25,6 +26,7 @@ public class EntityCountsResolver implements DataFetcher<CompletableFuture<Entit
   }
 
   @Override
+  @WithSpan
   public CompletableFuture<EntityCountResults> get(final DataFetchingEnvironment environment) throws Exception {
 
     final QueryContext context = environment.getContext();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/recommendation/ListRecommendationsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/recommendation/ListRecommendationsResolver.java
@@ -21,6 +21,7 @@ import com.linkedin.metadata.recommendation.RecommendationsService;
 import com.linkedin.metadata.recommendation.SearchRequestContext;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
@@ -41,6 +42,7 @@ public class ListRecommendationsResolver implements DataFetcher<CompletableFutur
 
   private final RecommendationsService _recommendationsService;
 
+  @WithSpan
   @Override
   public CompletableFuture<ListRecommendationsResult> get(DataFetchingEnvironment environment) {
     final ListRecommendationsInput input =

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/search/SearchResolver.java
@@ -8,6 +8,7 @@ import com.linkedin.datahub.graphql.types.mappers.UrnSearchResultsMapper;
 import com.linkedin.entity.client.EntityClient;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class SearchResolver implements DataFetcher<CompletableFuture<SearchResul
   private final EntityClient _entityClient;
 
   @Override
+  @WithSpan
   public CompletableFuture<SearchResults> get(DataFetchingEnvironment environment) {
     final SearchInput input = bindArgument(environment.getArgument("input"), SearchInput.class);
     final String entityName = EntityTypeMapper.getName(input.getType());

--- a/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/datahubusage/DataHubUsageEventType.java
@@ -14,7 +14,9 @@ public enum DataHubUsageEventType {
   BROWSE_RESULT_CLICK_EVENT("BrowseResultClickEvent"),
   ENTITY_VIEW_EVENT("EntityViewEvent"),
   ENTITY_SECTION_VIEW_EVENT("EntitySectionViewEvent"),
-  ENTITY_ACTION_EVENT("EntityActionEvent");
+  ENTITY_ACTION_EVENT("EntityActionEvent"),
+  RECOMMENDATION_IMPRESSION_EVENT("RecommendationImpressionEvent"),
+  RECOMMENDATION_CLICK_EVENT("RecommendationClickEvent");
 
   private final String type;
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ESGraphWriteDAO.java
@@ -2,50 +2,33 @@ package com.linkedin.metadata.graph.elastic;
 
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
-import com.linkedin.metadata.search.elasticsearch.update.BulkListener;
-
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 
-import static com.linkedin.metadata.graph.elastic.ESGraphQueryDAO.*;
-import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.*;
+import static com.linkedin.metadata.graph.elastic.ESGraphQueryDAO.buildQuery;
+import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.INDEX_NAME;
 
 
 @Slf4j
+@RequiredArgsConstructor
 public class ESGraphWriteDAO {
-  private final BulkProcessor bulkProcessor;
-  private final IndexConvention indexConvention;
   private final RestHighLevelClient client;
-
-  public ESGraphWriteDAO(RestHighLevelClient searchClient, IndexConvention indexConvention, int bulkRequestsLimit, int bulkFlushPeriod, int numRetries,
-      long retryInterval) {
-    this.client = searchClient;
-    this.indexConvention = indexConvention;
-    this.bulkProcessor = BulkProcessor.builder(
-        (request, bulkListener) -> {
-            searchClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
-        },
-        BulkListener.getInstance())
-        .setBulkActions(bulkRequestsLimit)
-        .setFlushInterval(TimeValue.timeValueSeconds(bulkFlushPeriod))
-        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(retryInterval), numRetries))
-        .build();
-  }
+  private final IndexConvention indexConvention;
+  private final BulkProcessor bulkProcessor;
 
   /**
    * Updates or inserts the given search document.
@@ -54,28 +37,21 @@ public class ESGraphWriteDAO {
    * @param docId the ID of the document
    */
   public void upsertDocument(@Nonnull String docId, @Nonnull String document) {
-    final IndexRequest indexRequest = new IndexRequest(indexConvention.getIndexName(INDEX_NAME)).id(docId).source(document, XContentType.JSON);
-    final UpdateRequest updateRequest = new UpdateRequest(indexConvention.getIndexName(INDEX_NAME), docId).doc(document, XContentType.JSON)
-        .detectNoop(false)
-        .upsert(indexRequest);
+    final IndexRequest indexRequest =
+        new IndexRequest(indexConvention.getIndexName(INDEX_NAME)).id(docId).source(document, XContentType.JSON);
+    final UpdateRequest updateRequest =
+        new UpdateRequest(indexConvention.getIndexName(INDEX_NAME), docId).doc(document, XContentType.JSON)
+            .detectNoop(false)
+            .upsert(indexRequest);
     bulkProcessor.add(updateRequest);
   }
 
-  public BulkByScrollResponse deleteByQuery(
-      @Nullable final String sourceType,
-      @Nonnull  final Filter sourceEntityFilter,
-      @Nullable final String destinationType,
-      @Nonnull final Filter destinationEntityFilter,
-      @Nonnull final List<String> relationshipTypes,
-      @Nonnull final RelationshipFilter relationshipFilter) {
-    BoolQueryBuilder finalQuery = buildQuery(
-        sourceType,
-        sourceEntityFilter,
-        destinationType,
-        destinationEntityFilter,
-        relationshipTypes,
-        relationshipFilter
-    );
+  public BulkByScrollResponse deleteByQuery(@Nullable final String sourceType, @Nonnull final Filter sourceEntityFilter,
+      @Nullable final String destinationType, @Nonnull final Filter destinationEntityFilter,
+      @Nonnull final List<String> relationshipTypes, @Nonnull final RelationshipFilter relationshipFilter) {
+    BoolQueryBuilder finalQuery =
+        buildQuery(sourceType, sourceEntityFilter, destinationType, destinationEntityFilter, relationshipTypes,
+            relationshipFilter);
 
     DeleteByQueryRequest deleteByQueryRequest = new DeleteByQueryRequest();
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ElasticSearchGraphService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/graph/elastic/ElasticSearchGraphService.java
@@ -16,7 +16,7 @@ import com.linkedin.metadata.query.filter.CriterionArray;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
-import com.linkedin.metadata.search.elasticsearch.indexbuilder.IndexBuilder;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -51,6 +51,7 @@ public class ElasticSearchGraphService implements GraphService {
   private final IndexConvention _indexConvention;
   private final ESGraphWriteDAO _graphWriteDAO;
   private final ESGraphQueryDAO _graphReadDAO;
+  private final ESIndexBuilder _indexBuilder;
 
   private static final String DOC_DELIMETER = "--";
   public static final String INDEX_NAME = "graph_service_v1";
@@ -206,8 +207,8 @@ public class ElasticSearchGraphService implements GraphService {
   public void configure() {
     log.info("Setting up elastic graph index");
     try {
-      new IndexBuilder(searchClient, _indexConvention.getIndexName(INDEX_NAME),
-          GraphRelationshipMappingsBuilder.getMappings(), Collections.emptyMap()).buildIndex();
+      _indexBuilder.buildIndex(_indexConvention.getIndexName(INDEX_NAME),
+          GraphRelationshipMappingsBuilder.getMappings(), Collections.emptyMap());
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/RecommendationsService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/RecommendationsService.java
@@ -4,6 +4,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.recommendation.candidatesource.RecommendationSource;
 import com.linkedin.metadata.recommendation.ranker.RecommendationModuleRanker;
 import com.linkedin.metadata.utils.ConcurrencyUtils;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -49,6 +50,7 @@ public class RecommendationsService {
    * @return List of recommendation modules
    */
   @Nonnull
+  @WithSpan
   public List<RecommendationModule> listRecommendations(
       @Nonnull Urn userUrn,
       @Nonnull RecommendationRequestContext requestContext,

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/MostPopularSource.java
@@ -14,6 +14,7 @@ import com.linkedin.metadata.recommendation.ScenarioType;
 import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -73,6 +74,7 @@ public class MostPopularSource implements RecommendationSource {
   }
 
   @Override
+  @WithSpan
   public List<RecommendationContent> getRecommendations(@Nonnull Urn userUrn,
       @Nonnull RecommendationRequestContext requestContext) {
     SearchRequest searchRequest = buildSearchRequest(userUrn);

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyViewedSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecentlyViewedSource.java
@@ -14,6 +14,7 @@ import com.linkedin.metadata.recommendation.ScenarioType;
 import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -74,6 +75,7 @@ public class RecentlyViewedSource implements RecommendationSource {
   }
 
   @Override
+  @WithSpan
   public List<RecommendationContent> getRecommendations(@Nonnull Urn userUrn,
       @Nonnull RecommendationRequestContext requestContext) {
     SearchRequest searchRequest = buildSearchRequest(userUrn);

--- a/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecommendationSource.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/recommendation/candidatesource/RecommendationSource.java
@@ -6,6 +6,7 @@ import com.linkedin.metadata.recommendation.RecommendationContentArray;
 import com.linkedin.metadata.recommendation.RecommendationModule;
 import com.linkedin.metadata.recommendation.RecommendationRenderType;
 import com.linkedin.metadata.recommendation.RecommendationRequestContext;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
@@ -47,6 +48,7 @@ public interface RecommendationSource {
    * @param requestContext Context of where the recommendations are being requested
    * @return list of recommendation candidates
    */
+  @WithSpan
   List<RecommendationContent> getRecommendations(@Nonnull Urn userUrn, @Nonnull RecommendationRequestContext requestContext);
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/EntitySearchService.java
@@ -93,14 +93,14 @@ public interface EntitySearchService {
   /**
    * Returns number of documents per field value given the field and filters
    *
-   * @param entityName name of the entity
+   * @param entityName name of the entity, if empty aggregate over all entities
    * @param field the field name for aggregate
    * @param requestParams filters to apply before aggregating
    * @param limit the number of aggregations to return
    * @return
    */
   @Nonnull
-  Map<String, Long> aggregateByValue(@Nonnull String entityName, @Nonnull String field, @Nullable Filter requestParams,
+  Map<String, Long> aggregateByValue(@Nullable String entityName, @Nonnull String field, @Nullable Filter requestParams,
       int limit);
 
   /**

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchService.java
@@ -7,7 +7,7 @@ import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.SortCriterion;
 import com.linkedin.metadata.search.EntitySearchService;
 import com.linkedin.metadata.search.SearchResult;
-import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilders;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.EntityIndexBuilders;
 import com.linkedin.metadata.search.elasticsearch.query.ESBrowseDAO;
 import com.linkedin.metadata.search.elasticsearch.query.ESSearchDAO;
 import com.linkedin.metadata.search.elasticsearch.update.ESWriteDAO;
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ElasticSearchService implements EntitySearchService {
 
-  private final ESIndexBuilders indexBuilders;
+  private final EntityIndexBuilders indexBuilders;
   private final ESSearchDAO esSearchDAO;
   private final ESBrowseDAO esBrowseDAO;
   private final ESWriteDAO esWriteDAO;
@@ -87,7 +87,7 @@ public class ElasticSearchService implements EntitySearchService {
 
   @Nonnull
   @Override
-  public Map<String, Long> aggregateByValue(@Nonnull String entityName, @Nonnull String field,
+  public Map<String, Long> aggregateByValue(@Nullable String entityName, @Nonnull String field,
       @Nullable Filter requestParams, int limit) {
     log.debug("Aggregating by value: {}, field: {}, requestParams: {}, limit: {}", entityName, field, requestParams,
         limit);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/EntityIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/EntityIndexBuilder.java
@@ -5,13 +5,12 @@ import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.client.RestHighLevelClient;
 
 
 @Slf4j
 @RequiredArgsConstructor
 public class EntityIndexBuilder {
-  private final RestHighLevelClient searchClient;
+  private final ESIndexBuilder indexBuilder;
   private final EntitySpec entitySpec;
   private final SettingsBuilder settingsBuilder;
   private final String indexName;
@@ -21,6 +20,6 @@ public class EntityIndexBuilder {
     Map<String, Object> mappings = MappingsBuilder.getMappings(entitySpec);
     Map<String, Object> settings = settingsBuilder.getSettings();
 
-    new IndexBuilder(searchClient, indexName, mappings, settings).buildIndex();
+    indexBuilder.buildIndex(indexName, mappings, settings);
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/EntityIndexBuilders.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/EntityIndexBuilders.java
@@ -5,20 +5,19 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.elasticsearch.client.RestHighLevelClient;
 
 
 @RequiredArgsConstructor
-public class ESIndexBuilders {
+public class EntityIndexBuilders {
+  private final ESIndexBuilder indexBuilder;
   private final EntityRegistry entityRegistry;
-  private final RestHighLevelClient searchClient;
   private final IndexConvention indexConvention;
   private final SettingsBuilder settingsBuilder;
 
   public void buildAll() {
     for (EntitySpec entitySpec : entityRegistry.getEntitySpecs().values()) {
       try {
-        new EntityIndexBuilder(searchClient, entitySpec, settingsBuilder,
+        new EntityIndexBuilder(indexBuilder, entitySpec, settingsBuilder,
             indexConvention.getIndexName(entitySpec)).buildIndex();
       } catch (IOException e) {
         e.printStackTrace();

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/SettingsBuilder.java
@@ -28,7 +28,7 @@ public class SettingsBuilder {
         .put("normalizer", buildNormalizers())
         .put("analyzer", buildAnalyzers())
         .build());
-    return ImmutableMap.of("index", settings.build());
+    return settings.build();
   }
 
   private static Map<String, Object> buildFilters(List<String> urnStopWords) {
@@ -88,7 +88,7 @@ public class SettingsBuilder {
 
     // Analyzer for text tokenized into words (split by spaces, periods, and slashes)
     analyzers.put("word_delimited", ImmutableMap.<String, Object>builder().put("tokenizer", "main_tokenizer")
-        .put("filter", ImmutableList.of("custom_delimiter", "lowercase"))
+        .put("filter", ImmutableList.of("custom_delimiter", "lowercase", "stop"))
         .build());
 
     // Analyzer for splitting by slashes (used to get depth of browsePath)

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESSearchDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/ESSearchDAO.java
@@ -14,8 +14,6 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -61,7 +59,7 @@ public class ESSearchDAO {
       // extract results, validated against document model as well
       return SearchRequestHandler.getBuilder(entitySpec).extractResult(searchResponse, from, size);
     } catch (Exception e) {
-      log.error("Search query failed:" + e.getMessage());
+      log.error("Search query failed", e);
       throw new ESQueryException("Search query failed:", e);
     }
   }
@@ -84,8 +82,8 @@ public class ESSearchDAO {
     Timer.Context searchRequestTimer = MetricUtils.timer(this.getClass(), "searchRequest").time();
     EntitySpec entitySpec = entityRegistry.getEntitySpec(entityName);
     // Step 1: construct the query
-    final SearchRequest searchRequest =
-        SearchRequestHandler.getBuilder(entitySpec).getSearchRequest(finalInput, postFilters, sortCriterion, from, size);
+    final SearchRequest searchRequest = SearchRequestHandler.getBuilder(entitySpec)
+        .getSearchRequest(finalInput, postFilters, sortCriterion, from, size);
     searchRequest.indices(indexConvention.getIndexName(entitySpec));
     searchRequestTimer.stop();
     // Step 2: execute the query and extract results, validated against document model as well
@@ -141,23 +139,32 @@ public class ESSearchDAO {
   /**
    * Returns number of documents per field value given the field and filters
    *
-   * @param entityName name of the entity
+   * @param entityName name of the entity, if null, aggregates over all entities
    * @param field the field name for aggregate
    * @param requestParams filters to apply before aggregating
    * @param limit the number of aggregations to return
    * @return
    */
   @Nonnull
-  public Map<String, Long> aggregateByValue(@Nonnull String entityName, @Nonnull String field,
+  public Map<String, Long> aggregateByValue(@Nullable String entityName, @Nonnull String field,
       @Nullable Filter requestParams, int limit) {
-    EntitySpec entitySpec = entityRegistry.getEntitySpec(entityName);
-    final SearchRequest searchRequest =
-        SearchRequestHandler.getBuilder(entitySpec).getAggregationRequest(field, requestParams, limit);
-    searchRequest.indices(indexConvention.getIndexName(entitySpec));
-    return executeAndExtract(entitySpec, searchRequest, 0, 0).getMetadata()
-        .getAggregations()
-        .stream()
-        .findFirst().<Map<String, Long>>map(aggregationMetadata -> new HashMap<>(aggregationMetadata.getAggregations()))
-        .orElse(Collections.emptyMap());
+    final SearchRequest searchRequest = SearchRequestHandler.getAggregationRequest(field, requestParams, limit);
+    String indexName;
+    if (entityName == null) {
+      indexName = indexConvention.getAllEntityIndicesPattern();
+    } else {
+      EntitySpec entitySpec = entityRegistry.getEntitySpec(entityName);
+      indexName = indexConvention.getIndexName(entitySpec);
+    }
+    searchRequest.indices(indexName);
+
+    try (Timer.Context ignored = MetricUtils.timer(this.getClass(), "esSearch").time()) {
+      final SearchResponse searchResponse = client.search(searchRequest, RequestOptions.DEFAULT);
+      // extract results, validated against document model as well
+      return SearchRequestHandler.extractTermAggregations(searchResponse, field);
+    } catch (Exception e) {
+      log.error("Aggregation query failed", e);
+      throw new ESQueryException("Aggregation query failed:", e);
+    }
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/query/request/SearchRequestHandler.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.DoubleMap;
 import com.linkedin.data.template.LongMap;
-import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.SearchableFieldSpec;
 import com.linkedin.metadata.models.annotation.SearchableAnnotation;
@@ -20,11 +19,13 @@ import com.linkedin.metadata.search.SearchEntityArray;
 import com.linkedin.metadata.search.SearchResult;
 import com.linkedin.metadata.search.SearchResultMetadata;
 import com.linkedin.metadata.search.features.Features;
+import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.utils.SearchUtil;
 import io.opentelemetry.extension.annotations.WithSpan;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -51,6 +52,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+
 
 @Slf4j
 public class SearchRequestHandler {
@@ -96,7 +98,7 @@ public class SearchRequestHandler {
         .collect(Collectors.toSet());
   }
 
-  private BoolQueryBuilder getFilterQuery(@Nullable Filter filter) {
+  private static BoolQueryBuilder getFilterQuery(@Nullable Filter filter) {
     BoolQueryBuilder filterQuery = ESUtils.buildFilterQuery(filter);
     // Filter out entities that are marked "removed"
     filterQuery.mustNot(QueryBuilders.matchQuery("removed", true));
@@ -123,8 +125,7 @@ public class SearchRequestHandler {
 
     searchSourceBuilder.from(from);
     searchSourceBuilder.size(size);
-
-    searchSourceBuilder.query(getQuery(input));
+    searchSourceBuilder.fetchSource("urn", null);
 
     BoolQueryBuilder filterQuery = getFilterQuery(filter);
     searchSourceBuilder.query(QueryBuilders.boolQuery().must(getQuery(input)).must(filterQuery));
@@ -171,7 +172,7 @@ public class SearchRequestHandler {
    * @return {@link SearchRequest} that contains the aggregation query
    */
   @Nonnull
-  public SearchRequest getAggregationRequest(@Nonnull String field, @Nullable Filter filter, int limit) {
+  public static SearchRequest getAggregationRequest(@Nonnull String field, @Nullable Filter filter, int limit) {
     SearchRequest searchRequest = new SearchRequest();
     BoolQueryBuilder filterQuery = getFilterQuery(filter);
 
@@ -292,7 +293,7 @@ public class SearchRequestHandler {
     final SearchResultMetadata searchResultMetadata =
         new SearchResultMetadata().setAggregations(new AggregationMetadataArray());
 
-    final List<AggregationMetadata> aggregationMetadataList = extractAggregation(searchResponse);
+    final List<AggregationMetadata> aggregationMetadataList = extractAggregationMetadata(searchResponse);
     if (!aggregationMetadataList.isEmpty()) {
       searchResultMetadata.setAggregations(new AggregationMetadataArray(aggregationMetadataList));
     }
@@ -300,7 +301,7 @@ public class SearchRequestHandler {
     return searchResultMetadata;
   }
 
-  private List<AggregationMetadata> extractAggregation(@Nonnull SearchResponse searchResponse) {
+  private List<AggregationMetadata> extractAggregationMetadata(@Nonnull SearchResponse searchResponse) {
     final List<AggregationMetadata> aggregationMetadataList = new ArrayList<>();
 
     if (searchResponse.getAggregations() == null) {
@@ -322,6 +323,20 @@ public class SearchRequestHandler {
     return aggregationMetadataList;
   }
 
+  @WithSpan
+  public static Map<String, Long> extractTermAggregations(@Nonnull SearchResponse searchResponse,
+      @Nonnull String aggregationName) {
+    if (searchResponse.getAggregations() == null) {
+      return Collections.emptyMap();
+    }
+
+    Aggregation aggregation = searchResponse.getAggregations().get(aggregationName);
+    if (aggregation == null) {
+      return Collections.emptyMap();
+    }
+    return extractTermAggregations((ParsedTerms) aggregation);
+  }
+
   /**
    * Extracts term aggregations give a parsed term.
    *
@@ -329,7 +344,7 @@ public class SearchRequestHandler {
    * @return a map with aggregation key and corresponding doc counts
    */
   @Nonnull
-  private Map<String, Long> extractTermAggregations(@Nonnull ParsedTerms terms) {
+  private static Map<String, Long> extractTermAggregations(@Nonnull ParsedTerms terms) {
 
     final Map<String, Long> aggResult = new HashMap<>();
     List<? extends Terms.Bucket> bucketList = terms.getBuckets();

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/update/ESWriteDAO.java
@@ -4,8 +4,8 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import java.io.IOException;
 import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -14,33 +14,19 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetIndexResponse;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 
 
 @Slf4j
+@RequiredArgsConstructor
 public class ESWriteDAO {
 
   private final EntityRegistry entityRegistry;
   private final RestHighLevelClient searchClient;
-  private final BulkProcessor bulkProcessor;
   private final IndexConvention indexConvention;
-
-  public ESWriteDAO(EntityRegistry entityRegistry, RestHighLevelClient searchClient, IndexConvention indexConvention,
-      int bulkRequestsLimit, int bulkFlushPeriod, int numRetries, long retryInterval) {
-    this.entityRegistry = entityRegistry;
-    this.indexConvention = indexConvention;
-    this.searchClient = searchClient;
-    this.bulkProcessor = BulkProcessor.builder(
-        (request, bulkListener) -> searchClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener),
-        BulkListener.getInstance())
-        .setBulkActions(bulkRequestsLimit)
-        .setFlushInterval(TimeValue.timeValueSeconds(bulkFlushPeriod))
-        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(retryInterval), numRetries))
-        .build();
-  }
+  private final BulkProcessor bulkProcessor;
 
   /**
    * Updates or inserts the given search document.

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformer.java
@@ -1,7 +1,6 @@
 package com.linkedin.metadata.search.transformer;
 
 import com.fasterxml.jackson.databind.JsonNode;
-
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -16,6 +15,7 @@ import com.linkedin.metadata.models.annotation.SearchableAnnotation.FieldType;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -23,12 +23,14 @@ import lombok.extern.slf4j.Slf4j;
  * Class that provides a utility function that transforms the snapshot object into a search document
  */
 @Slf4j
+@RequiredArgsConstructor
 public class SearchDocumentTransformer {
 
-  private SearchDocumentTransformer() {
-  }
+  // Number of elements to index for a given array.
+  // The cap improves search speed when having fields with a large number of elements
+  private final int maxArrayLength;
 
-  public static Optional<String> transformSnapshot(
+  public Optional<String> transformSnapshot(
       final RecordTemplate snapshot,
       final EntitySpec entitySpec,
       final Boolean forDelete
@@ -44,7 +46,7 @@ public class SearchDocumentTransformer {
     return Optional.of(searchDocument.toString());
   }
 
-  public static Optional<String> transformAspect(
+  public Optional<String> transformAspect(
       final Urn urn,
       final RecordTemplate aspect,
       final AspectSpec aspectSpec,
@@ -61,7 +63,7 @@ public class SearchDocumentTransformer {
     return Optional.of(searchDocument.toString());
   }
 
-  public static void setValue(final SearchableFieldSpec fieldSpec, final List<Object> fieldValues,
+  public void setValue(final SearchableFieldSpec fieldSpec, final List<Object> fieldValues,
       final ObjectNode searchDocument, final Boolean forDelete) {
     DataSchema.Type valueType = fieldSpec.getPegasusSchema().getType();
     Optional<Object> firstValue = fieldValues.stream().findFirst();
@@ -109,14 +111,15 @@ public class SearchDocumentTransformer {
 
     if (isArray || valueType == DataSchema.Type.MAP) {
       ArrayNode arrayNode = JsonNodeFactory.instance.arrayNode();
-      fieldValues.forEach(value -> getNodeForValue(valueType, value, fieldType).ifPresent(arrayNode::add));
+      fieldValues.subList(0, Math.min(fieldValues.size(), maxArrayLength))
+          .forEach(value -> getNodeForValue(valueType, value, fieldType).ifPresent(arrayNode::add));
       searchDocument.set(fieldName, arrayNode);
     } else if (!fieldValues.isEmpty()) {
       getNodeForValue(valueType, fieldValues.get(0), fieldType).ifPresent(node -> searchDocument.set(fieldName, node));
     }
   }
 
-  private static Optional<JsonNode> getNodeForValue(final DataSchema.Type schemaFieldType, final Object fieldValue,
+  private Optional<JsonNode> getNodeForValue(final DataSchema.Type schemaFieldType, final Object fieldValue,
       final FieldType fieldType) {
     switch (schemaFieldType) {
       case BOOLEAN:

--- a/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAO.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/systemmetadata/ESSystemMetadataDAO.java
@@ -1,15 +1,14 @@
 package com.linkedin.metadata.systemmetadata;
 
 import com.google.common.collect.ImmutableList;
-import com.linkedin.metadata.search.elasticsearch.update.BulkListener;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
@@ -19,7 +18,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -33,29 +31,15 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 
-import static com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService.*;
+import static com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService.INDEX_NAME;
 
 
 @Slf4j
+@RequiredArgsConstructor
 public class ESSystemMetadataDAO {
-  private final BulkProcessor bulkProcessor;
-  private final IndexConvention indexConvention;
   private final RestHighLevelClient client;
-
-  public ESSystemMetadataDAO(RestHighLevelClient searchClient, IndexConvention indexConvention, int bulkRequestsLimit, int bulkFlushPeriod, int numRetries,
-      long retryInterval) {
-    this.client = searchClient;
-    this.indexConvention = indexConvention;
-    this.bulkProcessor = BulkProcessor.builder(
-        (request, bulkListener) -> {
-            searchClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
-        },
-        BulkListener.getInstance())
-        .setBulkActions(bulkRequestsLimit)
-        .setFlushInterval(TimeValue.timeValueSeconds(bulkFlushPeriod))
-        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(retryInterval), numRetries))
-        .build();
-  }
+  private final IndexConvention indexConvention;
+  private final BulkProcessor bulkProcessor;
 
   /**
    * Updates or inserts the given search document.
@@ -64,16 +48,16 @@ public class ESSystemMetadataDAO {
    * @param docId the ID of the document
    */
   public void upsertDocument(@Nonnull String docId, @Nonnull String document) {
-    final IndexRequest indexRequest = new IndexRequest(indexConvention.getIndexName(INDEX_NAME)).id(docId).source(document, XContentType.JSON);
-    final UpdateRequest updateRequest = new UpdateRequest(indexConvention.getIndexName(INDEX_NAME), docId).doc(document, XContentType.JSON)
-        .detectNoop(false)
-        .upsert(indexRequest);
+    final IndexRequest indexRequest =
+        new IndexRequest(indexConvention.getIndexName(INDEX_NAME)).id(docId).source(document, XContentType.JSON);
+    final UpdateRequest updateRequest =
+        new UpdateRequest(indexConvention.getIndexName(INDEX_NAME), docId).doc(document, XContentType.JSON)
+            .detectNoop(false)
+            .upsert(indexRequest);
     bulkProcessor.add(updateRequest);
   }
 
-  public DeleteResponse deleteByDocId(
-      @Nonnull final String docId
-  ) {
+  public DeleteResponse deleteByDocId(@Nonnull final String docId) {
     DeleteRequest deleteRequest = new DeleteRequest(indexConvention.getIndexName(INDEX_NAME), docId);
 
     try {
@@ -86,9 +70,7 @@ public class ESSystemMetadataDAO {
     return null;
   }
 
-  public BulkByScrollResponse deleteByUrn(
-      @Nonnull final String urn
-  ) {
+  public BulkByScrollResponse deleteByUrn(@Nonnull final String urn) {
     BoolQueryBuilder finalQuery = QueryBuilders.boolQuery();
     finalQuery.must(QueryBuilders.termQuery("urn", urn));
 
@@ -114,7 +96,8 @@ public class ESSystemMetadataDAO {
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
     BoolQueryBuilder finalQuery = QueryBuilders.boolQuery();
-    searchParams.entrySet().forEach(entry -> finalQuery.must(QueryBuilders.termQuery(entry.getKey(), entry.getValue())));
+    searchParams.entrySet()
+        .forEach(entry -> finalQuery.must(QueryBuilders.termQuery(entry.getKey(), entry.getValue())));
     searchSourceBuilder.query(finalQuery);
 
     // this is the max page size elastic will return
@@ -160,12 +143,10 @@ public class ESSystemMetadataDAO {
     bucketSort.size(pageSize);
     bucketSort.from(pageOffset);
 
-    TermsAggregationBuilder aggregation =
-        AggregationBuilders.terms("runId")
-            .field("runId")
-            .subAggregation(AggregationBuilders.max("maxTimestamp").field("lastUpdated"))
-            .subAggregation(bucketSort);
-
+    TermsAggregationBuilder aggregation = AggregationBuilders.terms("runId")
+        .field("runId")
+        .subAggregation(AggregationBuilders.max("maxTimestamp").field("lastUpdated"))
+        .subAggregation(bucketSort);
 
     searchSourceBuilder.aggregation(aggregation);
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectService.java
@@ -8,13 +8,12 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.ByteString;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.dao.exception.ESQueryException;
-import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.Filter;
-import com.linkedin.metadata.search.elasticsearch.update.BulkListener;
+import com.linkedin.metadata.search.utils.ESUtils;
 import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.metadata.timeseries.elastic.indexbuilder.MappingsBuilder;
 import com.linkedin.metadata.timeseries.elastic.indexbuilder.TimeseriesAspectIndexBuilders;
@@ -34,7 +33,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -42,7 +40,6 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -68,18 +65,11 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
 
   public ElasticSearchTimeseriesAspectService(@Nonnull RestHighLevelClient searchClient,
       @Nonnull IndexConvention indexConvention, @Nonnull TimeseriesAspectIndexBuilders indexBuilders,
-      @Nonnull EntityRegistry entityRegistry, int bulkRequestsLimit, int bulkFlushPeriod, int numRetries,
-      long retryInterval) {
+      @Nonnull EntityRegistry entityRegistry, @Nonnull BulkProcessor bulkProcessor) {
     _indexConvention = indexConvention;
     _indexBuilders = indexBuilders;
     _searchClient = searchClient;
-    _bulkProcessor = BulkProcessor.builder(
-            (request, bulkListener) -> searchClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener),
-            BulkListener.getInstance())
-        .setBulkActions(bulkRequestsLimit)
-        .setFlushInterval(TimeValue.timeValueSeconds(bulkFlushPeriod))
-        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(retryInterval), numRetries))
-        .build();
+    _bulkProcessor = bulkProcessor;
 
     _esAggregatedStatsDAO = new ESAggregatedStatsDAO(indexConvention, searchClient, entityRegistry);
   }
@@ -128,12 +118,8 @@ public class ElasticSearchTimeseriesAspectService implements TimeseriesAspectSer
   }
 
   @Override
-  public List<EnvelopedAspect> getAspectValues(
-      @Nonnull final Urn urn,
-      @Nonnull String entityName,
-      @Nonnull String aspectName,
-      @Nullable Long startTimeMillis,
-      @Nullable Long endTimeMillis,
+  public List<EnvelopedAspect> getAspectValues(@Nonnull final Urn urn, @Nonnull String entityName,
+      @Nonnull String aspectName, @Nullable Long startTimeMillis, @Nullable Long endTimeMillis,
       @Nullable Integer limit) {
     final BoolQueryBuilder filterQueryBuilder = ESUtils.buildFilterQuery(null);
     filterQueryBuilder.must(QueryBuilders.matchQuery("urn", urn.toString()));

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/indexbuilder/TimeseriesAspectIndexBuilders.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeseries/elastic/indexbuilder/TimeseriesAspectIndexBuilders.java
@@ -3,20 +3,19 @@ package com.linkedin.metadata.timeseries.elastic.indexbuilder;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
-import com.linkedin.metadata.search.elasticsearch.indexbuilder.IndexBuilder;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import java.io.IOException;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.elasticsearch.client.RestHighLevelClient;
 
 
 @Slf4j
 @RequiredArgsConstructor
 public class TimeseriesAspectIndexBuilders {
+  private final ESIndexBuilder _indexBuilder;
   private final EntityRegistry _entityRegistry;
-  private final RestHighLevelClient _searchClient;
   private final IndexConvention _indexConvention;
 
   public void buildAll() {
@@ -24,9 +23,9 @@ public class TimeseriesAspectIndexBuilders {
       for (AspectSpec aspectSpec : entitySpec.getAspectSpecs()) {
         if (aspectSpec.isTimeseries()) {
           try {
-            new IndexBuilder(_searchClient,
+            _indexBuilder.buildIndex(
                 _indexConvention.getTimeseriesAspectIndexName(entitySpec.getName(), aspectSpec.getName()),
-                MappingsBuilder.getMappings(aspectSpec), Collections.emptyMap()).buildIndex();
+                MappingsBuilder.getMappings(aspectSpec), Collections.emptyMap());
           } catch (IOException e) {
             log.error("Issue while building timeseries field index for entity {} aspect {}", entitySpec.getName(),
                 aspectSpec.getName());

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -27,16 +27,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-<<<<<<< HEAD
-import javax.annotation.Nonnull;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-
 import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
-=======
 import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.INDEX_NAME;
->>>>>>> private/dl--reduce-source
 import static org.testng.Assert.assertEquals;
 
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -8,8 +8,13 @@ import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
 import com.linkedin.metadata.query.filter.Filter;
 import com.linkedin.metadata.query.filter.RelationshipDirection;
 import com.linkedin.metadata.query.filter.RelationshipFilter;
+import com.linkedin.metadata.search.elasticsearch.ElasticSearchServiceTest;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import javax.annotation.Nonnull;
 import org.apache.http.HttpHost;
 import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.elasticsearch.client.RestClient;
@@ -22,15 +27,18 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+<<<<<<< HEAD
 import javax.annotation.Nonnull;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 
 import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
+=======
+import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.INDEX_NAME;
+>>>>>>> private/dl--reduce-source
 import static org.testng.Assert.assertEquals;
 
-import static com.linkedin.metadata.graph.elastic.ElasticSearchGraphService.INDEX_NAME;
 
 public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
 
@@ -75,8 +83,10 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   @Nonnull
   private ElasticSearchGraphService buildService() {
     ESGraphQueryDAO readDAO = new ESGraphQueryDAO(_searchClient, _indexConvention);
-    ESGraphWriteDAO writeDAO = new ESGraphWriteDAO(_searchClient, _indexConvention, 1, 1, 1, 1);
-    return new ElasticSearchGraphService(_searchClient, _indexConvention, writeDAO, readDAO);
+    ESGraphWriteDAO writeDAO =
+        new ESGraphWriteDAO(_searchClient, _indexConvention, ElasticSearchServiceTest.getBulkProcessor(_searchClient));
+    return new ElasticSearchGraphService(_searchClient, _indexConvention, writeDAO, readDAO,
+        ElasticSearchServiceTest.getIndexBuilder(_searchClient));
   }
 
   @AfterTest
@@ -85,7 +95,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   }
 
   @Override
-  protected @Nonnull GraphService getGraphService() {
+  @Nonnull
+  protected GraphService getGraphService() {
     return _client;
   }
 
@@ -107,41 +118,35 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   protected <T> void assertEqualsAnyOrder(List<T> actual, List<T> expected, Comparator<T> comparator) {
     // https://github.com/linkedin/datahub/issues/3115
     // ElasticSearchGraphService produces duplicates, which is here ignored until fixed
-    assertEquals(
-            new HashSet<>(actual),
-            new HashSet<>(expected)
-    );
+    assertEquals(new HashSet<>(actual), new HashSet<>(expected));
   }
 
   @Override
-  public void testFindRelatedEntitiesSourceEntityFilter(Filter sourceEntityFilter,
-                                                        List<String> relationshipTypes,
-                                                        RelationshipFilter relationships,
-                                                        List<RelatedEntity> expectedRelatedEntities) throws Exception {
+  public void testFindRelatedEntitiesSourceEntityFilter(Filter sourceEntityFilter, List<String> relationshipTypes,
+      RelationshipFilter relationships, List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
       // https://github.com/linkedin/datahub/issues/3114
       throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
-    super.testFindRelatedEntitiesSourceEntityFilter(sourceEntityFilter, relationshipTypes, relationships, expectedRelatedEntities);
+    super.testFindRelatedEntitiesSourceEntityFilter(sourceEntityFilter, relationshipTypes, relationships,
+        expectedRelatedEntities);
   }
 
   @Override
   public void testFindRelatedEntitiesDestinationEntityFilter(Filter destinationEntityFilter,
-                                                             List<String> relationshipTypes,
-                                                             RelationshipFilter relationships,
-                                                             List<RelatedEntity> expectedRelatedEntities) throws Exception {
+      List<String> relationshipTypes, RelationshipFilter relationships, List<RelatedEntity> expectedRelatedEntities)
+      throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
       // https://github.com/linkedin/datahub/issues/3114
       throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
-    super.testFindRelatedEntitiesDestinationEntityFilter(destinationEntityFilter, relationshipTypes, relationships, expectedRelatedEntities);
+    super.testFindRelatedEntitiesDestinationEntityFilter(destinationEntityFilter, relationshipTypes, relationships,
+        expectedRelatedEntities);
   }
 
   @Override
-  public void testFindRelatedEntitiesSourceType(String datasetType,
-                                                List<String> relationshipTypes,
-                                                RelationshipFilter relationships,
-                                                List<RelatedEntity> expectedRelatedEntities) throws Exception {
+  public void testFindRelatedEntitiesSourceType(String datasetType, List<String> relationshipTypes,
+      RelationshipFilter relationships, List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
       // https://github.com/linkedin/datahub/issues/3114
       throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
@@ -154,10 +159,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   }
 
   @Override
-  public void testFindRelatedEntitiesDestinationType(String datasetType,
-                                                     List<String> relationshipTypes,
-                                                     RelationshipFilter relationships,
-                                                     List<RelatedEntity> expectedRelatedEntities) throws Exception {
+  public void testFindRelatedEntitiesDestinationType(String datasetType, List<String> relationshipTypes,
+      RelationshipFilter relationships, List<RelatedEntity> expectedRelatedEntities) throws Exception {
     if (relationships.getDirection() == RelationshipDirection.UNDIRECTED) {
       // https://github.com/linkedin/datahub/issues/3114
       throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
@@ -166,7 +169,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
       // https://github.com/linkedin/datahub/issues/3116
       throw new SkipException("ElasticSearchGraphService does not support empty destination type");
     }
-    super.testFindRelatedEntitiesDestinationType(datasetType, relationshipTypes, relationships, expectedRelatedEntities);
+    super.testFindRelatedEntitiesDestinationType(datasetType, relationshipTypes, relationships,
+        expectedRelatedEntities);
   }
 
   @Test
@@ -177,23 +181,18 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   }
 
   @Override
-  public void testRemoveEdgesFromNode(@Nonnull Urn nodeToRemoveFrom,
-                                      @Nonnull List<String> relationTypes,
-                                      @Nonnull RelationshipFilter relationshipFilter,
-                                      List<RelatedEntity> expectedOutgoingRelatedUrnsBeforeRemove,
-                                      List<RelatedEntity> expectedIncomingRelatedUrnsBeforeRemove,
-                                      List<RelatedEntity> expectedOutgoingRelatedUrnsAfterRemove,
-                                      List<RelatedEntity> expectedIncomingRelatedUrnsAfterRemove) throws Exception {
+  public void testRemoveEdgesFromNode(@Nonnull Urn nodeToRemoveFrom, @Nonnull List<String> relationTypes,
+      @Nonnull RelationshipFilter relationshipFilter, List<RelatedEntity> expectedOutgoingRelatedUrnsBeforeRemove,
+      List<RelatedEntity> expectedIncomingRelatedUrnsBeforeRemove,
+      List<RelatedEntity> expectedOutgoingRelatedUrnsAfterRemove,
+      List<RelatedEntity> expectedIncomingRelatedUrnsAfterRemove) throws Exception {
     if (relationshipFilter.getDirection() == RelationshipDirection.UNDIRECTED) {
       // https://github.com/linkedin/datahub/issues/3114
       throw new SkipException("ElasticSearchGraphService does not implement UNDIRECTED relationship filter");
     }
-    super.testRemoveEdgesFromNode(
-            nodeToRemoveFrom,
-            relationTypes, relationshipFilter,
-            expectedOutgoingRelatedUrnsBeforeRemove, expectedIncomingRelatedUrnsBeforeRemove,
-            expectedOutgoingRelatedUrnsAfterRemove, expectedIncomingRelatedUrnsAfterRemove
-    );
+    super.testRemoveEdgesFromNode(nodeToRemoveFrom, relationTypes, relationshipFilter,
+        expectedOutgoingRelatedUrnsBeforeRemove, expectedIncomingRelatedUrnsBeforeRemove,
+        expectedOutgoingRelatedUrnsAfterRemove, expectedIncomingRelatedUrnsAfterRemove);
   }
 
   @Test
@@ -207,7 +206,8 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   @Override
   public void testConcurrentAddEdge() {
     // https://github.com/linkedin/datahub/issues/3124
-    throw new SkipException("This test is flaky for ElasticSearchGraphService, ~5% of the runs fail on a race condition");
+    throw new SkipException(
+        "This test is flaky for ElasticSearchGraphService, ~5% of the runs fail on a race condition");
   }
 
   @Test
@@ -223,5 +223,4 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
     // https://github.com/linkedin/datahub/issues/3118
     throw new SkipException("ElasticSearchGraphService produces duplicates");
   }
-
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationCandidateSourceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/recommendation/candidatesource/EntitySearchAggregationCandidateSourceTest.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.recommendation.candidatesource;
 
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.TestEntityUrn;
 import com.linkedin.common.urn.Urn;
@@ -87,18 +86,8 @@ public class EntitySearchAggregationCandidateSourceTest {
   }
 
   @Test
-  public void testWhenNonEmptyCacheReturnsEmpty() {
-    Mockito.when(_nonEmptyEntitiesCache.getNonEmptyEntities()).thenReturn(Collections.emptyList());
-    List<RecommendationContent> candidates = _valueBasedCandidateSource.getRecommendations(USER, CONTEXT);
-    assertTrue(candidates.isEmpty());
-    Mockito.verifyZeroInteractions(_entitySearchService);
-    assertFalse(_valueBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
-  }
-
-  @Test
   public void testWhenSearchServiceReturnsEmpty() {
-    Mockito.when(_nonEmptyEntitiesCache.getNonEmptyEntities()).thenReturn(ImmutableList.of("testEntity"));
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testValue"), eq(null), anyInt()))
+    Mockito.when(_entitySearchService.aggregateByValue(eq(null), eq("testValue"), eq(null), anyInt()))
         .thenReturn(Collections.emptyMap());
     List<RecommendationContent> candidates = _valueBasedCandidateSource.getRecommendations(USER, CONTEXT);
     assertTrue(candidates.isEmpty());
@@ -107,9 +96,8 @@ public class EntitySearchAggregationCandidateSourceTest {
 
   @Test
   public void testWhenSearchServiceReturnsValueResults() {
-    // One entity type, one result
-    Mockito.when(_nonEmptyEntitiesCache.getNonEmptyEntities()).thenReturn(ImmutableList.of("testEntity"));
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testValue"), eq(null), anyInt()))
+    // One result
+    Mockito.when(_entitySearchService.aggregateByValue(eq(null), eq("testValue"), eq(null), anyInt()))
         .thenReturn(ImmutableMap.of("value1", 1L));
     List<RecommendationContent> candidates = _valueBasedCandidateSource.getRecommendations(USER, CONTEXT);
     assertEquals(candidates.size(), 1);
@@ -127,8 +115,8 @@ public class EntitySearchAggregationCandidateSourceTest {
     assertEquals(params.getContentParams().getCount().longValue(), 1L);
     assertTrue(_valueBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
 
-    // One entity type, multiple result
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testValue"), eq(null), anyInt()))
+    // Multiple result
+    Mockito.when(_entitySearchService.aggregateByValue(eq(null), eq("testValue"), eq(null), anyInt()))
         .thenReturn(ImmutableMap.of("value1", 1L, "value2", 2L, "value3", 3L));
     candidates = _valueBasedCandidateSource.getRecommendations(USER, CONTEXT);
     assertEquals(candidates.size(), 2);
@@ -157,54 +145,15 @@ public class EntitySearchAggregationCandidateSourceTest {
     assertNotNull(params.getContentParams());
     assertEquals(params.getContentParams().getCount().longValue(), 2L);
     assertTrue(_valueBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
-
-    // Multiple entity type, multiple result
-    Mockito.when(_nonEmptyEntitiesCache.getNonEmptyEntities())
-        .thenReturn(ImmutableList.of("testEntity", "testEntity2"));
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testValue"), eq(null), anyInt()))
-        .thenReturn(ImmutableMap.of("value1", 1L, "value3", 3L));
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity2"), eq("testValue"), eq(null), anyInt()))
-        .thenReturn(ImmutableMap.of("value1", 3L, "value2", 2L));
-    candidates = _valueBasedCandidateSource.getRecommendations(USER, CONTEXT);
-    assertEquals(candidates.size(), 2);
-    content = candidates.get(0);
-    assertEquals(content.getValue(), "value1");
-    assertNull(content.getEntity());
-    params = content.getParams();
-    assertNotNull(params);
-    assertNotNull(params.getSearchParams());
-    assertTrue(StringUtils.isEmpty(params.getSearchParams().getQuery()));
-    assertEquals(params.getSearchParams().getFilters().size(), 1);
-    assertEquals(params.getSearchParams().getFilters().get(0),
-        new Criterion().setField("testValue").setValue("value1"));
-    assertNotNull(params.getContentParams());
-    assertEquals(params.getContentParams().getCount().longValue(), 4L);
-    content = candidates.get(1);
-    assertEquals(content.getValue(), "value3");
-    assertNull(content.getEntity());
-    params = content.getParams();
-    assertNotNull(params);
-    assertNotNull(params.getSearchParams());
-    assertTrue(StringUtils.isEmpty(params.getSearchParams().getQuery()));
-    assertEquals(params.getSearchParams().getFilters().size(), 1);
-    assertEquals(params.getSearchParams().getFilters().get(0),
-        new Criterion().setField("testValue").setValue("value3"));
-    assertNotNull(params.getContentParams());
-    assertEquals(params.getContentParams().getCount().longValue(), 3L);
-    assertTrue(_valueBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
   }
 
   @Test
   public void testWhenSearchServiceReturnsUrnResults() {
-    // One entity type, one result
-    Mockito.when(_nonEmptyEntitiesCache.getNonEmptyEntities()).thenReturn(ImmutableList.of("testEntity"));
+    // One result
     Urn testUrn1 = new TestEntityUrn("testUrn1", "testUrn1", "testUrn1");
     Urn testUrn2 = new TestEntityUrn("testUrn2", "testUrn2", "testUrn2");
     Urn testUrn3 = new TestEntityUrn("testUrn3", "testUrn3", "testUrn3");
-//    Urn testUrn1 = new TestEntityUrn("testUrn1", TestEntityUtil.getTestEntityUrn().toString(), "VALUE_1");
-//    Urn testUrn2 = new TestEntityUrn("testUrn2", TestEntityUtil.getTestEntityUrn().toString(), "VALUE_1");
-//    Urn testUrn3 = new TestEntityUrn("testUrn3", TestEntityUtil.getTestEntityUrn().toString(), "VALUE_1");
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testUrn"), eq(null), anyInt()))
+    Mockito.when(_entitySearchService.aggregateByValue(eq(null), eq("testUrn"), eq(null), anyInt()))
         .thenReturn(ImmutableMap.of(testUrn1.toString(), 1L));
     List<RecommendationContent> candidates = _urnBasedCandidateSource.getRecommendations(USER, CONTEXT);
     assertEquals(candidates.size(), 1);
@@ -222,8 +171,8 @@ public class EntitySearchAggregationCandidateSourceTest {
     assertEquals(params.getContentParams().getCount().longValue(), 1L);
     assertTrue(_urnBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
 
-    // One entity type, multiple result
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testUrn"), eq(null), anyInt()))
+    // Multiple result
+    Mockito.when(_entitySearchService.aggregateByValue(eq(null), eq("testUrn"), eq(null), anyInt()))
         .thenReturn(ImmutableMap.of(testUrn1.toString(), 1L, testUrn2.toString(), 2L, testUrn3.toString(), 3L));
     candidates = _urnBasedCandidateSource.getRecommendations(USER, CONTEXT);
     assertEquals(candidates.size(), 2);
@@ -251,41 +200,6 @@ public class EntitySearchAggregationCandidateSourceTest {
         new Criterion().setField("testUrn").setValue(testUrn2.toString()));
     assertNotNull(params.getContentParams());
     assertEquals(params.getContentParams().getCount().longValue(), 2L);
-    assertTrue(_urnBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
-
-    // Multiple entity type, multiple result
-    Mockito.when(_nonEmptyEntitiesCache.getNonEmptyEntities())
-        .thenReturn(ImmutableList.of("testEntity", "testEntity2"));
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity"), eq("testUrn"), eq(null), anyInt()))
-        .thenReturn(ImmutableMap.of(testUrn1.toString(), 1L, testUrn3.toString(), 3L));
-    Mockito.when(_entitySearchService.aggregateByValue(eq("testEntity2"), eq("testUrn"), eq(null), anyInt()))
-        .thenReturn(ImmutableMap.of(testUrn1.toString(), 3L, testUrn2.toString(), 2L));
-    candidates = _urnBasedCandidateSource.getRecommendations(USER, CONTEXT);
-    assertEquals(candidates.size(), 2);
-    content = candidates.get(0);
-    assertEquals(content.getValue(), testUrn1.toString());
-    assertEquals(content.getEntity(), testUrn1);
-    params = content.getParams();
-    assertNotNull(params);
-    assertNotNull(params.getSearchParams());
-    assertTrue(StringUtils.isEmpty(params.getSearchParams().getQuery()));
-    assertEquals(params.getSearchParams().getFilters().size(), 1);
-    assertEquals(params.getSearchParams().getFilters().get(0),
-        new Criterion().setField("testUrn").setValue(testUrn1.toString()));
-    assertNotNull(params.getContentParams());
-    assertEquals(params.getContentParams().getCount().longValue(), 4L);
-    content = candidates.get(1);
-    assertEquals(content.getValue(), testUrn3.toString());
-    assertEquals(content.getEntity(), testUrn3);
-    params = content.getParams();
-    assertNotNull(params);
-    assertNotNull(params.getSearchParams());
-    assertTrue(StringUtils.isEmpty(params.getSearchParams().getQuery()));
-    assertEquals(params.getSearchParams().getFilters().size(), 1);
-    assertEquals(params.getSearchParams().getFilters().get(0),
-        new Criterion().setField("testUrn").setValue(testUrn3.toString()));
-    assertNotNull(params.getContentParams());
-    assertEquals(params.getContentParams().getCount().longValue(), 3L);
     assertTrue(_urnBasedCandidateSource.getRecommendationModule(USER, CONTEXT).isPresent());
   }
 }

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/SearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/SearchServiceTest.java
@@ -9,7 +9,8 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
-import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilders;
+import com.linkedin.metadata.search.elasticsearch.ElasticSearchServiceTest;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.EntityIndexBuilders;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.SettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.query.ESBrowseDAO;
 import com.linkedin.metadata.search.elasticsearch.query.ESSearchDAO;
@@ -88,11 +89,13 @@ public class SearchServiceTest {
 
   @Nonnull
   private ElasticSearchService buildEntitySearchService() {
-    ESIndexBuilders indexBuilders =
-        new ESIndexBuilders(_entityRegistry, _searchClient, _indexConvention, _settingsBuilder);
+    EntityIndexBuilders indexBuilders =
+        new EntityIndexBuilders(ElasticSearchServiceTest.getIndexBuilder(_searchClient), _entityRegistry,
+            _indexConvention, _settingsBuilder);
     ESSearchDAO searchDAO = new ESSearchDAO(_entityRegistry, _searchClient, _indexConvention);
     ESBrowseDAO browseDAO = new ESBrowseDAO(_entityRegistry, _searchClient, _indexConvention);
-    ESWriteDAO writeDAO = new ESWriteDAO(_entityRegistry, _searchClient, _indexConvention, 1, 1, 1, 1);
+    ESWriteDAO writeDAO = new ESWriteDAO(_entityRegistry, _searchClient, _indexConvention,
+        ElasticSearchServiceTest.getBulkProcessor(_searchClient));
     return new ElasticSearchService(indexBuilders, searchDAO, browseDAO, writeDAO);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/transformer/SearchDocumentTransformerTest.java
@@ -22,9 +22,10 @@ public class SearchDocumentTransformerTest {
 
   @Test
   public void testTransform() throws IOException {
+    SearchDocumentTransformer searchDocumentTransformer = new SearchDocumentTransformer(1000);
     TestEntitySnapshot snapshot = TestEntityUtil.getSnapshot();
     EntitySpec testEntitySpec = TestEntitySpecBuilder.getSpec();
-    Optional<String> result = SearchDocumentTransformer.transformSnapshot(snapshot, testEntitySpec, false);
+    Optional<String> result = searchDocumentTransformer.transformSnapshot(snapshot, testEntitySpec, false);
     assertTrue(result.isPresent());
     ObjectNode parsedJson = (ObjectNode) OBJECT_MAPPER.readTree(result.get());
     assertEquals(parsedJson.get("urn").asText(), snapshot.getUrn().toString());
@@ -51,9 +52,10 @@ public class SearchDocumentTransformerTest {
 
   @Test
   public void testTransformForDelete() throws IOException {
+    SearchDocumentTransformer searchDocumentTransformer = new SearchDocumentTransformer(1000);
     TestEntitySnapshot snapshot = TestEntityUtil.getSnapshot();
     EntitySpec testEntitySpec = TestEntitySpecBuilder.getSpec();
-    Optional<String> result = SearchDocumentTransformer.transformSnapshot(snapshot, testEntitySpec, true);
+    Optional<String> result = searchDocumentTransformer.transformSnapshot(snapshot, testEntitySpec, true);
     assertTrue(result.isPresent());
     ObjectNode parsedJson = (ObjectNode) OBJECT_MAPPER.readTree(result.get());
     assertEquals(parsedJson.get("urn").asText(), snapshot.getUrn().toString());

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.systemmetadata;
 
 import com.linkedin.metadata.run.AspectRowSummary;
 import com.linkedin.metadata.run.IngestionRunSummary;
+import com.linkedin.metadata.search.elasticsearch.ElasticSearchServiceTest;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import com.linkedin.mxe.SystemMetadata;
@@ -21,7 +22,8 @@ import org.testng.annotations.Test;
 import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
 import static com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService.INDEX_NAME;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+
 
 public class ElasticSearchSystemMetadataServiceTest {
 
@@ -65,8 +67,10 @@ public class ElasticSearchSystemMetadataServiceTest {
 
   @Nonnull
   private ElasticSearchSystemMetadataService buildService() {
-    ESSystemMetadataDAO dao = new ESSystemMetadataDAO(_searchClient, _indexConvention, 1, 1, 1, 1);
-    return new ElasticSearchSystemMetadataService(_searchClient, _indexConvention, dao);
+    ESSystemMetadataDAO dao = new ESSystemMetadataDAO(_searchClient, _indexConvention,
+        ElasticSearchServiceTest.getBulkProcessor(_searchClient));
+    return new ElasticSearchSystemMetadataService(_searchClient, _indexConvention, dao,
+        ElasticSearchServiceTest.getIndexBuilder(_searchClient));
   }
 
   @AfterTest

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
@@ -20,6 +20,7 @@ import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.filter.Condition;
 import com.linkedin.metadata.query.filter.Criterion;
 import com.linkedin.metadata.query.filter.Filter;
+import com.linkedin.metadata.search.elasticsearch.ElasticSearchServiceTest;
 import com.linkedin.metadata.search.utils.QueryUtils;
 import com.linkedin.metadata.timeseries.elastic.indexbuilder.TimeseriesAspectIndexBuilders;
 import com.linkedin.metadata.timeseries.transformer.TimeseriesAspectTransformer;
@@ -50,9 +51,15 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+<<<<<<< HEAD
 import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
 import static com.linkedin.metadata.ElasticSearchTestUtils.*;
 import static org.testng.Assert.*;
+=======
+import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+>>>>>>> private/dl--reduce-source
 
 
 public class ElasticSearchTimeseriesAspectServiceTest {
@@ -114,8 +121,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
   @Nonnull
   private ElasticSearchTimeseriesAspectService buildService() {
     return new ElasticSearchTimeseriesAspectService(_searchClient, _indexConvention,
-        new TimeseriesAspectIndexBuilders(_entityRegistry, _searchClient, _indexConvention), _entityRegistry, 1, 1, 3,
-        1);
+        new TimeseriesAspectIndexBuilders(ElasticSearchServiceTest.getIndexBuilder(_searchClient), _entityRegistry,
+            _indexConvention), _entityRegistry, ElasticSearchServiceTest.getBulkProcessor(_searchClient));
   }
 
   @AfterTest
@@ -265,7 +272,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 23 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec latestStatAggregationSpec =
@@ -301,7 +309,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 23 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec latestStatAggregationSpec =
@@ -345,7 +354,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 47 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec latestStatAggregationSpec =
@@ -384,7 +394,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 9 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec latestStatAggregationSpec =
@@ -422,7 +433,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
     Criterion hasCol1 =
         new Criterion().setField("componentProfiles.key").setCondition(Condition.EQUAL).setValue("col1");
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, hasCol1, startTimeCriterion, endTimeCriterion));
+    Filter filter = QueryUtils.getFilterFromCriteria(
+        ImmutableList.of(hasUrnCriterion, hasCol1, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec latestStatAggregationSpec =
@@ -463,7 +475,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(lastEntryTimeStamp));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec latestStatAggregationSpec =
@@ -508,7 +521,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 9 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate the sum of stat value
     AggregationSpec sumAggregationSpec =
@@ -548,7 +562,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
     Criterion hasCol2 =
         new Criterion().setField("componentProfiles.key").setCondition(Condition.EQUAL).setValue("col2");
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, hasCol2, startTimeCriterion, endTimeCriterion));
+    Filter filter = QueryUtils.getFilterFromCriteria(
+        ImmutableList.of(hasUrnCriterion, hasCol2, startTimeCriterion, endTimeCriterion));
 
     // Aggregate the sum of stat value
     AggregationSpec sumStatAggregationSpec =
@@ -591,7 +606,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 23 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec cardinalityStatAggregationSpec =
@@ -626,7 +642,8 @@ public class ElasticSearchTimeseriesAspectServiceTest {
         .setCondition(Condition.LESS_THAN_OR_EQUAL_TO)
         .setValue(String.valueOf(_startTime + 23 * TIME_INCREMENT));
 
-    Filter filter = QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
+    Filter filter =
+        QueryUtils.getFilterFromCriteria(ImmutableList.of(hasUrnCriterion, startTimeCriterion, endTimeCriterion));
 
     // Aggregate on latest stat value
     AggregationSpec cardinalityStatAggregationSpec =

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
@@ -51,15 +51,10 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-<<<<<<< HEAD
 import static com.linkedin.metadata.DockerTestUtils.checkContainerEngine;
-import static com.linkedin.metadata.ElasticSearchTestUtils.*;
-import static org.testng.Assert.*;
-=======
 import static com.linkedin.metadata.ElasticSearchTestUtils.syncAfterWrite;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
->>>>>>> private/dl--reduce-source
 
 
 public class ElasticSearchTimeseriesAspectServiceTest {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MetadataChangeLogProcessor.java
@@ -11,6 +11,7 @@ import com.linkedin.gms.factory.common.GraphServiceFactory;
 import com.linkedin.gms.factory.common.SystemMetadataServiceFactory;
 import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.gms.factory.search.EntitySearchServiceFactory;
+import com.linkedin.gms.factory.search.SearchDocumentTransformerFactory;
 import com.linkedin.gms.factory.timeseries.TimeseriesAspectServiceFactory;
 import com.linkedin.metadata.EventUtils;
 import com.linkedin.metadata.extractor.FieldExtractor;
@@ -55,14 +56,15 @@ import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
-import static com.linkedin.metadata.search.utils.QueryUtils.*;
+import static com.linkedin.metadata.search.utils.QueryUtils.createRelationshipFilter;
+import static com.linkedin.metadata.search.utils.QueryUtils.newRelationshipFilter;
 
 
 @Slf4j
 @Component
 @Conditional(MetadataChangeLogProcessorCondition.class)
 @Import({GraphServiceFactory.class, EntitySearchServiceFactory.class, TimeseriesAspectServiceFactory.class,
-    EntityRegistryFactory.class, SystemMetadataServiceFactory.class})
+    EntityRegistryFactory.class, SystemMetadataServiceFactory.class, SearchDocumentTransformerFactory.class})
 @EnableKafka
 public class MetadataChangeLogProcessor {
 
@@ -71,17 +73,20 @@ public class MetadataChangeLogProcessor {
   private final TimeseriesAspectService _timeseriesAspectService;
   private final SystemMetadataService _systemMetadataService;
   private final EntityRegistry _entityRegistry;
+  private final SearchDocumentTransformer _searchDocumentTransformer;
 
   private final Histogram kafkaLagStats = MetricUtils.get().histogram(MetricRegistry.name(this.getClass(), "kafkaLag"));
 
   @Autowired
   public MetadataChangeLogProcessor(GraphService graphService, EntitySearchService entitySearchService,
-      TimeseriesAspectService timeseriesAspectService, SystemMetadataService systemMetadataService, EntityRegistry entityRegistry) {
+      TimeseriesAspectService timeseriesAspectService, SystemMetadataService systemMetadataService,
+      EntityRegistry entityRegistry, SearchDocumentTransformer searchDocumentTransformer) {
     _graphService = graphService;
     _entitySearchService = entitySearchService;
     _timeseriesAspectService = timeseriesAspectService;
     _systemMetadataService = systemMetadataService;
     _entityRegistry = entityRegistry;
+    _searchDocumentTransformer = searchDocumentTransformer;
 
     _timeseriesAspectService.configure();
   }
@@ -162,7 +167,8 @@ public class MetadataChangeLogProcessor {
     }
   }
 
-  private Pair<List<Edge>, Set<String>> getEdgesAndRelationshipTypesFromAspect(Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
+  private Pair<List<Edge>, Set<String>> getEdgesAndRelationshipTypesFromAspect(Urn urn, AspectSpec aspectSpec,
+      RecordTemplate aspect) {
     final Set<String> relationshipTypesBeingAdded = new HashSet<>();
     final List<Edge> edgesToAdd = new ArrayList<>();
 
@@ -209,7 +215,7 @@ public class MetadataChangeLogProcessor {
   private void updateSearchService(String entityName, Urn urn, AspectSpec aspectSpec, RecordTemplate aspect) {
     Optional<String> searchDocument;
     try {
-      searchDocument = SearchDocumentTransformer.transformAspect(urn, aspect, aspectSpec, false);
+      searchDocument = _searchDocumentTransformer.transformAspect(urn, aspect, aspectSpec, false);
     } catch (Exception e) {
       log.error("Error in getting documents from aspect: {} for aspect {}", e, aspectSpec.getName());
       return;
@@ -270,11 +276,13 @@ public class MetadataChangeLogProcessor {
     final Set<String> relationshipTypesBeingAdded = edgeAndRelationTypes.getSecond();
     if (relationshipTypesBeingAdded.size() > 0) {
       _graphService.removeEdgesFromNode(urn, new ArrayList<>(relationshipTypesBeingAdded),
-          createRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()), RelationshipDirection.OUTGOING));
+          createRelationshipFilter(new Filter().setOr(new ConjunctiveCriterionArray()),
+              RelationshipDirection.OUTGOING));
     }
   }
 
-  private void deleteSearchData(Urn urn, String entityName, AspectSpec aspectSpec, RecordTemplate aspect, Boolean isKeyAspect) {
+  private void deleteSearchData(Urn urn, String entityName, AspectSpec aspectSpec, RecordTemplate aspect,
+      Boolean isKeyAspect) {
     String docId;
     try {
       docId = URLEncoder.encode(urn.toString(), "UTF-8");
@@ -290,7 +298,7 @@ public class MetadataChangeLogProcessor {
 
     Optional<String> searchDocument;
     try {
-      searchDocument = SearchDocumentTransformer.transformAspect(urn, aspect, aspectSpec, true);
+      searchDocument = _searchDocumentTransformer.transformAspect(urn, aspect, aspectSpec, true);
     } catch (Exception e) {
       log.error("Error in getting documents from aspect: {} for aspect {}", e, aspectSpec.getName());
       return;

--- a/metadata-models/src/main/pegasus/com/linkedin/common/GlossaryTermAssociation.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/GlossaryTermAssociation.pdl
@@ -9,7 +9,7 @@ record GlossaryTermAssociation {
   */
   @Searchable = {
     "fieldName": "glossaryTerms",
-    "fieldType": "URN_PARTIAL",
+    "fieldType": "URN",
     "addToFilters": true,
     "filterNameOverride": "Glossary Term"
   }

--- a/metadata-models/src/main/pegasus/com/linkedin/common/TagAssociation.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/common/TagAssociation.pdl
@@ -10,7 +10,7 @@ record TagAssociation {
   */
   @Searchable = {
     "fieldName": "tags",
-    "fieldType": "URN_PARTIAL",
+    "fieldType": "URN",
     "hasValuesFieldName": "hasTags",
     "addToFilters": true,
     "filterNameOverride": "Tag"

--- a/metadata-models/src/main/pegasus/com/linkedin/schema/EditableSchemaFieldInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/schema/EditableSchemaFieldInfo.pdl
@@ -28,7 +28,7 @@ record EditableSchemaFieldInfo {
   @Searchable = {
     "/tags/*/tag": {
       "fieldName": "editedFieldTags",
-      "fieldType": "URN_PARTIAL",
+      "fieldType": "URN",
       "boostScore": 0.5
     }
   }
@@ -40,7 +40,7 @@ record EditableSchemaFieldInfo {
    @Searchable = {
     "/terms/*/urn": {
       "fieldName": "editedFieldGlossaryTerms",
-      "fieldType": "URN_PARTIAL",
+      "fieldType": "URN",
       "boostScore": 0.5
     }
   }

--- a/metadata-models/src/main/pegasus/com/linkedin/schema/SchemaField.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/schema/SchemaField.pdl
@@ -14,7 +14,7 @@ record SchemaField {
    */
   @Searchable = {
     "fieldName": "fieldPaths",
-    "fieldType": "TEXT_PARTIAL"
+    "fieldType": "TEXT"
   }
   fieldPath: SchemaFieldPath
 
@@ -59,7 +59,7 @@ record SchemaField {
   @Searchable = {
     "/tags/*/tag": {
       "fieldName": "fieldTags",
-      "fieldType": "URN_PARTIAL",
+      "fieldType": "URN",
       "boostScore": 0.5
     }
   }
@@ -71,7 +71,7 @@ record SchemaField {
    @Searchable = {
     "/terms/*/urn": {
       "fieldName": "fieldGlossaryTerms",
-      "fieldType": "URN_PARTIAL",
+      "fieldType": "URN",
       "boostScore": 0.5
     }
   }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticSearchGraphServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticSearchGraphServiceFactory.java
@@ -1,15 +1,13 @@
 package com.linkedin.gms.factory.common;
 
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
 import com.linkedin.metadata.graph.elastic.ESGraphQueryDAO;
 import com.linkedin.metadata.graph.elastic.ESGraphWriteDAO;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
-import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import javax.annotation.Nonnull;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -18,41 +16,19 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
-@Import({RestHighLevelClientFactory.class, IndexConventionFactory.class})
+@Import({BaseElasticSearchComponentsFactory.class})
 public class ElasticSearchGraphServiceFactory {
   @Autowired
-  @Qualifier("elasticSearchRestHighLevelClient")
-  private RestHighLevelClient searchClient;
-
-  @Autowired
-  @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN)
-  private IndexConvention indexConvention;
-
-  @Value("${elasticsearch.bulkProcessor.requestsLimit}")
-  private Integer bulkRequestsLimit;
-
-  @Value("${elasticsearch.bulkProcessor.flushPeriod}")
-  private Integer bulkFlushPeriod;
-
-  @Value("${elasticsearch.bulkProcessor.numRetries}")
-  private Integer numRetries;
-
-  @Value("${elasticsearch.bulkProcessor.retryInterval}")
-  private Long retryInterval;
+  @Qualifier("baseElasticSearchComponents")
+  private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components;
 
   @Bean(name = "elasticSearchGraphService")
   @Nonnull
   protected ElasticSearchGraphService getInstance() {
-    return new ElasticSearchGraphService(
-        searchClient,
-        indexConvention,
-        new ESGraphWriteDAO(
-            searchClient,
-            indexConvention,
-            bulkRequestsLimit,
-            bulkFlushPeriod,
-            numRetries,
-            retryInterval),
-        new ESGraphQueryDAO(searchClient, indexConvention));
+    return new ElasticSearchGraphService(components.getSearchClient(), components.getIndexConvention(),
+        new ESGraphWriteDAO(components.getSearchClient(), components.getIndexConvention(),
+            components.getBulkProcessor()),
+        new ESGraphQueryDAO(components.getSearchClient(), components.getIndexConvention()),
+        components.getIndexBuilder());
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticSearchSystemMetadataServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/ElasticSearchSystemMetadataServiceFactory.java
@@ -1,14 +1,12 @@
 package com.linkedin.gms.factory.common;
 
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
 import com.linkedin.metadata.systemmetadata.ESSystemMetadataDAO;
 import com.linkedin.metadata.systemmetadata.ElasticSearchSystemMetadataService;
-import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import javax.annotation.Nonnull;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -17,41 +15,17 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
-@Import({RestHighLevelClientFactory.class, IndexConventionFactory.class})
+@Import({BaseElasticSearchComponentsFactory.class})
 public class ElasticSearchSystemMetadataServiceFactory {
   @Autowired
-  @Qualifier("elasticSearchRestHighLevelClient")
-  private RestHighLevelClient searchClient;
-
-  @Autowired
-  @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN)
-  private IndexConvention indexConvention;
-
-  @Value("${elasticsearch.bulkProcessor.requestsLimit}")
-  private Integer bulkRequestsLimit;
-
-  @Value("${elasticsearch.bulkProcessor.flushPeriod}")
-  private Integer bulkFlushPeriod;
-
-  @Value("${elasticsearch.bulkProcessor.numRetries}")
-  private Integer numRetries;
-
-  @Value("${elasticsearch.bulkProcessor.retryInterval}")
-  private Long retryInterval;
+  @Qualifier("baseElasticSearchComponents")
+  private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components;
 
   @Bean(name = "elasticSearchSystemMetadataService")
   @Nonnull
   protected ElasticSearchSystemMetadataService getInstance() {
-    return new ElasticSearchSystemMetadataService(
-        searchClient,
-        indexConvention,
-        new ESSystemMetadataDAO(
-            searchClient,
-            indexConvention,
-            bulkRequestsLimit,
-            bulkFlushPeriod,
-            numRetries,
-            retryInterval)
-    );
+    return new ElasticSearchSystemMetadataService(components.getSearchClient(), components.getIndexConvention(),
+        new ESSystemMetadataDAO(components.getSearchClient(), components.getIndexConvention(),
+            components.getBulkProcessor()), components.getIndexBuilder());
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/IndexConventionFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/IndexConventionFactory.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.PropertySource;
 public class IndexConventionFactory {
   public static final String INDEX_CONVENTION_BEAN = "searchIndexConvention";
 
-  @Value("${elasticsearch.indexPrefix:}")
+  @Value("${elasticsearch.index.prefix:}")
   private String indexPrefix;
 
   @Bean(name = INDEX_CONVENTION_BEAN)

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/BaseElasticSearchComponentsFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/BaseElasticSearchComponentsFactory.java
@@ -1,0 +1,56 @@
+package com.linkedin.gms.factory.search;
+
+import com.linkedin.gms.factory.common.IndexConventionFactory;
+import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
+import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import javax.annotation.Nonnull;
+import lombok.Value;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+
+/**
+ * Factory for components required for any services using elasticsearch
+ */
+@Configuration
+@Import({RestHighLevelClientFactory.class})
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class BaseElasticSearchComponentsFactory {
+  @Value
+  public static class BaseElasticSearchComponents {
+    RestHighLevelClient searchClient;
+    IndexConvention indexConvention;
+    BulkProcessor bulkProcessor;
+    ESIndexBuilder indexBuilder;
+  }
+
+  @Autowired
+  @Qualifier("elasticSearchRestHighLevelClient")
+  private RestHighLevelClient searchClient;
+
+  @Autowired
+  @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN)
+  private IndexConvention indexConvention;
+
+  @Autowired
+  @Qualifier("elasticSearchBulkProcessor")
+  private BulkProcessor bulkProcessor;
+
+  @Autowired
+  @Qualifier("elasticSearchIndexBuilder")
+  private ESIndexBuilder indexBuilder;
+
+  @Bean(name = "baseElasticSearchComponents")
+  @Nonnull
+  protected BaseElasticSearchComponents getInstance() {
+    return new BaseElasticSearchComponents(searchClient, indexConvention, bulkProcessor, indexBuilder);
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchBulkProcessorFactory.java
@@ -1,0 +1,52 @@
+package com.linkedin.gms.factory.search;
+
+import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.metadata.search.elasticsearch.update.BulkListener;
+import javax.annotation.Nonnull;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.unit.TimeValue;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+
+@Configuration
+@Import({RestHighLevelClientFactory.class})
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class ElasticSearchBulkProcessorFactory {
+  @Autowired
+  @Qualifier("elasticSearchRestHighLevelClient")
+  private RestHighLevelClient searchClient;
+
+  @Value("${elasticsearch.bulkProcessor.requestsLimit}")
+  private Integer bulkRequestsLimit;
+
+  @Value("${elasticsearch.bulkProcessor.flushPeriod}")
+  private Integer bulkFlushPeriod;
+
+  @Value("${elasticsearch.bulkProcessor.numRetries}")
+  private Integer numRetries;
+
+  @Value("${elasticsearch.bulkProcessor.retryInterval}")
+  private Long retryInterval;
+
+  @Bean(name = "elasticSearchBulkProcessor")
+  @Nonnull
+  protected BulkProcessor getInstance() {
+    return BulkProcessor.builder((request, bulkListener) -> {
+      searchClient.bulkAsync(request, RequestOptions.DEFAULT, bulkListener);
+    }, BulkListener.getInstance())
+        .setBulkActions(bulkRequestsLimit)
+        .setFlushInterval(TimeValue.timeValueSeconds(bulkFlushPeriod))
+        .setBackoffPolicy(BackoffPolicy.constantBackoff(TimeValue.timeValueSeconds(retryInterval), numRetries))
+        .build();
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchIndexBuilderFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchIndexBuilderFactory.java
@@ -1,0 +1,36 @@
+package com.linkedin.gms.factory.search;
+
+import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilder;
+import javax.annotation.Nonnull;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+
+
+@Configuration
+@Import({RestHighLevelClientFactory.class})
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class ElasticSearchIndexBuilderFactory {
+  @Autowired
+  @Qualifier("elasticSearchRestHighLevelClient")
+  private RestHighLevelClient searchClient;
+
+  @Value("${elasticsearch.index.numShards}")
+  private Integer numShards;
+
+  @Value("${elasticsearch.index.numReplicas}")
+  private Integer numReplicas;
+
+  @Bean(name = "elasticSearchIndexBuilder")
+  @Nonnull
+  protected ESIndexBuilder getInstance() {
+    return new ESIndexBuilder(searchClient, numShards, numReplicas);
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/ElasticSearchServiceFactory.java
@@ -1,22 +1,17 @@
 package com.linkedin.gms.factory.search;
 
-import com.linkedin.gms.factory.common.IndexConventionFactory;
-import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
 import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchService;
-import com.linkedin.metadata.search.elasticsearch.indexbuilder.ESIndexBuilders;
+import com.linkedin.metadata.search.elasticsearch.indexbuilder.EntityIndexBuilders;
 import com.linkedin.metadata.search.elasticsearch.indexbuilder.SettingsBuilder;
 import com.linkedin.metadata.search.elasticsearch.query.ESBrowseDAO;
 import com.linkedin.metadata.search.elasticsearch.query.ESSearchDAO;
 import com.linkedin.metadata.search.elasticsearch.update.ESWriteDAO;
-import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import javax.annotation.Nonnull;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -25,16 +20,11 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
-@Import({RestHighLevelClientFactory.class, IndexConventionFactory.class, EntityRegistryFactory.class,
-    SettingsBuilderFactory.class})
+@Import({EntityRegistryFactory.class, SettingsBuilderFactory.class})
 public class ElasticSearchServiceFactory {
   @Autowired
-  @Qualifier("elasticSearchRestHighLevelClient")
-  private RestHighLevelClient searchClient;
-
-  @Autowired
-  @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN)
-  private IndexConvention indexConvention;
+  @Qualifier("baseElasticSearchComponents")
+  private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components;
 
   @Autowired
   @Qualifier("entityRegistry")
@@ -44,25 +34,16 @@ public class ElasticSearchServiceFactory {
   @Qualifier("settingsBuilder")
   private SettingsBuilder settingsBuilder;
 
-  @Value("${elasticsearch.bulkProcessor.requestsLimit}")
-  private Integer bulkRequestsLimit;
-
-  @Value("${elasticsearch.bulkProcessor.flushPeriod}")
-  private Integer bulkFlushPeriod;
-
-  @Value("${elasticsearch.bulkProcessor.numRetries}")
-  private Integer numRetries;
-
-  @Value("${elasticsearch.bulkProcessor.retryInterval}")
-  private Long retryInterval;
-
   @Bean(name = "elasticSearchService")
   @Nonnull
   protected ElasticSearchService getInstance() {
-    ESSearchDAO esSearchDAO = new ESSearchDAO(entityRegistry, searchClient, indexConvention);
-    return new ElasticSearchService(new ESIndexBuilders(entityRegistry, searchClient, indexConvention, settingsBuilder),
-        esSearchDAO, new ESBrowseDAO(entityRegistry, searchClient, indexConvention),
-        new ESWriteDAO(entityRegistry, searchClient, indexConvention, bulkRequestsLimit, bulkFlushPeriod, numRetries,
-            retryInterval));
+    ESSearchDAO esSearchDAO =
+        new ESSearchDAO(entityRegistry, components.getSearchClient(), components.getIndexConvention());
+    return new ElasticSearchService(
+        new EntityIndexBuilders(components.getIndexBuilder(), entityRegistry, components.getIndexConvention(),
+            settingsBuilder), esSearchDAO,
+        new ESBrowseDAO(entityRegistry, components.getSearchClient(), components.getIndexConvention()),
+        new ESWriteDAO(entityRegistry, components.getSearchClient(), components.getIndexConvention(),
+            components.getBulkProcessor()));
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchDocumentTransformerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/search/SearchDocumentTransformerFactory.java
@@ -1,0 +1,21 @@
+package com.linkedin.gms.factory.search;
+
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.metadata.search.transformer.SearchDocumentTransformer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+
+@Configuration
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class SearchDocumentTransformerFactory {
+  @Value("${elasticsearch.index.maxArrayLength}")
+  private int maxArrayLength;
+
+  @Bean("searchDocumentTransformer")
+  protected SearchDocumentTransformer getInstance() {
+    return new SearchDocumentTransformer(maxArrayLength);
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeseries/ElasticSearchTimeseriesAspectServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/timeseries/ElasticSearchTimeseriesAspectServiceFactory.java
@@ -1,18 +1,14 @@
 package com.linkedin.gms.factory.timeseries;
 
-import com.linkedin.gms.factory.common.IndexConventionFactory;
-import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
 import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
+import com.linkedin.gms.factory.search.BaseElasticSearchComponentsFactory;
 import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.timeseries.elastic.ElasticSearchTimeseriesAspectService;
 import com.linkedin.metadata.timeseries.elastic.indexbuilder.TimeseriesAspectIndexBuilders;
-import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import javax.annotation.Nonnull;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -21,37 +17,21 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
-@Import({RestHighLevelClientFactory.class, IndexConventionFactory.class, EntityRegistryFactory.class})
+@Import({BaseElasticSearchComponentsFactory.class, EntityRegistryFactory.class})
 public class ElasticSearchTimeseriesAspectServiceFactory {
   @Autowired
-  @Qualifier("elasticSearchRestHighLevelClient")
-  private RestHighLevelClient searchClient;
-
-  @Autowired
-  @Qualifier(IndexConventionFactory.INDEX_CONVENTION_BEAN)
-  private IndexConvention indexConvention;
+  @Qualifier("baseElasticSearchComponents")
+  private BaseElasticSearchComponentsFactory.BaseElasticSearchComponents components;
 
   @Autowired
   @Qualifier("entityRegistry")
   private EntityRegistry entityRegistry;
 
-  @Value("${elasticsearch.bulkProcessor.requestsLimit}")
-  private Integer bulkRequestsLimit;
-
-  @Value("${elasticsearch.bulkProcessor.flushPeriod}")
-  private Integer bulkFlushPeriod;
-
-  @Value("${elasticsearch.bulkProcessor.numRetries}")
-  private Integer numRetries;
-
-  @Value("${elasticsearch.bulkProcessor.retryInterval}")
-  private Long retryInterval;
-
   @Bean(name = "elasticSearchTimeseriesAspectService")
   @Nonnull
   protected ElasticSearchTimeseriesAspectService getInstance() {
-    return new ElasticSearchTimeseriesAspectService(searchClient, indexConvention,
-        new TimeseriesAspectIndexBuilders(entityRegistry, searchClient, indexConvention), entityRegistry,
-        bulkRequestsLimit, bulkFlushPeriod, numRetries, retryInterval);
+    return new ElasticSearchTimeseriesAspectService(components.getSearchClient(), components.getIndexConvention(),
+        new TimeseriesAspectIndexBuilders(components.getIndexBuilder(), entityRegistry,
+            components.getIndexConvention()), entityRegistry, components.getBulkProcessor());
   }
 }

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -83,7 +83,11 @@ elasticsearch:
     flushPeriod: ${ES_BULK_FLUSH_PERIOD:1}
     numRetries: ${ES_BULK_NUM_RETRIES:3}
     retryInterval: ${ES_BULK_RETRY_INTERVAL:1}
-  indexPrefix: ${INDEX_PREFIX:}
+  index:
+    prefix: ${INDEX_PREFIX:}
+    numShards: ${ELASTICSEARCH_NUM_SHARDS_PER_INDEX:1}
+    numReplicas: ${ELASTICSEARCH_NUM_REPLICAS_PER_INDEX:1}
+    maxArrayLength: ${SEARCH_DOCUMENT_MAX_ARRAY_LENGTH:1000}
 
 # TODO: Kafka topic convention
 kafka:

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -32,6 +32,7 @@ import com.linkedin.metadata.timeseries.TimeseriesAspectService;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
 import com.linkedin.r2.RemoteInvocationException;
+import io.opentelemetry.extension.annotations.WithSpan;
 import java.time.Clock;
 import java.util.List;
 import java.util.Map;
@@ -183,6 +184,7 @@ public class JavaEntityClient implements EntityClient {
      * @throws RemoteInvocationException
      */
     @Nonnull
+    @WithSpan
     public SearchResult search(
         @Nonnull String entity,
         @Nonnull String input,


### PR DESCRIPTION
Changes being made
- Add ability to set number of shards and replicas for all es indices (also, ability to reindex if these settings change)
- Add capping to the number of elements in the array being indexed
- Change TEXT_PARTIAL fields to TEXT for higher performance
- Make aggregation recommendations do a single call to all entity indices instead of separate calls per index type
- Only fetch urns from elasticsearch instead of fetching whole documents
- Refactor common components shared by services using elasticsearch

All the above changes surmounted to 50% improvement in search performance (When there are datasets with over 10000 fields in the schema, the changes lead to 100 times faster search speed) and 50% improvement in home page load time.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
