### PR TITLE
fix(datahub-upgrade): Fix Spring injection issue with datahub-upgrade

### DIFF
--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCli.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCli.java
@@ -1,6 +1,5 @@
 package com.linkedin.datahub.upgrade;
 
-import com.linkedin.datahub.upgrade.applyretention.ApplyRetention;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeManager;
 import com.linkedin.datahub.upgrade.nocode.NoCodeUpgrade;
 import com.linkedin.datahub.upgrade.nocodecleanup.NoCodeCleanupUpgrade;

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCli.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCli.java
@@ -1,5 +1,6 @@
 package com.linkedin.datahub.upgrade;
 
+import com.linkedin.datahub.upgrade.applyretention.ApplyRetention;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeManager;
 import com.linkedin.datahub.upgrade.nocode.NoCodeUpgrade;
 import com.linkedin.datahub.upgrade.nocodecleanup.NoCodeCleanupUpgrade;

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCliApplication.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/UpgradeCliApplication.java
@@ -7,9 +7,8 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 
 
 @SuppressWarnings("checkstyle:HideUtilityClassConstructor")
-@SpringBootApplication(exclude = {RestClientAutoConfiguration.class}, scanBasePackages = {
-    "com.linkedin.gms.factory.common", "com.linkedin.gms.factory.kafka", "com.linkedin.gms.factory.search",
-    "com.linkedin.datahub.upgrade.config", "com.linkedin.gms.factory.entity"})
+@SpringBootApplication(exclude = {RestClientAutoConfiguration.class}, scanBasePackages = {"com.linkedin.gms.factory",
+    "com.linkedin.datahub.upgrade.config"})
 public class UpgradeCliApplication {
   public static void main(String[] args) {
     new SpringApplicationBuilder(UpgradeCliApplication.class, UpgradeCli.class).web(WebApplicationType.NONE).run(args);

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/common/steps/GMSDisableWriteModeStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/common/steps/GMSDisableWriteModeStep.java
@@ -5,7 +5,7 @@ import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 public class GMSDisableWriteModeStep implements UpgradeStep {
 
   private final Authentication _systemAuthentication;
-  private final EntityClient _entityClient;
+  private final RestliEntityClient _entityClient;
 
   @Override
   public String id() {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/common/steps/GMSEnableWriteModeStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/common/steps/GMSEnableWriteModeStep.java
@@ -5,7 +5,7 @@ import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
 import com.linkedin.datahub.upgrade.impl.DefaultUpgradeStepResult;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 public class GMSEnableWriteModeStep implements UpgradeStep {
 
   private final Authentication _systemAuthentication;
-  private final EntityClient _entityClient;
+  private final RestliEntityClient _entityClient;
 
   @Override
   public String id() {

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/common/steps/GMSQualificationStep.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/common/steps/GMSQualificationStep.java
@@ -2,6 +2,7 @@ package com.linkedin.datahub.upgrade.common.steps;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.datahub.upgrade.UpgradeContext;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.UpgradeStepResult;
@@ -12,10 +13,15 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Map;
 import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
 
 
+@RequiredArgsConstructor
 public class GMSQualificationStep implements UpgradeStep {
+
+  private final Map<String, String> configToMatch;
 
   private static String convertStreamToString(InputStream is) {
 
@@ -39,8 +45,6 @@ public class GMSQualificationStep implements UpgradeStep {
     return sb.toString();
   }
 
-  public GMSQualificationStep() { }
-
   @Override
   public String id() {
     return "GMSQualificationStep";
@@ -49,6 +53,15 @@ public class GMSQualificationStep implements UpgradeStep {
   @Override
   public int retryCount() {
     return 2;
+  }
+
+  private boolean isEligible(ObjectNode configJson) {
+    for (String key : configToMatch.keySet()) {
+      if (!configJson.has(key) || !configJson.get(key).asText().equals(configToMatch.get(key))) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override
@@ -65,7 +78,7 @@ public class GMSQualificationStep implements UpgradeStep {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode configJson = mapper.readTree(responseString);
-        if (configJson.get("noCode").asBoolean()) {
+        if (isEligible((ObjectNode) configJson)) {
           return new DefaultUpgradeStepResult(
               id(),
               UpgradeStepResult.Result.SUCCEEDED);

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/NoCodeUpgradeConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/NoCodeUpgradeConfig.java
@@ -2,7 +2,6 @@ package com.linkedin.datahub.upgrade.config;
 
 import com.datahub.authentication.Authentication;
 import com.linkedin.datahub.upgrade.nocode.NoCodeUpgrade;
-
 import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -22,7 +21,7 @@ public class NoCodeUpgradeConfig {
   ApplicationContext applicationContext;
 
   @Bean(name = "noCodeUpgrade")
-  @DependsOn({"ebeanServer", "entityService",  "systemAuthentication", "javaEntityClient", "entityRegistry"})
+  @DependsOn({"ebeanServer", "entityService", "systemAuthentication", "restliEntityClient", "entityRegistry"})
   @Nonnull
   public NoCodeUpgrade createInstance() {
     final EbeanServer ebeanServer = applicationContext.getBean(EbeanServer.class);

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/RestoreBackupConfig.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/config/RestoreBackupConfig.java
@@ -2,8 +2,7 @@ package com.linkedin.datahub.upgrade.config;
 
 import com.datahub.authentication.Authentication;
 import com.linkedin.datahub.upgrade.restorebackup.RestoreBackup;
-import com.linkedin.entity.client.EntityClient;
-import com.linkedin.entity.client.JavaEntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -23,24 +22,19 @@ public class RestoreBackupConfig {
   ApplicationContext applicationContext;
 
   @Bean(name = "restoreBackup")
-  @DependsOn({"ebeanServer", "entityService", "systemAuthentication", "javaEntityClient", "graphService", "searchService", "entityRegistry"})
+  @DependsOn({"ebeanServer", "entityService", "systemAuthentication", "restliEntityClient", "graphService",
+      "searchService", "entityRegistry"})
   @Nonnull
   public RestoreBackup createInstance() {
     final EbeanServer ebeanServer = applicationContext.getBean(EbeanServer.class);
     final EntityService entityService = applicationContext.getBean(EntityService.class);
     final Authentication systemAuthentication = applicationContext.getBean(Authentication.class);
-    final EntityClient entityClient = applicationContext.getBean(JavaEntityClient.class);
+    final RestliEntityClient entityClient = applicationContext.getBean(RestliEntityClient.class);
     final GraphService graphClient = applicationContext.getBean(GraphService.class);
     final EntitySearchService searchClient = applicationContext.getBean(EntitySearchService.class);
     final EntityRegistry entityRegistry = applicationContext.getBean(EntityRegistry.class);
 
-    return new RestoreBackup(
-        ebeanServer,
-        entityService,
-        entityRegistry,
-        systemAuthentication,
-        entityClient,
-        graphClient,
-        searchClient);
+    return new RestoreBackup(ebeanServer, entityService, entityRegistry, systemAuthentication, entityClient,
+        graphClient, searchClient);
   }
 }

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/nocode/NoCodeUpgrade.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/nocode/NoCodeUpgrade.java
@@ -1,12 +1,13 @@
 package com.linkedin.datahub.upgrade.nocode;
 
 import com.datahub.authentication.Authentication;
+import com.google.common.collect.ImmutableMap;
 import com.linkedin.datahub.upgrade.Upgrade;
 import com.linkedin.datahub.upgrade.UpgradeCleanupStep;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.common.steps.GMSEnableWriteModeStep;
 import com.linkedin.datahub.upgrade.common.steps.GMSQualificationStep;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import io.ebean.EbeanServer;
@@ -30,7 +31,7 @@ public class NoCodeUpgrade implements Upgrade {
       final EntityService entityService,
       final EntityRegistry entityRegistry,
       final Authentication systemAuthentication,
-      final EntityClient entityClient) {
+      final RestliEntityClient entityClient) {
     _steps = buildUpgradeSteps(
         server,
         entityService,
@@ -64,10 +65,10 @@ public class NoCodeUpgrade implements Upgrade {
       final EntityService entityService,
       final EntityRegistry entityRegistry,
       final Authentication systemAuthentication,
-      final EntityClient entityClient) {
+      final RestliEntityClient entityClient) {
     final List<UpgradeStep> steps = new ArrayList<>();
     steps.add(new RemoveAspectV2TableStep(server));
-    steps.add(new GMSQualificationStep());
+    steps.add(new GMSQualificationStep(ImmutableMap.of("noCode", "true")));
     steps.add(new UpgradeQualificationStep(server));
     steps.add(new CreateAspectTableStep(server));
     steps.add(new DataMigrationStep(server, entityService, entityRegistry));

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restorebackup/RestoreBackup.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restorebackup/RestoreBackup.java
@@ -9,8 +9,7 @@ import com.linkedin.datahub.upgrade.common.steps.ClearGraphServiceStep;
 import com.linkedin.datahub.upgrade.common.steps.ClearSearchServiceStep;
 import com.linkedin.datahub.upgrade.common.steps.GMSDisableWriteModeStep;
 import com.linkedin.datahub.upgrade.common.steps.GMSEnableWriteModeStep;
-import com.linkedin.datahub.upgrade.common.steps.GMSQualificationStep;
-import com.linkedin.entity.client.EntityClient;
+import com.linkedin.entity.client.RestliEntityClient;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -29,7 +28,7 @@ public class RestoreBackup implements Upgrade {
       final EntityService entityService,
       final EntityRegistry entityRegistry,
       final Authentication systemAuthentication,
-      final EntityClient entityClient,
+      final RestliEntityClient entityClient,
       final GraphService graphClient,
       final EntitySearchService searchClient) {
     _steps = buildSteps(server, entityService, entityRegistry, systemAuthentication, entityClient, graphClient, searchClient);
@@ -50,11 +49,10 @@ public class RestoreBackup implements Upgrade {
       final EntityService entityService,
       final EntityRegistry entityRegistry,
       final Authentication systemAuthentication,
-      final EntityClient entityClient,
+      final RestliEntityClient entityClient,
       final GraphService graphClient,
       final EntitySearchService searchClient) {
     final List<UpgradeStep> steps = new ArrayList<>();
-    steps.add(new GMSQualificationStep());
     steps.add(new GMSDisableWriteModeStep(systemAuthentication, entityClient));
     steps.add(new ClearSearchServiceStep(searchClient, true));
     steps.add(new ClearGraphServiceStep(graphClient, true));

--- a/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/RestoreIndices.java
+++ b/datahub-upgrade/src/main/java/com/linkedin/datahub/upgrade/restoreindices/RestoreIndices.java
@@ -6,7 +6,6 @@ import com.linkedin.datahub.upgrade.UpgradeCleanupStep;
 import com.linkedin.datahub.upgrade.UpgradeStep;
 import com.linkedin.datahub.upgrade.common.steps.ClearGraphServiceStep;
 import com.linkedin.datahub.upgrade.common.steps.ClearSearchServiceStep;
-import com.linkedin.datahub.upgrade.common.steps.GMSQualificationStep;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.graph.GraphService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
@@ -42,7 +41,6 @@ public class RestoreIndices implements Upgrade {
       final EntityRegistry entityRegistry, final EntitySearchService entitySearchService,
       final GraphService graphService) {
     final List<UpgradeStep> steps = new ArrayList<>();
-    steps.add(new GMSQualificationStep());
     steps.add(new ClearSearchServiceStep(entitySearchService, false));
     steps.add(new ClearGraphServiceStep(graphService, false));
     steps.add(new SendMAEStep(server, entityService, entityRegistry));


### PR DESCRIPTION
Addition of auth caused an injection failure in datahub-upgrade. This PR aims to fix this while also making sure all entity clients refer to the RestliEntityClient and not the JavaEntityClient


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
