### PR TITLE
fix(url encoding): also encode square brackets

### DIFF
--- a/datahub-web-react/src/app/entity/shared/utils.ts
+++ b/datahub-web-react/src/app/entity/shared/utils.ts
@@ -1,5 +1,14 @@
 export function urlEncodeUrn(urn: string) {
-    return urn && urn.replace(/%/g, '%25').replace(/\//g, '%2F').replace(/\?/g, '%3F').replace(/#/g, '%23');
+    return (
+        urn &&
+        urn
+            .replace(/%/g, '%25')
+            .replace(/\//g, '%2F')
+            .replace(/\?/g, '%3F')
+            .replace(/#/g, '%23')
+            .replace(/\[/g, '%5B')
+            .replace(/\]/g, '%5D')
+    );
 }
 
 export function notEmpty<TValue>(value: TValue | null | undefined): value is TValue {


### PR DESCRIPTION
We didn't encode square brackets in our encode method. this created problems because square brackets are used in spark streaming entity urns.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
