### PR TITLE
fix(metadata-ingestion): fix requirements for m1 preflight checks

### DIFF
--- a/metadata-ingestion/scripts/datahub_preflight.sh
+++ b/metadata-ingestion/scripts/datahub_preflight.sh
@@ -68,7 +68,7 @@ if [ "$(basename "$(pwd)")"	 != "metadata-ingestion" ]; then
 	exit 123
 fi
 printf '✅ Current folder is metadata-ingestion (%s) folder\n' "$(pwd)"
-if [[ $(uname -m) == 'arm64' || $(uname) == 'Darwin' ]]; then
+if [[ $(uname -m) == 'arm64' && $(uname) == 'Darwin' ]]; then
   printf "👟 Running preflight for m1 mac\n"
   arm64_darwin_preflight
 fi


### PR DESCRIPTION
Non m1 computers have `uname` of Darwin as well. We need to also verify the machine hardware name in order to run m1 checks.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
