### PR TITLE
fix(ingestion): Disable query parser failure reporting to Datahub in redshift lineage by default

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -101,7 +101,7 @@ class RedshiftConfig(PostgresConfig, BaseTimeWindowConfig):
 
     include_table_lineage: Optional[bool] = True
     include_copy_lineage: Optional[bool] = True
-    capture_lineage_query_parser_failures: Optional[bool] = True
+    capture_lineage_query_parser_failures: Optional[bool] = False
 
     table_lineage_mode: Optional[LineageMode] = LineageMode.STL_SCAN_BASED
 


### PR DESCRIPTION
Disable query parser failure reporting to Datahub in redshift lineage by default


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
