### PR TITLE
feat(retention): Add retention to Local DB

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -227,6 +227,7 @@ module.exports = {
       {
         Advanced: [
           "docs/advanced/no-code-modeling",
+          "docs/advanced/db-retention",
           "docs/advanced/aspect-versioning",
           "docs/advanced/es-7-upgrade",
           "docs/advanced/high-cardinality",

--- a/docs/advanced/db-retention.md
+++ b/docs/advanced/db-retention.md
@@ -1,0 +1,79 @@
+# Configuring Database Retention
+
+## Goal
+
+DataHub uses a database (or key-value store) to store different versions of the aspects as they get ingested. Storing
+multiple versions of the aspects allows us to look at the history of how the aspect changed and to rollback to previous
+version when incorrect metadata gets ingested. However, each version takes up space in the database, while bringing less
+value to the system. We need to be able to impose **retention** on these records to keep the size of the DB in check.
+
+Goal of the retention system is to be able to **configure and enforce retention policies** on documents in various
+levels (
+global, entity-level, aspect-level)
+
+## What type of retention policies are supported?
+
+We support 3 types of retention policies.
+
+1. Indefinite retention: Keep all versions of aspects
+2. Version-based retention: Keep the latest N versions
+3. Time-based retention: Keep versions that have been ingested in the last N seconds
+
+Note, the latest version of each aspect (version 0) is never deleted. This is to ensure that we do not impact the core
+functionality of DataHub while applying retention.
+
+## When is the retention policy applied?
+
+As of now, retention policies are applied in two places
+
+1. **GMS boot-up**: On boot, it runs a bootstrap step to ingest the predefined set of retention policies. If there were
+   no existing policies or the existing policies got updated, it will trigger an asynchronous call to apply retention
+   to **
+   all** records in the database.
+2. **Ingest**: On every ingest, if an existing aspect got updated, it applies retention to the urn, aspect pair being
+   ingested.
+
+We are planning to support a cron-based application of retention in the near future to ensure that the time-based
+retention is applied correctly.
+
+## How to configure?
+
+For the initial iteration, we have made this feature opt-in. Please set **ENTITY_SERVICE_DISABLE_RETENTION=false** when
+creating the datahub-gms container/k8s pod.
+
+On GMS start up, it fetches the list of retention policies to ingest from two sources. First is the default we provide,
+which adds a version-based retention to keep 20 latest aspects for all entity-aspect pairs. Second, we read YAML files
+from the `/etc/datahub/plugins/retention` directory and overlay them on the default set of policies we provide.
+
+For docker, we set docker-compose to mount `${HOME}/.datahub/plugins` directory to `/etc/datahub/plugins` directory
+within the containers, so you can customize the initial set of retention policies by creating
+a `${HOME}/.datahub/plugins/retention/retention.yaml` file.
+
+We will support a standardized way to do this in kubernetes setup in the near future. 
+
+The format for the YAML file is as follows. 
+
+```yaml
+- entity: "*" # denotes that policy will be applied to all entities
+  aspect: "*" # denotes that policy will be applied to all aspects
+  retention:
+    retentionPolicies:
+      - version:
+          maxVersions: 10
+- entity: "dataset"
+  aspect: "datasetProperties"
+  retention:
+    retentionPolicies:
+      - version:
+          maxVersions: 5
+#      - time:
+#          maxAgeInSeconds: 2592000 # 30 days
+```
+
+Note, it searches for the policies corresponding to the entity, aspect pair in the following order
+1. entity, aspect
+2. *, aspect
+3. entity, *
+4. *, *
+
+By restarting datahub-gms after creating the plugin yaml file, the new set of retention policies will be applied. 

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/EntityService.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.entity;
 
+import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.linkedin.common.AuditStamp;
@@ -26,6 +27,7 @@ import com.linkedin.metadata.utils.DataPlatformInstanceUtils;
 import com.linkedin.metadata.utils.EntityKeyUtils;
 import com.linkedin.metadata.utils.GenericAspectUtils;
 import com.linkedin.metadata.utils.PegasusUtils;
+import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataAuditOperation;
 import com.linkedin.mxe.MetadataChangeLog;
 import com.linkedin.mxe.MetadataChangeProposal;
@@ -38,9 +40,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 import static com.linkedin.metadata.Constants.ASPECT_LATEST_VERSION;
@@ -88,7 +94,10 @@ public abstract class EntityService {
   private final EntityEventProducer _producer;
   private final EntityRegistry _entityRegistry;
   private final Map<String, Set<String>> _entityToValidAspects;
-  private Boolean _emitAspectSpecificAuditEvent = false;
+  @Getter
+  @Setter
+  private RetentionService retentionService;
+  private Boolean _alwaysEmitAuditEvent = false;
   public static final String DEFAULT_RUN_ID = "no-run-id-provided";
   public static final String BROWSE_PATHS = "browsePaths";
   public static final String DATA_PLATFORM_INSTANCE = "dataPlatformInstance";
@@ -107,7 +116,7 @@ public abstract class EntityService {
    * @param aspectNames aspects to fetch for each urn in urns set
    * @return a map of provided {@link Urn} to a List containing the requested aspects.
    */
-  protected abstract Map<Urn, List<RecordTemplate>> getLatestAspects(@Nonnull final Set<Urn> urns,
+  public abstract Map<Urn, List<RecordTemplate>> getLatestAspects(@Nonnull final Set<Urn> urns,
       @Nonnull final Set<String> aspectNames);
 
   /**
@@ -147,6 +156,22 @@ public abstract class EntityService {
       @Nonnull final String aspectName, final int start, int count);
 
   /**
+   * Checks whether there is an actual update to the aspect by applying the updateLambda
+   * If there is an update, push the new version into the local DB.
+   * Otherwise, do not push the new version, but just update the system metadata.
+   *
+   * @param urn an urn associated with the new aspect
+   * @param aspectName name of the aspect being inserted
+   * @param updateLambda Function to apply to the latest version of the aspect to get the updated version
+   * @param auditStamp an {@link AuditStamp} containing metadata about the writer & current time   * @param providedSystemMetadata
+   * @return Details about the new and old version of the aspect
+   */
+  @Nonnull
+  protected abstract UpdateAspectResult ingestAspectToLocalDB(@Nonnull final Urn urn, @Nonnull final String aspectName,
+      @Nonnull final Function<Optional<RecordTemplate>, RecordTemplate> updateLambda,
+      @Nonnull final AuditStamp auditStamp, @Nonnull final SystemMetadata providedSystemMetadata);
+
+  /**
    * Ingests (inserts) a new version of an entity aspect & emits a {@link com.linkedin.mxe.MetadataAuditEvent}.
    *
    * Note that in general, this should not be used externally. It is currently serving upgrade scripts and
@@ -159,8 +184,47 @@ public abstract class EntityService {
    * @param systemMetadata
    * @return the {@link RecordTemplate} representation of the written aspect object
    */
-  public abstract RecordTemplate ingestAspect(@Nonnull final Urn urn, @Nonnull final String aspectName,
-      @Nonnull final RecordTemplate newValue, @Nonnull final AuditStamp auditStamp, SystemMetadata systemMetadata);
+  public RecordTemplate ingestAspect(@Nonnull final Urn urn, @Nonnull final String aspectName,
+      @Nonnull final RecordTemplate newValue, @Nonnull final AuditStamp auditStamp, SystemMetadata systemMetadata) {
+
+    log.debug("Invoked ingestAspect with urn: {}, aspectName: {}, newValue: {}", urn, aspectName, newValue);
+
+    if (!urn.toString().trim().equals(urn.toString())) {
+      throw new IllegalArgumentException("Error: cannot provide an URN with leading or trailing whitespace");
+    }
+
+    Timer.Context ingestToLocalDBTimer = MetricUtils.timer(this.getClass(), "ingestAspectToLocalDB").time();
+    UpdateAspectResult result = ingestAspectToLocalDB(urn, aspectName, ignored -> newValue, auditStamp, systemMetadata);
+    ingestToLocalDBTimer.stop();
+
+    final RecordTemplate oldValue = result.getOldValue();
+    final RecordTemplate updatedValue = result.getNewValue();
+
+    // Apply retention policies asynchronously if there was an update to existing aspect value
+    if (oldValue != updatedValue && oldValue != null && retentionService != null) {
+      retentionService.applyRetention(urn, aspectName,
+          Optional.of(new RetentionService.RetentionContext(Optional.of(result.maxVersion))));
+    }
+
+    // Produce MAE after a successful update
+    if (oldValue != updatedValue || _alwaysEmitAuditEvent) {
+      log.debug(String.format("Producing MetadataAuditEvent for ingested aspect %s, urn %s", aspectName, urn));
+      Timer.Context produceMAETimer = MetricUtils.timer(this.getClass(), "produceMAE").time();
+      if (aspectName.equals(getKeyAspectName(urn))) {
+        produceMetadataAuditEventForKey(urn, result.getNewSystemMetadata());
+      } else {
+        produceMetadataAuditEvent(urn, oldValue, updatedValue, result.getOldSystemMetadata(),
+            result.getNewSystemMetadata(), MetadataAuditOperation.UPDATE);
+      }
+      produceMAETimer.stop();
+    } else {
+      log.debug(
+          String.format("Skipped producing MetadataAuditEvent for ingested aspect %s, urn %s. Aspect has not changed.",
+              aspectName, urn));
+    }
+
+    return updatedValue;
+  }
 
   public RecordTemplate ingestAspect(@Nonnull final Urn urn, @Nonnull final String aspectName,
       @Nonnull final RecordTemplate newValue, @Nonnull final AuditStamp auditStamp) {
@@ -169,6 +233,105 @@ public abstract class EntityService {
     generatedSystemMetadata.setLastObserved(System.currentTimeMillis());
 
     return ingestAspect(urn, aspectName, newValue, auditStamp, generatedSystemMetadata);
+  }
+
+  public IngestProposalResult ingestProposal(@Nonnull MetadataChangeProposal metadataChangeProposal, AuditStamp auditStamp) {
+
+    log.debug("entity type = {}", metadataChangeProposal.getEntityType());
+    EntitySpec entitySpec = getEntityRegistry().getEntitySpec(metadataChangeProposal.getEntityType());
+    log.debug("entity spec = {}", entitySpec);
+
+    Urn entityUrn = EntityKeyUtils.getUrnFromProposal(metadataChangeProposal, entitySpec.getKeyAspectSpec());
+
+    if (metadataChangeProposal.getChangeType() != ChangeType.UPSERT) {
+      throw new UnsupportedOperationException("Only upsert operation is supported");
+    }
+
+    if (!metadataChangeProposal.hasAspectName() || !metadataChangeProposal.hasAspect()) {
+      throw new UnsupportedOperationException("Aspect and aspect name is required for create and update operations");
+    }
+
+    AspectSpec aspectSpec = entitySpec.getAspectSpec(metadataChangeProposal.getAspectName());
+
+    if (aspectSpec == null) {
+      throw new RuntimeException(
+          String.format("Unknown aspect %s for entity %s", metadataChangeProposal.getAspectName(),
+              metadataChangeProposal.getEntityType()));
+    }
+
+    log.debug("aspect spec = {}", aspectSpec);
+
+    RecordTemplate aspect;
+    try {
+      aspect = GenericAspectUtils.deserializeAspect(metadataChangeProposal.getAspect().getValue(),
+          metadataChangeProposal.getAspect().getContentType(), aspectSpec);
+      ValidationUtils.validateOrThrow(aspect);
+    } catch (ModelConversionException e) {
+      throw new RuntimeException(
+          String.format("Could not deserialize {} for aspect {}", metadataChangeProposal.getAspect().getValue(),
+              metadataChangeProposal.getAspectName()));
+    }
+    log.debug("aspect = {}", aspect);
+
+    SystemMetadata systemMetadata = metadataChangeProposal.getSystemMetadata();
+    if (systemMetadata == null) {
+      systemMetadata = new SystemMetadata();
+      systemMetadata.setRunId(DEFAULT_RUN_ID);
+      systemMetadata.setLastObserved(System.currentTimeMillis());
+    }
+    systemMetadata.setRegistryName(aspectSpec.getRegistryName());
+    systemMetadata.setRegistryVersion(aspectSpec.getRegistryVersion().toString());
+
+    RecordTemplate oldAspect = null;
+    SystemMetadata oldSystemMetadata = null;
+    RecordTemplate newAspect = aspect;
+    SystemMetadata newSystemMetadata = systemMetadata;
+
+    if (!aspectSpec.isTimeseries()) {
+      Timer.Context ingestToLocalDBTimer = MetricUtils.timer(this.getClass(), "ingestProposalToLocalDB").time();
+      UpdateAspectResult result =
+          ingestAspectToLocalDB(entityUrn, metadataChangeProposal.getAspectName(), ignored -> aspect, auditStamp,
+              systemMetadata);
+      ingestToLocalDBTimer.stop();
+      oldAspect = result.getOldValue();
+      oldSystemMetadata = result.getOldSystemMetadata();
+      newAspect = result.getNewValue();
+      newSystemMetadata = result.getNewSystemMetadata();
+      // Apply retention policies asynchronously if there was an update to existing aspect value
+      if (oldAspect != newAspect && oldAspect != null && retentionService != null) {
+        retentionService.applyRetention(entityUrn, aspectSpec.getName(),
+            Optional.of(new RetentionService.RetentionContext(Optional.of(result.maxVersion))));
+      }
+    }
+
+    if (oldAspect != newAspect || getAlwaysEmitAuditEvent()) {
+      log.debug(String.format("Producing MetadataChangeLog for ingested aspect %s, urn %s",
+          metadataChangeProposal.getAspectName(), entityUrn));
+
+      final MetadataChangeLog metadataChangeLog = new MetadataChangeLog(metadataChangeProposal.data());
+      if (oldAspect != null) {
+        metadataChangeLog.setPreviousAspectValue(GenericAspectUtils.serializeAspect(oldAspect));
+      }
+      if (oldSystemMetadata != null) {
+        metadataChangeLog.setPreviousSystemMetadata(oldSystemMetadata);
+      }
+      if (newAspect != null) {
+        metadataChangeLog.setAspect(GenericAspectUtils.serializeAspect(newAspect));
+      }
+      if (newSystemMetadata != null) {
+        metadataChangeLog.setSystemMetadata(newSystemMetadata);
+      }
+
+      log.debug(String.format("Serialized MCL event: %s", metadataChangeLog));
+      // Since only timeseries aspects are ingested as of now, simply produce mae event for it
+      produceMetadataChangeLog(entityUrn, aspectSpec, metadataChangeLog);
+    } else {
+      log.debug(
+          String.format("Skipped producing MetadataAuditEvent for ingested aspect %s, urn %s. Aspect has not changed.",
+              metadataChangeProposal.getAspectName(), entityUrn));
+    }
+
+    return new IngestProposalResult(entityUrn, oldAspect != newAspect);
   }
 
   /**
@@ -483,12 +646,12 @@ public abstract class EntityService {
             entry -> entry.getAspectSpecs().stream().map(AspectSpec::getName).collect(Collectors.toSet())));
   }
 
-  public Boolean getEmitAspectSpecificAuditEvent() {
-    return _emitAspectSpecificAuditEvent;
+  public Boolean getAlwaysEmitAuditEvent() {
+    return _alwaysEmitAuditEvent;
   }
 
-  public void setEmitAspectSpecificAuditEvent(Boolean emitAspectSpecificAuditEvent) {
-    _emitAspectSpecificAuditEvent = emitAspectSpecificAuditEvent;
+  public void setAlwaysEmitAuditEvent(Boolean alwaysEmitAuditEvent) {
+    _alwaysEmitAuditEvent = alwaysEmitAuditEvent;
   }
 
   public EntityRegistry getEntityRegistry() {
@@ -505,8 +668,6 @@ public abstract class EntityService {
 
   public abstract void setWritable(boolean canWrite);
 
-  public abstract Urn ingestProposal(MetadataChangeProposal metadataChangeProposal, AuditStamp auditStamp);
-
   public RollbackRunResult rollbackRun(List<AspectRowSummary> aspectRows, String runId) {
     return rollbackWithConditions(aspectRows, Collections.singletonMap("runId", runId));
   }
@@ -517,4 +678,21 @@ public abstract class EntityService {
   public abstract RollbackRunResult deleteUrn(Urn urn);
 
   public abstract Boolean exists(Urn urn);
+
+  @Value
+  public static class UpdateAspectResult {
+    Urn urn;
+    RecordTemplate oldValue;
+    RecordTemplate newValue;
+    SystemMetadata oldSystemMetadata;
+    SystemMetadata newSystemMetadata;
+    MetadataAuditOperation operation;
+    long maxVersion;
+  }
+
+  @Value
+  public static class IngestProposalResult {
+    Urn urn;
+    boolean didUpdate;
+  }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/RetentionService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/RetentionService.java
@@ -1,0 +1,207 @@
+package com.linkedin.metadata.entity;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.linkedin.common.AuditStamp;
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.Constants;
+import com.linkedin.metadata.key.DataHubRetentionKey;
+import com.linkedin.metadata.utils.EntityKeyUtils;
+import com.linkedin.metadata.utils.GenericAspectUtils;
+import com.linkedin.mxe.GenericAspect;
+import com.linkedin.mxe.MetadataChangeProposal;
+import com.linkedin.retention.DataHubRetentionInfo;
+import com.linkedin.retention.Retention;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.SneakyThrows;
+import lombok.Value;
+
+
+/**
+ * Service coupled with an entity service to handle retention
+ */
+public abstract class RetentionService {
+  protected static final String ALL = "*";
+  protected static final String DATAHUB_RETENTION_ENTITY = "dataHubRetention";
+  protected static final String DATAHUB_RETENTION_ASPECT = "dataHubRetentionInfo";
+  protected static final String DATAHUB_RETENTION_KEY_ASPECT = "dataHubRetentionKey";
+
+  protected abstract EntityService getEntityService();
+
+  /**
+   * Fetch retention policies given the entityName and aspectName
+   * Uses the entity service to fetch the latest retention policies set for the input entity and aspect
+   *
+   * @param entityName Name of the entity
+   * @param aspectName Name of the aspect
+   * @return retention policies to apply to the input entity and aspect
+   */
+  public List<Retention> getRetention(@Nonnull String entityName, @Nonnull String aspectName) {
+    // Prioritized list of retention keys to fetch
+    List<Urn> retentionUrns = getRetentionKeys(entityName, aspectName);
+    Map<Urn, List<RecordTemplate>> fetchedAspects =
+        getEntityService().getLatestAspects(new HashSet<>(retentionUrns), ImmutableSet.of(DATAHUB_RETENTION_ASPECT));
+    // Find the first retention info that is set among the prioritized list of retention keys above
+    Optional<DataHubRetentionInfo> retentionInfo = retentionUrns.stream()
+        .flatMap(urn -> fetchedAspects.getOrDefault(urn, Collections.emptyList())
+            .stream()
+            .filter(aspect -> aspect instanceof DataHubRetentionInfo))
+        .map(retention -> (DataHubRetentionInfo) retention)
+        .findFirst();
+    return retentionInfo.<List<Retention>>map(DataHubRetentionInfo::getRetentionPolicies).orElse(
+        Collections.emptyList());
+  }
+
+  // Get list of datahub retention keys that match the input entity name and aspect name
+  protected List<Urn> getRetentionKeys(@Nonnull String entityName, @Nonnull String aspectName) {
+    return ImmutableList.of(new DataHubRetentionKey().setEntityName(entityName).setAspectName(aspectName),
+        new DataHubRetentionKey().setEntityName(entityName).setAspectName(ALL),
+        new DataHubRetentionKey().setEntityName(ALL).setAspectName(aspectName),
+        new DataHubRetentionKey().setEntityName(ALL).setAspectName(ALL))
+        .stream()
+        .map(key -> EntityKeyUtils.convertEntityKeyToUrn(key, DATAHUB_RETENTION_ENTITY))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Set retention policy for given entity and aspect. If entity or aspect names are null, the policy is set as default
+   *
+   * @param entityName Entity name to apply policy to. If null, set as "*",
+   *                   meaning it will be the default for any entities without specified policy
+   * @param aspectName Aspect name to apply policy to. If null, set as "*",
+   *                   meaning it will be the default for any aspects without specified policy
+   * @param retentionInfo Retention policy
+   */
+  @SneakyThrows
+  public boolean setRetention(@Nullable String entityName, @Nullable String aspectName,
+      @Nonnull DataHubRetentionInfo retentionInfo) {
+    validateRetentionInfo(retentionInfo);
+    DataHubRetentionKey retentionKey = new DataHubRetentionKey();
+    retentionKey.setEntityName(entityName != null ? entityName : ALL);
+    retentionKey.setAspectName(aspectName != null ? aspectName : ALL);
+    Urn retentionUrn = EntityKeyUtils.convertEntityKeyToUrn(retentionKey, DATAHUB_RETENTION_ENTITY);
+    MetadataChangeProposal keyProposal = new MetadataChangeProposal();
+    GenericAspect keyAspect = GenericAspectUtils.serializeAspect(retentionKey);
+    keyProposal.setAspect(keyAspect);
+    keyProposal.setAspectName(DATAHUB_RETENTION_KEY_ASPECT);
+    keyProposal.setEntityType(DATAHUB_RETENTION_ENTITY);
+    keyProposal.setChangeType(ChangeType.UPSERT);
+    keyProposal.setEntityUrn(retentionUrn);
+    AuditStamp auditStamp =
+        new AuditStamp().setActor(Urn.createFromString(Constants.SYSTEM_ACTOR)).setTime(System.currentTimeMillis());
+    getEntityService().ingestProposal(keyProposal, auditStamp);
+    MetadataChangeProposal aspectProposal = keyProposal.clone();
+    GenericAspect retentionAspect = GenericAspectUtils.serializeAspect(retentionInfo);
+    aspectProposal.setAspect(retentionAspect);
+    aspectProposal.setAspectName(DATAHUB_RETENTION_ASPECT);
+    return getEntityService().ingestProposal(aspectProposal, auditStamp).isDidUpdate();
+  }
+
+  /**
+   * Delete the retention policy set for given entity and aspect.
+   *
+   * @param entityName Entity name to apply policy to. If null, set as "*",
+   *                   meaning it will delete the default policy for any entities without specified policy
+   * @param aspectName Aspect name to apply policy to. If null, set as "*",
+   *                   meaning it will delete the default policy for any aspects without specified policy
+   */
+  public void deleteRetention(@Nullable String entityName, @Nullable String aspectName) {
+    DataHubRetentionKey retentionKey = new DataHubRetentionKey();
+    retentionKey.setEntityName(entityName != null ? entityName : ALL);
+    retentionKey.setAspectName(aspectName != null ? aspectName : ALL);
+    Urn retentionUrn = EntityKeyUtils.convertEntityKeyToUrn(retentionKey, DATAHUB_RETENTION_ENTITY);
+    getEntityService().deleteUrn(retentionUrn);
+  }
+
+  private void validateRetentionInfo(DataHubRetentionInfo retentionInfo) {
+    Set<String> retentionsSoFar = new HashSet<>();
+    for (Retention retention : retentionInfo.getRetentionPolicies()) {
+      if (retention.data().size() != 1) {
+        throw new IllegalArgumentException("Exactly one retention policy should be set per element");
+      }
+      if (retention.hasIndefinite() && retentionInfo.getRetentionPolicies().size() > 1) {
+        throw new IllegalArgumentException("Indefinite policy cannot be combined with any other policy");
+      }
+      String retentionType = retention.data().keySet().stream().findFirst().get();
+      if (retentionsSoFar.contains(retentionType)) {
+        throw new IllegalArgumentException("Type of policies in the list must be unique");
+      }
+      retentionsSoFar.add(retentionType);
+      validateRetention(retention);
+    }
+  }
+
+  private void validateRetention(Retention retention) {
+    if (retention.hasVersion()) {
+      if (retention.getVersion().getMaxVersions() <= 0) {
+        throw new IllegalArgumentException("Invalid maxVersions: " + retention.getVersion().getMaxVersions());
+      }
+    }
+    if (retention.hasTime()) {
+      if (retention.getTime().getMaxAgeInSeconds() <= 0) {
+        throw new IllegalArgumentException("Invalid maxAgeInSeconds: " + retention.getTime().getMaxAgeInSeconds());
+      }
+    }
+  }
+
+  /**
+   * Apply retention policies given the urn and aspect name asynchronously
+   *
+   * @param urn Urn of the entity
+   * @param aspectName Name of the aspect
+   * @param context Additional context that could be used to apply retention
+   */
+  public void applyRetentionAsync(@Nonnull Urn urn, @Nonnull String aspectName, Optional<RetentionContext> context) {
+    CompletableFuture.runAsync(() -> applyRetention(urn, aspectName, context));
+  }
+
+  /**
+   * Apply retention policies given the urn and aspect name
+   *
+   * @param urn Urn of the entity
+   * @param aspectName Name of the aspect
+   * @param context Additional context that could be used to apply retention
+   */
+  public void applyRetention(@Nonnull Urn urn, @Nonnull String aspectName, Optional<RetentionContext> context) {
+    List<Retention> retentionPolicies = getRetention(urn.getEntityType(), aspectName);
+    if (retentionPolicies.isEmpty()) {
+      return;
+    }
+    applyRetention(urn, aspectName, retentionPolicies, context);
+  }
+
+  /**
+   * Apply retention policies given the urn and aspect name and policies
+   *
+   * @param urn Urn of the entity
+   * @param aspectName Name of the aspect
+   * @param retentionPolicies Retention policies to apply
+   * @param context Additional context that could be used to apply retention
+   */
+  public abstract void applyRetention(@Nonnull Urn urn, @Nonnull String aspectName, List<Retention> retentionPolicies,
+      Optional<RetentionService.RetentionContext> context);
+
+  /**
+   * Batch apply retention to all records that match the input entityName and aspectName
+   *
+   * @param entityName Name of the entity to apply retention to. If null, applies to all entities
+   * @param aspectName Name of the aspect to apply retention to. If null, applies to all aspects
+   */
+  public abstract void batchApplyRetention(@Nullable String entityName, @Nullable String aspectName);
+
+  @Value
+  public static class RetentionContext {
+    Optional<Long> maxVersion;
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -1,6 +1,5 @@
 package com.linkedin.metadata.entity.ebean;
 
-import com.codahale.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
@@ -13,28 +12,20 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.events.metadata.ChangeType;
 import com.linkedin.metadata.aspect.Aspect;
 import com.linkedin.metadata.aspect.VersionedAspect;
-import com.linkedin.metadata.dao.exception.ModelConversionException;
 import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.entity.ListResult;
 import com.linkedin.metadata.entity.RollbackResult;
 import com.linkedin.metadata.entity.RollbackRunResult;
-import com.linkedin.metadata.entity.ValidationUtils;
 import com.linkedin.metadata.event.EntityEventProducer;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.EntitySpec;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.query.ListUrnsResult;
 import com.linkedin.metadata.run.AspectRowSummary;
-import com.linkedin.metadata.utils.EntityKeyUtils;
-import com.linkedin.metadata.utils.GenericAspectUtils;
 import com.linkedin.metadata.utils.PegasusUtils;
-import com.linkedin.metadata.utils.metrics.MetricUtils;
 import com.linkedin.mxe.MetadataAuditOperation;
-import com.linkedin.mxe.MetadataChangeLog;
-import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
-import io.opentelemetry.extension.annotations.WithSpan;
 import java.net.URISyntaxException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -50,11 +41,12 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.linkedin.metadata.Constants.*;
-import static com.linkedin.metadata.entity.ebean.EbeanUtils.*;
+import static com.linkedin.metadata.Constants.ASPECT_LATEST_VERSION;
+import static com.linkedin.metadata.entity.ebean.EbeanUtils.parseSystemMetadata;
+import static com.linkedin.metadata.entity.ebean.EbeanUtils.toAspectRecord;
+import static com.linkedin.metadata.entity.ebean.EbeanUtils.toJsonAspect;
 
 
 /**
@@ -68,8 +60,6 @@ public class EbeanEntityService extends EntityService {
 
   private final EbeanAspectDao _entityDao;
   private final JacksonDataTemplateCodec _dataTemplateCodec = new JacksonDataTemplateCodec();
-  private Boolean _alwaysEmitAuditEvent = false;
-
 
   public EbeanEntityService(@Nonnull final EbeanAspectDao entityDao, @Nonnull final EntityEventProducer eventProducer,
       @Nonnull final EntityRegistry entityRegistry) {
@@ -206,50 +196,9 @@ public class EbeanEntityService extends EntityService {
 
   @Override
   @Nonnull
-  @WithSpan
-  public RecordTemplate ingestAspect(@Nonnull final Urn urn, @Nonnull final String aspectName,
-      @Nonnull final RecordTemplate newValue, @Nonnull final AuditStamp auditStamp,
-      @Nonnull final SystemMetadata systemMetadata) {
-
-    log.debug("Invoked ingestAspect with urn: {}, aspectName: {}, newValue: {}", urn, aspectName, newValue);
-
-    if (!urn.toString().trim().equals(urn.toString())) {
-      throw new IllegalArgumentException("Error: cannot provide an URN with leading or trailing whitespace");
-    }
-
-    Timer.Context ingestToLocalDBTimer = MetricUtils.timer(this.getClass(), "ingestAspectToLocalDB").time();
-    UpdateAspectResult result = ingestAspectToLocalDB(urn, aspectName, ignored -> newValue, auditStamp, systemMetadata,
-        DEFAULT_MAX_TRANSACTION_RETRY);
-    ingestToLocalDBTimer.stop();
-
-    final RecordTemplate oldValue = result.getOldValue();
-    final RecordTemplate updatedValue = result.getNewValue();
-
-    // 5. Produce MAE after a successful update
-    if (oldValue != updatedValue || _alwaysEmitAuditEvent) {
-      log.debug(String.format("Producing MetadataAuditEvent for ingested aspect %s, urn %s", aspectName, urn));
-      Timer.Context produceMAETimer = MetricUtils.timer(this.getClass(), "produceMAE").time();
-      if (aspectName.equals(getKeyAspectName(urn))) {
-        produceMetadataAuditEventForKey(urn, result.getNewSystemMetadata());
-      } else {
-        produceMetadataAuditEvent(urn, oldValue, updatedValue, result.getOldSystemMetadata(),
-            result.getNewSystemMetadata(), MetadataAuditOperation.UPDATE);
-      }
-      produceMAETimer.stop();
-    } else {
-      log.debug(
-          String.format("Skipped producing MetadataAuditEvent for ingested aspect %s, urn %s. Aspect has not changed.",
-              aspectName, urn));
-    }
-
-    return updatedValue;
-  }
-
-  @Nonnull
-  private UpdateAspectResult ingestAspectToLocalDB(@Nonnull final Urn urn, @Nonnull final String aspectName,
+  protected UpdateAspectResult ingestAspectToLocalDB(@Nonnull final Urn urn, @Nonnull final String aspectName,
       @Nonnull final Function<Optional<RecordTemplate>, RecordTemplate> updateLambda,
-      @Nonnull final AuditStamp auditStamp, @Nonnull final SystemMetadata providedSystemMetadata,
-      final int maxTransactionRetry) {
+      @Nonnull final AuditStamp auditStamp, @Nonnull final SystemMetadata providedSystemMetadata) {
 
     return _entityDao.runInTransactionWithRetry(() -> {
 
@@ -274,12 +223,12 @@ public class EbeanEntityService extends EntityService {
 
         return new UpdateAspectResult(urn, oldValue, oldValue,
             EbeanUtils.parseSystemMetadata(latest.getSystemMetadata()), latestSystemMetadata,
-            MetadataAuditOperation.UPDATE);
+            MetadataAuditOperation.UPDATE, 0);
       }
 
       // 4. Save the newValue as the latest version
       log.debug(String.format("Ingesting aspect with name %s, urn %s", aspectName, urn));
-      _entityDao.saveLatestAspect(urn.toString(), aspectName, latest == null ? null : toJsonAspect(oldValue),
+      long versionOfOld = _entityDao.saveLatestAspect(urn.toString(), aspectName, latest == null ? null : toJsonAspect(oldValue),
           latest == null ? null : latest.getCreatedBy(), latest == null ? null : latest.getCreatedFor(),
           latest == null ? null : latest.getCreatedOn(), latest == null ? null : latest.getSystemMetadata(),
           toJsonAspect(newValue), auditStamp.getActor().toString(),
@@ -288,8 +237,8 @@ public class EbeanEntityService extends EntityService {
 
       return new UpdateAspectResult(urn, oldValue, newValue,
           latest == null ? null : EbeanUtils.parseSystemMetadata(latest.getSystemMetadata()), providedSystemMetadata,
-          MetadataAuditOperation.UPDATE);
-    }, maxTransactionRetry);
+          MetadataAuditOperation.UPDATE, versionOfOld);
+    }, DEFAULT_MAX_TRANSACTION_RETRY);
   }
 
   @Override
@@ -329,7 +278,7 @@ public class EbeanEntityService extends EntityService {
           new Timestamp(auditStamp.getTime()), toJsonAspect(newSystemMetadata), version, oldAspect == null);
 
       return new UpdateAspectResult(urn, oldValue, value, oldSystemMetadata, newSystemMetadata,
-          MetadataAuditOperation.UPDATE);
+          MetadataAuditOperation.UPDATE, version);
     }, maxTransactionRetry);
 
     final RecordTemplate oldValue = result.getOldValue();
@@ -337,8 +286,8 @@ public class EbeanEntityService extends EntityService {
 
     if (emitMae) {
       log.debug(String.format("Producing MetadataAuditEvent for updated aspect %s, urn %s", aspectName, urn));
-      produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, oldValue, newValue, result.oldSystemMetadata,
-          result.newSystemMetadata, ChangeType.UPSERT);
+      produceMetadataChangeLog(urn, entityName, aspectName, aspectSpec, oldValue, newValue,
+          result.getOldSystemMetadata(), result.getNewSystemMetadata(), ChangeType.UPSERT);
     } else {
       log.debug(String.format("Skipped producing MetadataAuditEvent for updated aspect %s, urn %s. emitMAE is false.",
           aspectName, urn));
@@ -347,112 +296,9 @@ public class EbeanEntityService extends EntityService {
     return newValue;
   }
 
-  public Boolean getAlwaysEmitAuditEvent() {
-    return _alwaysEmitAuditEvent;
-  }
-
-  public void setAlwaysEmitAuditEvent(Boolean alwaysEmitAuditEvent) {
-    _alwaysEmitAuditEvent = alwaysEmitAuditEvent;
-  }
-
   public void setWritable(boolean canWrite) {
     log.debug("Enabling writes");
     _entityDao.setWritable(canWrite);
-  }
-
-  @Override
-  public Urn ingestProposal(@Nonnull MetadataChangeProposal metadataChangeProposal, AuditStamp auditStamp) {
-
-    log.debug("entity type = {}", metadataChangeProposal.getEntityType());
-    EntitySpec entitySpec = getEntityRegistry().getEntitySpec(metadataChangeProposal.getEntityType());
-    log.debug("entity spec = {}", entitySpec);
-
-    Urn entityUrn = EntityKeyUtils.getUrnFromProposal(metadataChangeProposal, entitySpec.getKeyAspectSpec());
-
-    if (metadataChangeProposal.getChangeType() != ChangeType.UPSERT) {
-      throw new UnsupportedOperationException("Only upsert operation is supported");
-    }
-
-    if (!metadataChangeProposal.hasAspectName() || !metadataChangeProposal.hasAspect()) {
-      throw new UnsupportedOperationException("Aspect and aspect name is required for create and update operations");
-    }
-
-    AspectSpec aspectSpec = entitySpec.getAspectSpec(metadataChangeProposal.getAspectName());
-
-    if (aspectSpec == null) {
-      throw new RuntimeException(
-          String.format("Unknown aspect %s for entity %s", metadataChangeProposal.getAspectName(),
-              metadataChangeProposal.getEntityType()));
-    }
-
-    log.debug("aspect spec = {}", aspectSpec);
-
-    RecordTemplate aspect;
-    try {
-      aspect = GenericAspectUtils.deserializeAspect(metadataChangeProposal.getAspect().getValue(),
-          metadataChangeProposal.getAspect().getContentType(), aspectSpec);
-      ValidationUtils.validateOrThrow(aspect);
-    } catch (ModelConversionException e) {
-      throw new RuntimeException(
-          String.format("Could not deserialize {} for aspect {}", metadataChangeProposal.getAspect().getValue(),
-              metadataChangeProposal.getAspectName()));
-    }
-    log.debug("aspect = {}", aspect);
-
-    SystemMetadata systemMetadata = metadataChangeProposal.getSystemMetadata();
-    if (systemMetadata == null) {
-      systemMetadata = new SystemMetadata();
-      systemMetadata.setRunId(DEFAULT_RUN_ID);
-      systemMetadata.setLastObserved(System.currentTimeMillis());
-    }
-    systemMetadata.setRegistryName(aspectSpec.getRegistryName());
-    systemMetadata.setRegistryVersion(aspectSpec.getRegistryVersion().toString());
-
-    RecordTemplate oldAspect = null;
-    SystemMetadata oldSystemMetadata = null;
-    RecordTemplate newAspect = aspect;
-    SystemMetadata newSystemMetadata = systemMetadata;
-
-    if (!aspectSpec.isTimeseries()) {
-      Timer.Context ingestToLocalDBTimer = MetricUtils.timer(this.getClass(), "ingestProposalToLocalDB").time();
-      UpdateAspectResult result =
-          ingestAspectToLocalDB(entityUrn, metadataChangeProposal.getAspectName(), ignored -> aspect, auditStamp,
-              systemMetadata, DEFAULT_MAX_TRANSACTION_RETRY);
-      ingestToLocalDBTimer.stop();
-      oldAspect = result.oldValue;
-      oldSystemMetadata = result.oldSystemMetadata;
-      newAspect = result.newValue;
-      newSystemMetadata = result.newSystemMetadata;
-    }
-
-    if (oldAspect != newAspect || _alwaysEmitAuditEvent) {
-      log.debug(String.format("Producing MetadataChangeLog for ingested aspect %s, urn %s",
-          metadataChangeProposal.getAspectName(), entityUrn));
-
-      final MetadataChangeLog metadataChangeLog = new MetadataChangeLog(metadataChangeProposal.data());
-      if (oldAspect != null) {
-        metadataChangeLog.setPreviousAspectValue(GenericAspectUtils.serializeAspect(oldAspect));
-      }
-      if (oldSystemMetadata != null) {
-        metadataChangeLog.setPreviousSystemMetadata(oldSystemMetadata);
-      }
-      if (newAspect != null) {
-        metadataChangeLog.setAspect(GenericAspectUtils.serializeAspect(newAspect));
-      }
-      if (newSystemMetadata != null) {
-        metadataChangeLog.setSystemMetadata(newSystemMetadata);
-      }
-
-      log.debug(String.format("Serialized MCL event: %s", metadataChangeLog));
-      // Since only timeseries aspects are ingested as of now, simply produce mae event for it
-      produceMetadataChangeLog(entityUrn, aspectSpec, metadataChangeLog);
-    } else {
-      log.debug(
-          String.format("Skipped producing MetadataAuditEvent for ingested aspect %s, urn %s. Aspect has not changed.",
-              metadataChangeProposal.getAspectName(), entityUrn));
-    }
-
-    return entityUrn;
   }
 
   private boolean filterMatch(SystemMetadata systemMetadata, Map<String, String> conditions) {
@@ -585,7 +431,7 @@ public class EbeanEntityService extends EntityService {
 
     return result;
   }
-  
+
 
   @Override
   public RollbackRunResult rollbackRun(List<AspectRowSummary> aspectRows, String runId) {
@@ -693,15 +539,5 @@ public class EbeanEntityService extends EntityService {
     }
     result.setEntities(entityUrns);
     return result;
-  }
-
-  @Value
-  private static class UpdateAspectResult {
-    Urn urn;
-    RecordTemplate oldValue;
-    RecordTemplate newValue;
-    SystemMetadata oldSystemMetadata;
-    SystemMetadata newSystemMetadata;
-    MetadataAuditOperation operation;
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanRetentionService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanRetentionService.java
@@ -1,0 +1,193 @@
+package com.linkedin.metadata.entity.ebean;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.RetentionService;
+import com.linkedin.retention.DataHubRetentionInfo;
+import com.linkedin.retention.Retention;
+import com.linkedin.retention.TimeBasedRetention;
+import com.linkedin.retention.VersionBasedRetention;
+import io.ebean.EbeanServer;
+import io.ebean.ExpressionList;
+import io.ebean.PagedList;
+import io.ebean.Transaction;
+import io.opentelemetry.extension.annotations.WithSpan;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.linkedin.metadata.Constants.ASPECT_LATEST_VERSION;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class EbeanRetentionService extends RetentionService {
+  private final EntityService _entityService;
+  private final EbeanServer _server;
+  private final int _batchSize;
+
+  private final Clock _clock = Clock.systemUTC();
+
+  public EntityService getEntityService() {
+    return _entityService;
+  }
+
+  @Override
+  @WithSpan
+  public void applyRetention(@Nonnull Urn urn, @Nonnull String aspectName, List<Retention> retentionPolicies,
+      Optional<RetentionService.RetentionContext> retentionContext) {
+    log.debug("Applying retention to urn {}, aspectName {}", urn, aspectName);
+    // If no policies are set or has indefinite policy set, do not apply any retention
+    if (retentionPolicies.isEmpty() || retentionPolicies.get(0).hasIndefinite()) {
+      return;
+    }
+    ExpressionList<EbeanAspectV2> deleteQuery = _server.find(EbeanAspectV2.class)
+        .where()
+        .eq(EbeanAspectV2.URN_COLUMN, urn.toString())
+        .eq(EbeanAspectV2.ASPECT_COLUMN, aspectName)
+        .ne(EbeanAspectV2.VERSION_COLUMN, ASPECT_LATEST_VERSION)
+        .or();
+    boolean retentionApplied = false;
+    for (Retention retention : retentionPolicies) {
+      if (retention.hasVersion() && applyVersionBasedRetention(urn, aspectName, deleteQuery, retention.getVersion(),
+          retentionContext.flatMap(RetentionService.RetentionContext::getMaxVersion))) {
+        retentionApplied = true;
+      } else if (retention.hasTime() && applyTimeBasedRetention(deleteQuery, retention.getTime())) {
+        retentionApplied = true;
+      }
+    }
+
+    // Only run delete if at least one of the retention policies are applicable
+    if (retentionApplied) {
+      deleteQuery.endOr().delete();
+    }
+  }
+
+  private long getMaxVersion(@Nonnull final String urn, @Nonnull final String aspectName) {
+    List<EbeanAspectV2> result = _server.find(EbeanAspectV2.class)
+        .where()
+        .eq("urn", urn)
+        .eq("aspect", aspectName)
+        .orderBy()
+        .desc("version")
+        .findList();
+    if (result.size() == 0) {
+      return -1;
+    }
+    return result.get(0).getKey().getVersion();
+  }
+
+  private boolean applyVersionBasedRetention(@Nonnull Urn urn, @Nonnull String aspectName,
+      @Nonnull final ExpressionList<EbeanAspectV2> querySoFar, @Nonnull final VersionBasedRetention retention,
+      final Optional<Long> maxVersionFromUpdate) {
+    long largestVersion = maxVersionFromUpdate.orElseGet(() -> getMaxVersion(urn.toString(), aspectName));
+
+    if (largestVersion < retention.getMaxVersions()) {
+      return false;
+    }
+    querySoFar.le(EbeanAspectV2.VERSION_COLUMN, largestVersion - retention.getMaxVersions() + 1);
+    return true;
+  }
+
+  private boolean applyTimeBasedRetention(@Nonnull final ExpressionList<EbeanAspectV2> querySoFar,
+      @Nonnull final TimeBasedRetention retention) {
+    querySoFar.lt(EbeanAspectV2.CREATED_ON_COLUMN,
+        new Timestamp(_clock.millis() - retention.getMaxAgeInSeconds() * 1000));
+    return true;
+  }
+
+  @Override
+  @WithSpan
+  public void batchApplyRetention(@Nullable String entityName, @Nullable String aspectName) {
+    log.debug("Applying retention to all records");
+    int numCandidates = queryCandidates(entityName, aspectName).findCount();
+    log.info("Found {} urn, aspect pair with more than 1 version", numCandidates);
+    Map<String, DataHubRetentionInfo> retentionPolicyMap = getRetentionPolicies();
+
+    int start = 0;
+    while (start < numCandidates) {
+      log.info("Applying retention to pairs {} through {}", start, start + _batchSize);
+      PagedList<EbeanAspectV2> rows = getPagedAspects(entityName, aspectName, start, _batchSize);
+
+      try (Transaction transaction = _server.beginTransaction()) {
+        transaction.setBatchMode(true);
+        transaction.setBatchSize(_batchSize);
+        for (EbeanAspectV2 row : rows.getList()) {
+          // Only run for cases where there's multiple versions of the aspect
+          if (row.getVersion() == 0) {
+            continue;
+          }
+          // 1. Extract an Entity type from the entity Urn
+          Urn urn;
+          try {
+            urn = Urn.createFromString(row.getUrn());
+          } catch (Exception e) {
+            log.error("Failed to serialize urn {}", row.getUrn(), e);
+            continue;
+          }
+          final String aspectNameFromRecord = row.getAspect();
+          // Get the retention policies to apply from the local retention policy map
+          List<Retention> retentionPolicies = getRetentionKeys(urn.getEntityType(), aspectNameFromRecord).stream()
+              .map(key -> retentionPolicyMap.get(key.toString()))
+              .filter(Objects::nonNull)
+              .findFirst().<List<Retention>>map(DataHubRetentionInfo::getRetentionPolicies).orElse(
+                  Collections.emptyList());
+          applyRetention(urn, aspectNameFromRecord, retentionPolicies,
+              Optional.of(new RetentionContext(Optional.of(row.getVersion()))));
+        }
+        transaction.commit();
+      }
+
+      start += _batchSize;
+    }
+
+    log.info("Finished applying retention to all records");
+  }
+
+  private Map<String, DataHubRetentionInfo> getRetentionPolicies() {
+    return _server.find(EbeanAspectV2.class)
+        .select(String.format("%s, %s, %s", EbeanAspectV2.URN_COLUMN, EbeanAspectV2.ASPECT_COLUMN,
+            EbeanAspectV2.METADATA_COLUMN))
+        .where()
+        .eq(EbeanAspectV2.ASPECT_COLUMN, DATAHUB_RETENTION_ASPECT)
+        .eq(EbeanAspectV2.VERSION_COLUMN, ASPECT_LATEST_VERSION)
+        .findList()
+        .stream()
+        .collect(Collectors.toMap(EbeanAspectV2::getUrn,
+            row -> RecordUtils.toRecordTemplate(DataHubRetentionInfo.class, row.getMetadata())));
+  }
+
+  private ExpressionList<EbeanAspectV2> queryCandidates(@Nullable String entityName, @Nullable String aspectName) {
+    ExpressionList<EbeanAspectV2> query = _server.find(EbeanAspectV2.class)
+        .setDistinct(true)
+        .select(String.format("%s, %s, max(%s)", EbeanAspectV2.URN_COLUMN, EbeanAspectV2.ASPECT_COLUMN,
+            EbeanAspectV2.VERSION_COLUMN))
+        .where();
+    if (entityName != null) {
+      query.like(EbeanAspectV2.URN_COLUMN, String.format("urn:li:%s%%", entityName));
+    }
+    if (aspectName != null) {
+      query.eq(EbeanAspectV2.ASPECT_COLUMN, aspectName);
+    }
+    return query;
+  }
+
+  private PagedList<EbeanAspectV2> getPagedAspects(@Nullable String entityName, @Nullable String aspectName,
+      final int start, final int pageSize) {
+    return queryCandidates(entityName, aspectName).orderBy(
+        EbeanAspectV2.URN_COLUMN + ", " + EbeanAspectV2.ASPECT_COLUMN)
+        .setFirstRow(start)
+        .setMaxRows(pageSize)
+        .findPagedList();
+  }
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/entity/EbeanEntityServiceTest.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.entity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.linkedin.common.AuditStamp;
+import com.linkedin.common.Status;
 import com.linkedin.common.urn.CorpuserUrn;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.ByteString;
@@ -19,6 +20,7 @@ import com.linkedin.metadata.aspect.VersionedAspect;
 import com.linkedin.metadata.entity.ebean.EbeanAspectDao;
 import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.entity.ebean.EbeanEntityService;
+import com.linkedin.metadata.entity.ebean.EbeanRetentionService;
 import com.linkedin.metadata.entity.ebean.EbeanUtils;
 import com.linkedin.metadata.event.EntityEventProducer;
 import com.linkedin.metadata.key.CorpUserKey;
@@ -37,6 +39,10 @@ import com.linkedin.mxe.GenericAspect;
 import com.linkedin.mxe.MetadataAuditOperation;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.mxe.SystemMetadata;
+import com.linkedin.retention.DataHubRetentionInfo;
+import com.linkedin.retention.Retention;
+import com.linkedin.retention.RetentionArray;
+import com.linkedin.retention.VersionBasedRetention;
 import io.ebean.EbeanServer;
 import io.ebean.EbeanServerFactory;
 import io.ebean.config.ServerConfig;
@@ -56,6 +62,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -71,6 +78,7 @@ public class EbeanEntityServiceTest {
   private EbeanAspectDao _aspectDao;
   private EbeanServer _server;
   private EntityEventProducer _mockProducer;
+  private EbeanRetentionService _retentionService;
 
   public EbeanEntityServiceTest() throws EntityRegistryException {
   }
@@ -107,6 +115,8 @@ public class EbeanEntityServiceTest {
     _aspectDao = new EbeanAspectDao(_server);
     _aspectDao.setConnectionValidated(true);
     _entityService = new EbeanEntityService(_aspectDao, _mockProducer, _testEntityRegistry);
+    _retentionService = new EbeanRetentionService(_entityService, _server, 1000);
+    _entityService.setRetentionService(_retentionService);
   }
 
   @Test
@@ -648,6 +658,62 @@ public class EbeanEntityServiceTest {
     assertEquals(3, (int) batch2.getTotal());
     assertEquals(1, batch2.getEntities().size());
     assertEquals(entityUrn3.toString(), batch2.getEntities().get(0).toString());
+  }
+
+  @Test
+  public void testRetention() throws Exception {
+    Urn entityUrn = Urn.createFromString("urn:li:corpuser:test1");
+
+    SystemMetadata metadata1 = new SystemMetadata();
+    metadata1.setLastObserved(1625792689);
+    metadata1.setRunId("run-123");
+
+    String aspectName = PegasusUtils.getAspectNameFromSchema(new CorpUserInfo().schema());
+
+    // Ingest CorpUserInfo Aspect
+    CorpUserInfo writeAspect1 = createCorpUserInfo("email@test.com");
+    _entityService.ingestAspect(entityUrn, aspectName, writeAspect1, TEST_AUDIT_STAMP, metadata1);
+    CorpUserInfo writeAspect1a = createCorpUserInfo("email_a@test.com");
+    _entityService.ingestAspect(entityUrn, aspectName, writeAspect1a, TEST_AUDIT_STAMP, metadata1);
+    CorpUserInfo writeAspect1b = createCorpUserInfo("email_b@test.com");
+    _entityService.ingestAspect(entityUrn, aspectName, writeAspect1b, TEST_AUDIT_STAMP, metadata1);
+
+    String aspectName2 = PegasusUtils.getAspectNameFromSchema(new Status().schema());
+    // Ingest Status Aspect
+    Status writeAspect2 = new Status().setRemoved(true);
+    _entityService.ingestAspect(entityUrn, aspectName2, writeAspect2, TEST_AUDIT_STAMP, metadata1);
+    Status writeAspect2a = new Status().setRemoved(false);
+    _entityService.ingestAspect(entityUrn, aspectName2, writeAspect2a, TEST_AUDIT_STAMP, metadata1);
+    Status writeAspect2b = new Status().setRemoved(true);
+    _entityService.ingestAspect(entityUrn, aspectName2, writeAspect2b, TEST_AUDIT_STAMP, metadata1);
+
+    assertEquals(_entityService.getAspect(entityUrn, aspectName, 1), writeAspect1);
+    assertEquals(_entityService.getAspect(entityUrn, aspectName2, 1), writeAspect2);
+
+    _retentionService.setRetention(null, null, new DataHubRetentionInfo().setRetentionPolicies(new RetentionArray(
+        ImmutableList.of(new Retention().setVersion(new VersionBasedRetention().setMaxVersions(2))))));
+    _retentionService.setRetention("corpuser", "status", new DataHubRetentionInfo().setRetentionPolicies(
+        new RetentionArray(
+            ImmutableList.of(new Retention().setVersion(new VersionBasedRetention().setMaxVersions(4))))));
+
+    // Ingest CorpUserInfo Aspect again
+    CorpUserInfo writeAspect1c = createCorpUserInfo("email_c@test.com");
+    _entityService.ingestAspect(entityUrn, aspectName, writeAspect1c, TEST_AUDIT_STAMP, metadata1);
+    // Ingest Status Aspect again
+    Status writeAspect2c = new Status().setRemoved(false);
+    _entityService.ingestAspect(entityUrn, aspectName2, writeAspect2c, TEST_AUDIT_STAMP, metadata1);
+
+    assertNull(_entityService.getAspect(entityUrn, aspectName, 1));
+    assertEquals(_entityService.getAspect(entityUrn, aspectName2, 1), writeAspect2);
+
+    // Reset retention policies
+    _retentionService.setRetention(null, null, new DataHubRetentionInfo().setRetentionPolicies(new RetentionArray(
+        ImmutableList.of(new Retention().setVersion(new VersionBasedRetention().setMaxVersions(1))))));
+    _retentionService.deleteRetention("corpuser", "status");
+    // Invoke batch apply
+    _retentionService.batchApplyRetention(null, null);
+    assertEquals(_entityService.listLatestAspects(entityUrn.getEntityType(), aspectName, 0, 10).getTotalCount(), 1);
+    assertEquals(_entityService.listLatestAspects(entityUrn.getEntityType(), aspectName2, 0, 10).getTotalCount(), 1);
   }
 
   @Nonnull

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataHubRetentionAspect.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/aspect/DataHubRetentionAspect.pdl
@@ -1,0 +1,12 @@
+namespace com.linkedin.metadata.aspect
+
+import com.linkedin.metadata.key.DataHubRetentionKey
+import com.linkedin.retention.DataHubRetentionInfo
+
+/**
+ * A union of all supported metadata aspects for a DataHub access policy.
+ */
+typeref DataHubRetentionAspect = union[
+    DataHubRetentionKey,
+    DataHubRetentionInfo
+]

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DataHubRetentionKey.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DataHubRetentionKey.pdl
@@ -1,0 +1,19 @@
+namespace com.linkedin.metadata.key
+
+/**
+ * Key for a DataHub Retention
+ */
+@Aspect = {
+  "name": "dataHubRetentionKey"
+}
+record DataHubRetentionKey {
+  /**
+   * Entity name to apply retention to. * (or empty) for applying defaults.
+   */
+  entityName: string
+
+  /**
+   * Aspect name to apply retention to. * (or empty) for applying defaults.
+   */
+  aspectName: string
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataHubRetentionSnapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/DataHubRetentionSnapshot.pdl
@@ -1,0 +1,24 @@
+namespace com.linkedin.metadata.snapshot
+
+import com.linkedin.common.Urn
+import com.linkedin.metadata.aspect.DataHubRetentionAspect
+
+/**
+ * A metadata snapshot for DataHub Access Policy data.
+ */
+@Entity = {
+  "name": "dataHubRetention",
+  "keyAspect": "dataHubRetentionKey"
+}
+record DataHubRetentionSnapshot {
+
+  /**
+   * URN for the entity the metadata snapshot is associated with.
+   */
+  urn: Urn
+
+  /**
+   * The list of metadata aspects associated with the DataHub access policy.
+   */
+  aspects: array[DataHubRetentionAspect]
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/Snapshot.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/snapshot/Snapshot.pdl
@@ -24,4 +24,5 @@ typeref Snapshot = union[
   GlossaryNodeSnapshot,
   DataHubPolicySnapshot,
   SchemaFieldSnapshot,
+  DataHubRetentionSnapshot,
 ]

--- a/metadata-models/src/main/pegasus/com/linkedin/retention/DataHubRetentionInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/retention/DataHubRetentionInfo.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.retention
+
+@Aspect = {
+  "name": "dataHubRetentionInfo"
+}
+record DataHubRetentionInfo {
+  retentionPolicies: array[Retention] = []
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/retention/IndefiniteRetention.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/retention/IndefiniteRetention.pdl
@@ -1,0 +1,7 @@
+namespace com.linkedin.retention
+
+/**
+ * Keep records indefinitely
+ */
+record IndefiniteRetention {
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/retention/Retention.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/retention/Retention.pdl
@@ -1,0 +1,11 @@
+namespace com.linkedin.retention
+
+/**
+ * Base class that encapsulates different retention policies.
+ * Only one of the fields should be set
+ */
+record Retention {
+  indefinite: optional IndefiniteRetention
+  version: optional VersionBasedRetention
+  time: optional TimeBasedRetention
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/retention/TimeBasedRetention.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/retention/TimeBasedRetention.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.retention
+
+/**
+ * Keep records that are less than X seconds old
+ */
+record TimeBasedRetention {
+  maxAgeInSeconds: int
+}

--- a/metadata-models/src/main/pegasus/com/linkedin/retention/VersionBasedRetention.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/retention/VersionBasedRetention.pdl
@@ -1,0 +1,8 @@
+namespace com.linkedin.retention
+
+/**
+ * Keep max N latest records
+ */
+record VersionBasedRetention {
+  maxVersions: int
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/RetentionServiceFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/RetentionServiceFactory.java
@@ -1,0 +1,42 @@
+package com.linkedin.gms.factory.entity;
+
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.RetentionService;
+import com.linkedin.metadata.entity.ebean.EbeanRetentionService;
+import io.ebean.EbeanServer;
+import javax.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.PropertySource;
+
+
+@Configuration
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class RetentionServiceFactory {
+
+  @Autowired
+  @Qualifier("entityService")
+  private EntityService _entityService;
+
+  @Autowired
+  @Qualifier("ebeanServer")
+  private EbeanServer _server;
+
+  @Value("${RETENTION_APPLICATION_BATCH_SIZE:1000}")
+  private Integer _batchSize;
+
+
+  @Bean(name = "retentionService")
+  @DependsOn({"ebeanServer", "entityService"})
+  @Nonnull
+  protected RetentionService createInstance() {
+    RetentionService retentionService = new EbeanRetentionService(_entityService, _server, _batchSize);
+    _entityService.setRetentionService(retentionService);
+    return retentionService;
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/PluginEntityRegistryFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entityregistry/PluginEntityRegistryFactory.java
@@ -1,6 +1,6 @@
 package com.linkedin.gms.factory.entityregistry;
 
-//import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
 import com.linkedin.metadata.models.registry.PluginEntityRegistryLoader;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
@@ -8,14 +8,14 @@ import javax.annotation.Nonnull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-//import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySource;
 
 
 @Configuration
-//@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
 public class PluginEntityRegistryFactory {
 
-  @Value("${ENTITY_REGISTRY_PLUGIN_PATH:/etc/datahub/plugins/models}")
+  @Value("${datahub.plugin.entityRegistry.path}")
   private String pluginRegistryPath;
 
   @Bean(name = "pluginEntityRegistry")

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/BootstrapManagerFactory.java
@@ -1,10 +1,12 @@
-package com.linkedin.metadata.boot;
+package com.linkedin.metadata.boot.factories;
 
 import com.google.common.collect.ImmutableList;
 import com.linkedin.gms.factory.entity.EntityServiceFactory;
+import com.linkedin.metadata.boot.BootstrapManager;
 import com.linkedin.metadata.boot.steps.IngestDataPlatformInstancesStep;
 import com.linkedin.metadata.boot.steps.IngestDataPlatformsStep;
 import com.linkedin.metadata.boot.steps.IngestPoliciesStep;
+import com.linkedin.metadata.boot.steps.IngestRetentionPoliciesStep;
 import com.linkedin.metadata.boot.steps.IngestRootUserStep;
 import com.linkedin.metadata.entity.EntityService;
 import io.ebean.EbeanServer;
@@ -29,6 +31,10 @@ public class BootstrapManagerFactory {
   @Qualifier("ebeanServer")
   private EbeanServer _server;
 
+  @Autowired
+  @Qualifier("ingestRetentionPoliciesStep")
+  private IngestRetentionPoliciesStep _ingestRetentionPoliciesStep;
+
   @Bean(name = "bootstrapManager")
   @Scope("singleton")
   @Nonnull
@@ -38,11 +44,7 @@ public class BootstrapManagerFactory {
     final IngestDataPlatformsStep ingestDataPlatformsStep = new IngestDataPlatformsStep(_entityService);
     final IngestDataPlatformInstancesStep ingestDataPlatformInstancesStep =
         new IngestDataPlatformInstancesStep(_entityService, _server);
-    return new BootstrapManager(
-        ImmutableList.of(
-            ingestRootUserStep,
-            ingestPoliciesStep,
-            ingestDataPlatformsStep,
-            ingestDataPlatformInstancesStep));
+    return new BootstrapManager(ImmutableList.of(ingestRootUserStep, ingestPoliciesStep, ingestDataPlatformsStep,
+        ingestDataPlatformInstancesStep, _ingestRetentionPoliciesStep));
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/IngestRetentionPoliciesStepFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/factories/IngestRetentionPoliciesStepFactory.java
@@ -1,0 +1,39 @@
+package com.linkedin.metadata.boot.factories;
+
+import com.linkedin.gms.factory.entity.RetentionServiceFactory;
+import com.linkedin.gms.factory.spring.YamlPropertySourceFactory;
+import com.linkedin.metadata.boot.steps.IngestRetentionPoliciesStep;
+import com.linkedin.metadata.entity.RetentionService;
+import javax.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.Scope;
+
+
+@Configuration
+@Import({RetentionServiceFactory.class})
+@PropertySource(value = "classpath:/application.yml", factory = YamlPropertySourceFactory.class)
+public class IngestRetentionPoliciesStepFactory {
+
+  @Autowired
+  @Qualifier("retentionService")
+  private RetentionService _retentionService;
+
+  @Value("${entityService.retention.disable}")
+  private Boolean _disable;
+
+  @Value("${datahub.plugin.retention.path}")
+  private String _pluginRegistryPath;
+
+  @Bean(name = "ingestRetentionPoliciesStep")
+  @Scope("singleton")
+  @Nonnull
+  protected IngestRetentionPoliciesStep createInstance() {
+    return new IngestRetentionPoliciesStep(_retentionService, _disable, _pluginRegistryPath);
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRetentionPoliciesStep.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/metadata/boot/steps/IngestRetentionPoliciesStep.java
@@ -1,0 +1,144 @@
+package com.linkedin.metadata.boot.steps;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.linkedin.metadata.boot.BootstrapStep;
+import com.linkedin.metadata.dao.utils.RecordUtils;
+import com.linkedin.metadata.entity.RetentionService;
+import com.linkedin.metadata.key.DataHubRetentionKey;
+import com.linkedin.retention.DataHubRetentionInfo;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+
+
+@Slf4j
+@RequiredArgsConstructor
+public class IngestRetentionPoliciesStep implements BootstrapStep {
+
+  private final RetentionService _retentionService;
+  private final boolean _disableRetention;
+  private final String pluginPath;
+
+  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+  @Nonnull
+  @Override
+  public ExecutionMode getExecutionMode() {
+    return ExecutionMode.ASYNC;
+  }
+
+  @Override
+  public String name() {
+    return "IngestRetentionPoliciesStep";
+  }
+
+  @Override
+  public void execute() throws IOException, URISyntaxException {
+    // 0. Execute preflight check to see whether we need to ingest policies
+    log.info("Ingesting default retention...");
+
+    // Whether we are at clean boot or not.
+    if (_disableRetention) {
+      log.info("IngestRetentionPolicies disabled. Skipping.");
+      return;
+    }
+
+    // 1. Read default retention config
+    final Map<DataHubRetentionKey, DataHubRetentionInfo> retentionPolicyMap =
+        parseFileOrDir(new ClassPathResource("./boot/retention.yaml").getFile());
+
+    // 2. Read plugin retention config files from input path and overlay
+    retentionPolicyMap.putAll(parseFileOrDir(new File(pluginPath)));
+
+    // 4. Set the specified retention policies
+    log.info("Setting {} policies", retentionPolicyMap.size());
+    boolean hasUpdate = false;
+    for (DataHubRetentionKey key : retentionPolicyMap.keySet()) {
+      if (_retentionService.setRetention(key.getEntityName(), key.getAspectName(), retentionPolicyMap.get(key))) {
+        hasUpdate = true;
+      }
+    }
+
+    // 5. If there were updates on any of the retention policies, apply retention to all records
+    if (hasUpdate) {
+      log.info("Applying policies to all records");
+      _retentionService.batchApplyRetention(null, null);
+    }
+  }
+
+  // Parse input yaml file or yaml files in the input directory to generate a retention policy map
+  private Map<DataHubRetentionKey, DataHubRetentionInfo> parseFileOrDir(File retentionFileOrDir) throws IOException {
+    // If path does not exist return empty
+    if (!retentionFileOrDir.exists()) {
+      return Collections.emptyMap();
+    }
+
+    // If directory, parse the yaml files under the directory
+    if (retentionFileOrDir.isDirectory()) {
+      Map<DataHubRetentionKey, DataHubRetentionInfo> result = new HashMap<>();
+
+      for (File retentionFile : retentionFileOrDir.listFiles()) {
+        if (!retentionFile.isFile()) {
+          log.info("Element {} in plugin directory {} is not a file. Skipping", retentionFile.getPath(),
+              retentionFileOrDir.getPath());
+          continue;
+        }
+        result.putAll(parseFileOrDir(retentionFile));
+      }
+      return result;
+    }
+    // If file, parse the yaml file and return result;
+    if (!retentionFileOrDir.getPath().endsWith(".yaml") && retentionFileOrDir.getPath().endsWith(".yml")) {
+      log.info("File {} is not a YAML file. Skipping", retentionFileOrDir.getPath());
+      return Collections.emptyMap();
+    }
+    return parseYamlRetentionConfig(retentionFileOrDir);
+  }
+
+  private Map<DataHubRetentionKey, DataHubRetentionInfo> parseYamlRetentionConfig(File retentionConfigFile)
+      throws IOException {
+    final JsonNode retentionPolicies = YAML_MAPPER.readTree(retentionConfigFile);
+    if (!retentionPolicies.isArray()) {
+      throw new IllegalArgumentException("Retention config file must contain an array of retention policies");
+    }
+
+    Map<DataHubRetentionKey, DataHubRetentionInfo> retentionPolicyMap = new HashMap<>();
+
+    for (JsonNode retentionPolicy : retentionPolicies) {
+      DataHubRetentionKey key = new DataHubRetentionKey();
+      if (retentionPolicy.has("entity")) {
+        key.setEntityName(retentionPolicy.get("entity").asText());
+      } else {
+        throw new IllegalArgumentException(
+            "Each element in the retention config must contain field entity. Set to * for setting defaults");
+      }
+
+      if (retentionPolicy.has("aspect")) {
+        key.setAspectName(retentionPolicy.get("aspect").asText());
+      } else {
+        throw new IllegalArgumentException(
+            "Each element in the retention config must contain field aspect. Set to * for setting defaults");
+      }
+
+      DataHubRetentionInfo retentionInfo;
+      if (retentionPolicy.has("retention")) {
+        retentionInfo =
+            RecordUtils.toRecordTemplate(DataHubRetentionInfo.class, retentionPolicy.get("retention").toString());
+      } else {
+        throw new IllegalArgumentException("Each element in the retention config must contain field retention");
+      }
+
+      retentionPolicyMap.put(key, retentionInfo);
+    }
+    return retentionPolicyMap;
+  }
+}

--- a/metadata-service/factories/src/main/resources/application.yml
+++ b/metadata-service/factories/src/main/resources/application.yml
@@ -32,6 +32,16 @@ datahub:
     sslContext:
       protocol: ${DATAHUB_GMS_SSL_PROTOCOL:${GMS_SSL_PROTOCOL:#{null}}}
 
+  plugin:
+    entityRegistry:
+      path: ${ENTITY_REGISTRY_PLUGIN_PATH:/etc/datahub/plugins/models}
+    retention:
+      path: ${RETENTION_PLUGIN_PATH:/etc/datahub/plugins/retention}
+
+entityService:
+  retention:
+    disable: ${ENTITY_SERVICE_DISABLE_RETENTION:true}
+
 graphService:
   type: ${GRAPH_SERVICE_IMPL:elasticsearch}
 
@@ -43,7 +53,7 @@ configEntityRegistry:
   path: ${ENTITY_REGISTRY_CONFIG_PATH:../../metadata-models/src/main/resources/entity-registry.yml}
 
 pluginEntityRegistry:
-  path: ${ENTITY_REGISTRY_PLUGIN_PATH:$HOME/.datahub/plugins/models}
+  path: ${ENTITY_REGISTRY_PLUGIN_PATH:/etc/datahub/plugins/models}
 
 authorizationManager:
   enabled: ${AUTH_POLICIES_ENABLED:true}

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -708,7 +708,7 @@
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
-              "fieldType" : "URN_PARTIAL",
+              "fieldType" : "URN",
               "filterNameOverride" : "Tag",
               "hasValuesFieldName" : "hasTags"
             }
@@ -785,7 +785,7 @@
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
-        "fieldType" : "URN_PARTIAL",
+        "fieldType" : "URN",
         "filterNameOverride" : "Glossary Term"
       }
     } ]
@@ -2027,20 +2027,21 @@
           "items" : {
             "type" : "record",
             "name" : "SchemaField",
-            "doc" : "SchemaField to describe metadata related to dataset schema. Schema normalization rules: http://go/tms-schema",
+            "doc" : "SchemaField to describe metadata related to dataset schema.",
             "fields" : [ {
               "name" : "fieldPath",
               "type" : "com.linkedin.dataset.SchemaFieldPath",
-              "doc" : "Flattened name of the field. Field is computed from jsonPath field. For data translation rules refer to wiki page above.",
+              "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
               "Searchable" : {
                 "fieldName" : "fieldPaths",
-                "fieldType" : "TEXT_PARTIAL"
+                "fieldType" : "TEXT"
               }
             }, {
               "name" : "jsonPath",
               "type" : "string",
               "doc" : "Flattened name of a field in JSON Path notation.",
-              "optional" : true
+              "optional" : true,
+              "Deprecated" : true
             }, {
               "name" : "nullable",
               "type" : "boolean",
@@ -2178,7 +2179,7 @@
                 "/tags/*/tag" : {
                   "boostScore" : 0.5,
                   "fieldName" : "fieldTags",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             }, {
@@ -2190,7 +2191,7 @@
                 "/terms/*/urn" : {
                   "boostScore" : 0.5,
                   "fieldName" : "fieldGlossaryTerms",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             }, {
@@ -2348,7 +2349,7 @@
                 "/tags/*/tag" : {
                   "boostScore" : 0.5,
                   "fieldName" : "editedFieldTags",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             }, {
@@ -2360,7 +2361,7 @@
                 "/terms/*/urn" : {
                   "boostScore" : 0.5,
                   "fieldName" : "editedFieldGlossaryTerms",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             } ]

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -776,7 +776,7 @@
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
-              "fieldType" : "URN_PARTIAL",
+              "fieldType" : "URN",
               "filterNameOverride" : "Tag",
               "hasValuesFieldName" : "hasTags"
             }
@@ -853,7 +853,7 @@
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
-        "fieldType" : "URN_PARTIAL",
+        "fieldType" : "URN",
         "filterNameOverride" : "Glossary Term"
       }
     } ]
@@ -2505,20 +2505,21 @@
                       "items" : {
                         "type" : "record",
                         "name" : "SchemaField",
-                        "doc" : "SchemaField to describe metadata related to dataset schema. Schema normalization rules: http://go/tms-schema",
+                        "doc" : "SchemaField to describe metadata related to dataset schema.",
                         "fields" : [ {
                           "name" : "fieldPath",
                           "type" : "com.linkedin.dataset.SchemaFieldPath",
-                          "doc" : "Flattened name of the field. Field is computed from jsonPath field. For data translation rules refer to wiki page above.",
+                          "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
                           "Searchable" : {
                             "fieldName" : "fieldPaths",
-                            "fieldType" : "TEXT_PARTIAL"
+                            "fieldType" : "TEXT"
                           }
                         }, {
                           "name" : "jsonPath",
                           "type" : "string",
                           "doc" : "Flattened name of a field in JSON Path notation.",
-                          "optional" : true
+                          "optional" : true,
+                          "Deprecated" : true
                         }, {
                           "name" : "nullable",
                           "type" : "boolean",
@@ -2656,7 +2657,7 @@
                             "/tags/*/tag" : {
                               "boostScore" : 0.5,
                               "fieldName" : "fieldTags",
-                              "fieldType" : "URN_PARTIAL"
+                              "fieldType" : "URN"
                             }
                           }
                         }, {
@@ -2668,7 +2669,7 @@
                             "/terms/*/urn" : {
                               "boostScore" : 0.5,
                               "fieldName" : "fieldGlossaryTerms",
-                              "fieldType" : "URN_PARTIAL"
+                              "fieldType" : "URN"
                             }
                           }
                         }, {
@@ -2826,7 +2827,7 @@
                             "/tags/*/tag" : {
                               "boostScore" : 0.5,
                               "fieldName" : "editedFieldTags",
-                              "fieldType" : "URN_PARTIAL"
+                              "fieldType" : "URN"
                             }
                           }
                         }, {
@@ -2838,7 +2839,7 @@
                             "/terms/*/urn" : {
                               "boostScore" : 0.5,
                               "fieldName" : "editedFieldGlossaryTerms",
-                              "fieldType" : "URN_PARTIAL"
+                              "fieldType" : "URN"
                             }
                           }
                         } ]
@@ -4463,10 +4464,106 @@
             "keyAspect" : "schemaFieldKey",
             "name" : "schemaField"
           }
+        }, {
+          "type" : "record",
+          "name" : "DataHubRetentionSnapshot",
+          "doc" : "A metadata snapshot for DataHub Access Policy data.",
+          "fields" : [ {
+            "name" : "urn",
+            "type" : "com.linkedin.common.Urn",
+            "doc" : "URN for the entity the metadata snapshot is associated with."
+          }, {
+            "name" : "aspects",
+            "type" : {
+              "type" : "array",
+              "items" : {
+                "type" : "typeref",
+                "name" : "DataHubRetentionAspect",
+                "namespace" : "com.linkedin.metadata.aspect",
+                "doc" : "A union of all supported metadata aspects for a DataHub access policy.",
+                "ref" : [ {
+                  "type" : "record",
+                  "name" : "DataHubRetentionKey",
+                  "namespace" : "com.linkedin.metadata.key",
+                  "doc" : "Key for a DataHub Retention",
+                  "fields" : [ {
+                    "name" : "entityName",
+                    "type" : "string",
+                    "doc" : "Entity name to apply retention to. * (or empty) for applying defaults."
+                  }, {
+                    "name" : "aspectName",
+                    "type" : "string",
+                    "doc" : "Aspect name to apply retention to. * (or empty) for applying defaults."
+                  } ],
+                  "Aspect" : {
+                    "name" : "dataHubRetentionKey"
+                  }
+                }, {
+                  "type" : "record",
+                  "name" : "DataHubRetentionInfo",
+                  "namespace" : "com.linkedin.retention",
+                  "fields" : [ {
+                    "name" : "retentionPolicies",
+                    "type" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "record",
+                        "name" : "Retention",
+                        "doc" : "Base class that encapsulates different retention policies.\nOnly one of the fields should be set",
+                        "fields" : [ {
+                          "name" : "indefinite",
+                          "type" : {
+                            "type" : "record",
+                            "name" : "IndefiniteRetention",
+                            "doc" : "Keep records indefinitely",
+                            "fields" : [ ]
+                          },
+                          "optional" : true
+                        }, {
+                          "name" : "version",
+                          "type" : {
+                            "type" : "record",
+                            "name" : "VersionBasedRetention",
+                            "doc" : "Keep max N latest records",
+                            "fields" : [ {
+                              "name" : "maxVersions",
+                              "type" : "int"
+                            } ]
+                          },
+                          "optional" : true
+                        }, {
+                          "name" : "time",
+                          "type" : {
+                            "type" : "record",
+                            "name" : "TimeBasedRetention",
+                            "doc" : "Keep records that are less than X seconds old",
+                            "fields" : [ {
+                              "name" : "maxAgeInSeconds",
+                              "type" : "int"
+                            } ]
+                          },
+                          "optional" : true
+                        } ]
+                      }
+                    },
+                    "default" : [ ]
+                  } ],
+                  "Aspect" : {
+                    "name" : "dataHubRetentionInfo"
+                  }
+                } ]
+              }
+            },
+            "doc" : "The list of metadata aspects associated with the DataHub access policy."
+          } ],
+          "Entity" : {
+            "keyAspect" : "dataHubRetentionKey",
+            "name" : "dataHubRetention"
+          }
         } ]
       }
     } ]
-  }, "com.linkedin.glossary.GlossaryNodeInfo", "com.linkedin.glossary.GlossaryRelatedTerms", "com.linkedin.glossary.GlossaryTermInfo", "com.linkedin.identity.CorpGroupInfo", "com.linkedin.identity.CorpUserEditableInfo", "com.linkedin.identity.CorpUserInfo", "com.linkedin.identity.CorpUserStatus", "com.linkedin.identity.GroupMembership", "com.linkedin.metadata.aspect.ChartAspect", "com.linkedin.metadata.aspect.CorpGroupAspect", "com.linkedin.metadata.aspect.CorpUserAspect", "com.linkedin.metadata.aspect.DashboardAspect", "com.linkedin.metadata.aspect.DataFlowAspect", "com.linkedin.metadata.aspect.DataHubPolicyAspect", "com.linkedin.metadata.aspect.DataJobAspect", "com.linkedin.metadata.aspect.DataPlatformAspect", "com.linkedin.metadata.aspect.DataProcessAspect", "com.linkedin.metadata.aspect.DatasetAspect", "com.linkedin.metadata.aspect.GlossaryNodeAspect", "com.linkedin.metadata.aspect.GlossaryTermAspect", "com.linkedin.metadata.aspect.MLFeatureAspect", "com.linkedin.metadata.aspect.MLFeatureTableAspect", "com.linkedin.metadata.aspect.MLModelAspect", "com.linkedin.metadata.aspect.MLModelDeploymentAspect", "com.linkedin.metadata.aspect.MLModelGroupAspect", "com.linkedin.metadata.aspect.MLPrimaryKeyAspect", "com.linkedin.metadata.aspect.SchemaFieldAspect", "com.linkedin.metadata.aspect.TagAspect", {
+  }, "com.linkedin.glossary.GlossaryNodeInfo", "com.linkedin.glossary.GlossaryRelatedTerms", "com.linkedin.glossary.GlossaryTermInfo", "com.linkedin.identity.CorpGroupInfo", "com.linkedin.identity.CorpUserEditableInfo", "com.linkedin.identity.CorpUserInfo", "com.linkedin.identity.CorpUserStatus", "com.linkedin.identity.GroupMembership", "com.linkedin.metadata.aspect.ChartAspect", "com.linkedin.metadata.aspect.CorpGroupAspect", "com.linkedin.metadata.aspect.CorpUserAspect", "com.linkedin.metadata.aspect.DashboardAspect", "com.linkedin.metadata.aspect.DataFlowAspect", "com.linkedin.metadata.aspect.DataHubPolicyAspect", "com.linkedin.metadata.aspect.DataHubRetentionAspect", "com.linkedin.metadata.aspect.DataJobAspect", "com.linkedin.metadata.aspect.DataPlatformAspect", "com.linkedin.metadata.aspect.DataProcessAspect", "com.linkedin.metadata.aspect.DatasetAspect", "com.linkedin.metadata.aspect.GlossaryNodeAspect", "com.linkedin.metadata.aspect.GlossaryTermAspect", "com.linkedin.metadata.aspect.MLFeatureAspect", "com.linkedin.metadata.aspect.MLFeatureTableAspect", "com.linkedin.metadata.aspect.MLModelAspect", "com.linkedin.metadata.aspect.MLModelDeploymentAspect", "com.linkedin.metadata.aspect.MLModelGroupAspect", "com.linkedin.metadata.aspect.MLPrimaryKeyAspect", "com.linkedin.metadata.aspect.SchemaFieldAspect", "com.linkedin.metadata.aspect.TagAspect", {
     "type" : "record",
     "name" : "BrowseResult",
     "namespace" : "com.linkedin.metadata.browse",
@@ -4550,7 +4647,7 @@
       "type" : "int",
       "doc" : "The total number of elements (entities + groups) directly under queried path"
     } ]
-  }, "com.linkedin.metadata.browse.BrowseResultEntity", "com.linkedin.metadata.browse.BrowseResultGroup", "com.linkedin.metadata.browse.BrowseResultMetadata", "com.linkedin.metadata.key.ChartKey", "com.linkedin.metadata.key.CorpGroupKey", "com.linkedin.metadata.key.CorpUserKey", "com.linkedin.metadata.key.DashboardKey", "com.linkedin.metadata.key.DataFlowKey", "com.linkedin.metadata.key.DataHubPolicyKey", "com.linkedin.metadata.key.DataJobKey", "com.linkedin.metadata.key.DataPlatformKey", "com.linkedin.metadata.key.DataProcessKey", "com.linkedin.metadata.key.DatasetKey", "com.linkedin.metadata.key.GlossaryNodeKey", "com.linkedin.metadata.key.GlossaryTermKey", "com.linkedin.metadata.key.MLFeatureKey", "com.linkedin.metadata.key.MLFeatureTableKey", "com.linkedin.metadata.key.MLModelDeploymentKey", "com.linkedin.metadata.key.MLModelGroupKey", "com.linkedin.metadata.key.MLModelKey", "com.linkedin.metadata.key.MLPrimaryKeyKey", "com.linkedin.metadata.key.SchemaFieldKey", "com.linkedin.metadata.key.TagKey", {
+  }, "com.linkedin.metadata.browse.BrowseResultEntity", "com.linkedin.metadata.browse.BrowseResultGroup", "com.linkedin.metadata.browse.BrowseResultMetadata", "com.linkedin.metadata.key.ChartKey", "com.linkedin.metadata.key.CorpGroupKey", "com.linkedin.metadata.key.CorpUserKey", "com.linkedin.metadata.key.DashboardKey", "com.linkedin.metadata.key.DataFlowKey", "com.linkedin.metadata.key.DataHubPolicyKey", "com.linkedin.metadata.key.DataHubRetentionKey", "com.linkedin.metadata.key.DataJobKey", "com.linkedin.metadata.key.DataPlatformKey", "com.linkedin.metadata.key.DataProcessKey", "com.linkedin.metadata.key.DatasetKey", "com.linkedin.metadata.key.GlossaryNodeKey", "com.linkedin.metadata.key.GlossaryTermKey", "com.linkedin.metadata.key.MLFeatureKey", "com.linkedin.metadata.key.MLFeatureTableKey", "com.linkedin.metadata.key.MLModelDeploymentKey", "com.linkedin.metadata.key.MLModelGroupKey", "com.linkedin.metadata.key.MLModelKey", "com.linkedin.metadata.key.MLPrimaryKeyKey", "com.linkedin.metadata.key.SchemaFieldKey", "com.linkedin.metadata.key.TagKey", {
     "type" : "record",
     "name" : "AutoCompleteResult",
     "namespace" : "com.linkedin.metadata.query",
@@ -4889,7 +4986,7 @@
       "type" : "int",
       "doc" : "The total number of entities directly under searched path"
     } ]
-  }, "com.linkedin.metadata.search.SearchResultMetadata", "com.linkedin.metadata.snapshot.ChartSnapshot", "com.linkedin.metadata.snapshot.CorpGroupSnapshot", "com.linkedin.metadata.snapshot.CorpUserSnapshot", "com.linkedin.metadata.snapshot.DashboardSnapshot", "com.linkedin.metadata.snapshot.DataFlowSnapshot", "com.linkedin.metadata.snapshot.DataHubPolicySnapshot", "com.linkedin.metadata.snapshot.DataJobSnapshot", "com.linkedin.metadata.snapshot.DataPlatformSnapshot", "com.linkedin.metadata.snapshot.DataProcessSnapshot", "com.linkedin.metadata.snapshot.DatasetSnapshot", "com.linkedin.metadata.snapshot.GlossaryNodeSnapshot", "com.linkedin.metadata.snapshot.GlossaryTermSnapshot", "com.linkedin.metadata.snapshot.MLFeatureSnapshot", "com.linkedin.metadata.snapshot.MLFeatureTableSnapshot", "com.linkedin.metadata.snapshot.MLModelDeploymentSnapshot", "com.linkedin.metadata.snapshot.MLModelGroupSnapshot", "com.linkedin.metadata.snapshot.MLModelSnapshot", "com.linkedin.metadata.snapshot.MLPrimaryKeySnapshot", "com.linkedin.metadata.snapshot.SchemaFieldSnapshot", "com.linkedin.metadata.snapshot.Snapshot", "com.linkedin.metadata.snapshot.TagSnapshot", "com.linkedin.ml.metadata.BaseData", "com.linkedin.ml.metadata.CaveatDetails", "com.linkedin.ml.metadata.CaveatsAndRecommendations", "com.linkedin.ml.metadata.DeploymentStatus", "com.linkedin.ml.metadata.EthicalConsiderations", "com.linkedin.ml.metadata.EvaluationData", "com.linkedin.ml.metadata.HyperParameterValueType", "com.linkedin.ml.metadata.IntendedUse", "com.linkedin.ml.metadata.IntendedUserType", "com.linkedin.ml.metadata.MLFeatureProperties", "com.linkedin.ml.metadata.MLFeatureTableProperties", "com.linkedin.ml.metadata.MLHyperParam", "com.linkedin.ml.metadata.MLMetric", "com.linkedin.ml.metadata.MLModelDeploymentProperties", "com.linkedin.ml.metadata.MLModelFactorPrompts", "com.linkedin.ml.metadata.MLModelFactors", "com.linkedin.ml.metadata.MLModelGroupProperties", "com.linkedin.ml.metadata.MLModelProperties", "com.linkedin.ml.metadata.MLPrimaryKeyProperties", "com.linkedin.ml.metadata.Metrics", "com.linkedin.ml.metadata.QuantitativeAnalyses", "com.linkedin.ml.metadata.ResultsType", "com.linkedin.ml.metadata.SourceCode", "com.linkedin.ml.metadata.SourceCodeUrl", "com.linkedin.ml.metadata.SourceCodeUrlType", "com.linkedin.ml.metadata.TrainingData", {
+  }, "com.linkedin.metadata.search.SearchResultMetadata", "com.linkedin.metadata.snapshot.ChartSnapshot", "com.linkedin.metadata.snapshot.CorpGroupSnapshot", "com.linkedin.metadata.snapshot.CorpUserSnapshot", "com.linkedin.metadata.snapshot.DashboardSnapshot", "com.linkedin.metadata.snapshot.DataFlowSnapshot", "com.linkedin.metadata.snapshot.DataHubPolicySnapshot", "com.linkedin.metadata.snapshot.DataHubRetentionSnapshot", "com.linkedin.metadata.snapshot.DataJobSnapshot", "com.linkedin.metadata.snapshot.DataPlatformSnapshot", "com.linkedin.metadata.snapshot.DataProcessSnapshot", "com.linkedin.metadata.snapshot.DatasetSnapshot", "com.linkedin.metadata.snapshot.GlossaryNodeSnapshot", "com.linkedin.metadata.snapshot.GlossaryTermSnapshot", "com.linkedin.metadata.snapshot.MLFeatureSnapshot", "com.linkedin.metadata.snapshot.MLFeatureTableSnapshot", "com.linkedin.metadata.snapshot.MLModelDeploymentSnapshot", "com.linkedin.metadata.snapshot.MLModelGroupSnapshot", "com.linkedin.metadata.snapshot.MLModelSnapshot", "com.linkedin.metadata.snapshot.MLPrimaryKeySnapshot", "com.linkedin.metadata.snapshot.SchemaFieldSnapshot", "com.linkedin.metadata.snapshot.Snapshot", "com.linkedin.metadata.snapshot.TagSnapshot", "com.linkedin.ml.metadata.BaseData", "com.linkedin.ml.metadata.CaveatDetails", "com.linkedin.ml.metadata.CaveatsAndRecommendations", "com.linkedin.ml.metadata.DeploymentStatus", "com.linkedin.ml.metadata.EthicalConsiderations", "com.linkedin.ml.metadata.EvaluationData", "com.linkedin.ml.metadata.HyperParameterValueType", "com.linkedin.ml.metadata.IntendedUse", "com.linkedin.ml.metadata.IntendedUserType", "com.linkedin.ml.metadata.MLFeatureProperties", "com.linkedin.ml.metadata.MLFeatureTableProperties", "com.linkedin.ml.metadata.MLHyperParam", "com.linkedin.ml.metadata.MLMetric", "com.linkedin.ml.metadata.MLModelDeploymentProperties", "com.linkedin.ml.metadata.MLModelFactorPrompts", "com.linkedin.ml.metadata.MLModelFactors", "com.linkedin.ml.metadata.MLModelGroupProperties", "com.linkedin.ml.metadata.MLModelProperties", "com.linkedin.ml.metadata.MLPrimaryKeyProperties", "com.linkedin.ml.metadata.Metrics", "com.linkedin.ml.metadata.QuantitativeAnalyses", "com.linkedin.ml.metadata.ResultsType", "com.linkedin.ml.metadata.SourceCode", "com.linkedin.ml.metadata.SourceCodeUrl", "com.linkedin.ml.metadata.SourceCodeUrlType", "com.linkedin.ml.metadata.TrainingData", {
     "type" : "record",
     "name" : "SystemMetadata",
     "namespace" : "com.linkedin.mxe",
@@ -4925,7 +5022,7 @@
       "doc" : "Additional properties",
       "optional" : true
     } ]
-  }, "com.linkedin.policy.DataHubActorFilter", "com.linkedin.policy.DataHubPolicyInfo", "com.linkedin.policy.DataHubResourceFilter", "com.linkedin.schema.ArrayType", "com.linkedin.schema.BinaryJsonSchema", "com.linkedin.schema.BooleanType", "com.linkedin.schema.BytesType", "com.linkedin.schema.DatasetFieldForeignKey", "com.linkedin.schema.DateType", "com.linkedin.schema.EditableSchemaFieldInfo", "com.linkedin.schema.EditableSchemaMetadata", "com.linkedin.schema.EnumType", "com.linkedin.schema.EspressoSchema", "com.linkedin.schema.FixedType", "com.linkedin.schema.ForeignKeyConstraint", "com.linkedin.schema.ForeignKeySpec", "com.linkedin.schema.KafkaSchema", "com.linkedin.schema.KeyValueSchema", "com.linkedin.schema.MapType", "com.linkedin.schema.MySqlDDL", "com.linkedin.schema.NullType", "com.linkedin.schema.NumberType", "com.linkedin.schema.OracleDDL", "com.linkedin.schema.OrcSchema", "com.linkedin.schema.OtherSchema", "com.linkedin.schema.PrestoDDL", "com.linkedin.schema.RecordType", "com.linkedin.schema.SchemaField", "com.linkedin.schema.SchemaFieldDataType", "com.linkedin.schema.SchemaMetadata", "com.linkedin.schema.SchemaMetadataKey", "com.linkedin.schema.Schemaless", "com.linkedin.schema.StringType", "com.linkedin.schema.TimeType", "com.linkedin.schema.UnionType", "com.linkedin.schema.UrnForeignKey", "com.linkedin.tag.TagProperties" ],
+  }, "com.linkedin.policy.DataHubActorFilter", "com.linkedin.policy.DataHubPolicyInfo", "com.linkedin.policy.DataHubResourceFilter", "com.linkedin.retention.DataHubRetentionInfo", "com.linkedin.retention.IndefiniteRetention", "com.linkedin.retention.Retention", "com.linkedin.retention.TimeBasedRetention", "com.linkedin.retention.VersionBasedRetention", "com.linkedin.schema.ArrayType", "com.linkedin.schema.BinaryJsonSchema", "com.linkedin.schema.BooleanType", "com.linkedin.schema.BytesType", "com.linkedin.schema.DatasetFieldForeignKey", "com.linkedin.schema.DateType", "com.linkedin.schema.EditableSchemaFieldInfo", "com.linkedin.schema.EditableSchemaMetadata", "com.linkedin.schema.EnumType", "com.linkedin.schema.EspressoSchema", "com.linkedin.schema.FixedType", "com.linkedin.schema.ForeignKeyConstraint", "com.linkedin.schema.ForeignKeySpec", "com.linkedin.schema.KafkaSchema", "com.linkedin.schema.KeyValueSchema", "com.linkedin.schema.MapType", "com.linkedin.schema.MySqlDDL", "com.linkedin.schema.NullType", "com.linkedin.schema.NumberType", "com.linkedin.schema.OracleDDL", "com.linkedin.schema.OrcSchema", "com.linkedin.schema.OtherSchema", "com.linkedin.schema.PrestoDDL", "com.linkedin.schema.RecordType", "com.linkedin.schema.SchemaField", "com.linkedin.schema.SchemaFieldDataType", "com.linkedin.schema.SchemaMetadata", "com.linkedin.schema.SchemaMetadataKey", "com.linkedin.schema.Schemaless", "com.linkedin.schema.StringType", "com.linkedin.schema.TimeType", "com.linkedin.schema.UnionType", "com.linkedin.schema.UrnForeignKey", "com.linkedin.tag.TagProperties" ],
   "schema" : {
     "name" : "entities",
     "namespace" : "com.linkedin.entity",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -556,7 +556,7 @@
             "Searchable" : {
               "addToFilters" : true,
               "fieldName" : "tags",
-              "fieldType" : "URN_PARTIAL",
+              "fieldType" : "URN",
               "filterNameOverride" : "Tag",
               "hasValuesFieldName" : "hasTags"
             }
@@ -633,7 +633,7 @@
       "Searchable" : {
         "addToFilters" : true,
         "fieldName" : "glossaryTerms",
-        "fieldType" : "URN_PARTIAL",
+        "fieldType" : "URN",
         "filterNameOverride" : "Glossary Term"
       }
     } ]
@@ -1862,20 +1862,21 @@
           "items" : {
             "type" : "record",
             "name" : "SchemaField",
-            "doc" : "SchemaField to describe metadata related to dataset schema. Schema normalization rules: http://go/tms-schema",
+            "doc" : "SchemaField to describe metadata related to dataset schema.",
             "fields" : [ {
               "name" : "fieldPath",
               "type" : "com.linkedin.dataset.SchemaFieldPath",
-              "doc" : "Flattened name of the field. Field is computed from jsonPath field. For data translation rules refer to wiki page above.",
+              "doc" : "Flattened name of the field. Field is computed from jsonPath field.",
               "Searchable" : {
                 "fieldName" : "fieldPaths",
-                "fieldType" : "TEXT_PARTIAL"
+                "fieldType" : "TEXT"
               }
             }, {
               "name" : "jsonPath",
               "type" : "string",
               "doc" : "Flattened name of a field in JSON Path notation.",
-              "optional" : true
+              "optional" : true,
+              "Deprecated" : true
             }, {
               "name" : "nullable",
               "type" : "boolean",
@@ -2013,7 +2014,7 @@
                 "/tags/*/tag" : {
                   "boostScore" : 0.5,
                   "fieldName" : "fieldTags",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             }, {
@@ -2025,7 +2026,7 @@
                 "/terms/*/urn" : {
                   "boostScore" : 0.5,
                   "fieldName" : "fieldGlossaryTerms",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             }, {
@@ -2183,7 +2184,7 @@
                 "/tags/*/tag" : {
                   "boostScore" : 0.5,
                   "fieldName" : "editedFieldTags",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             }, {
@@ -2195,7 +2196,7 @@
                 "/terms/*/urn" : {
                   "boostScore" : 0.5,
                   "fieldName" : "editedFieldGlossaryTerms",
-                  "fieldType" : "URN_PARTIAL"
+                  "fieldType" : "URN"
                 }
               }
             } ]

--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/JavaEntityClient.java
@@ -355,7 +355,7 @@ public class JavaEntityClient implements EntityClient {
         final List<MetadataChangeProposal> additionalChanges =
             AspectUtils.getAdditionalChanges(metadataChangeProposal, _entityService);
 
-        Urn urn = _entityService.ingestProposal(metadataChangeProposal, auditStamp);
+        Urn urn = _entityService.ingestProposal(metadataChangeProposal, auditStamp).getUrn();
         additionalChanges.forEach(proposal -> _entityService.ingestProposal(proposal, auditStamp));
         return urn.toString();
     }

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/AspectResource.java
@@ -132,7 +132,7 @@ public class AspectResource extends CollectionResourceTaskTemplate<String, Versi
     return RestliUtil.toTask(() -> {
       log.debug("Proposal: {}", metadataChangeProposal);
       try {
-        Urn urn = _entityService.ingestProposal(metadataChangeProposal, auditStamp);
+        Urn urn = _entityService.ingestProposal(metadataChangeProposal, auditStamp).getUrn();
         additionalChanges.forEach(proposal -> _entityService.ingestProposal(proposal, auditStamp));
         return urn.toString();
       } catch (ValidationException e) {

--- a/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
+++ b/metadata-service/restli-servlet-impl/src/main/java/com/linkedin/metadata/resources/entity/EntityResource.java
@@ -10,6 +10,7 @@ import com.linkedin.entity.Entity;
 import com.linkedin.metadata.Constants;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.entity.RetentionService;
 import com.linkedin.metadata.entity.RollbackRunResult;
 import com.linkedin.metadata.entity.ValidationException;
 import com.linkedin.metadata.query.AutoCompleteResult;
@@ -58,9 +59,22 @@ import javax.inject.Named;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
-import static com.linkedin.metadata.entity.ValidationUtils.*;
-import static com.linkedin.metadata.restli.RestliConstants.*;
-import static com.linkedin.metadata.utils.PegasusUtils.*;
+import static com.linkedin.metadata.entity.ValidationUtils.validateOrThrow;
+import static com.linkedin.metadata.restli.RestliConstants.ACTION_AUTOCOMPLETE;
+import static com.linkedin.metadata.restli.RestliConstants.ACTION_BROWSE;
+import static com.linkedin.metadata.restli.RestliConstants.ACTION_GET_BROWSE_PATHS;
+import static com.linkedin.metadata.restli.RestliConstants.ACTION_INGEST;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_ASPECTS;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_FIELD;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_FILTER;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_INPUT;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_LIMIT;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_PATH;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_QUERY;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_SORT;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_START;
+import static com.linkedin.metadata.restli.RestliConstants.PARAM_URN;
+import static com.linkedin.metadata.utils.PegasusUtils.urnToEntityName;
 
 
 /**
@@ -99,6 +113,10 @@ public class EntityResource extends CollectionResourceTaskTemplate<String, Entit
   @Inject
   @Named("systemMetadataService")
   private SystemMetadataService _systemMetadataService;
+
+  @Inject
+  @Named("retentionService")
+  private RetentionService _retentionService;
 
   /**
    * Retrieves the value for an entity that is made up of latest versions of specified aspects.

--- a/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
+++ b/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
@@ -24,6 +24,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 public class Config extends HttpServlet {
   Map<String, String> config = new HashMap<String, String>() {{
     put("noCode", "true");
+    put("retention", "true");
   }};
   ObjectMapper objectMapper = new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
@@ -51,8 +52,7 @@ public class Config extends HttpServlet {
     PrintWriter out = resp.getWriter();
 
     try {
-      Map<String, Object> config = new HashMap<>();
-      config.put("noCode", "true");
+      Map<String, Object> config = new HashMap<>(this.config);
       Map<String, Map<ComparableVersion, EntityRegistryLoadResult>> pluginTree =
           getPluginModels(req.getServletContext());
       config.put("models", pluginTree);

--- a/metadata-service/war/src/main/resources/boot/retention.yaml
+++ b/metadata-service/war/src/main/resources/boot/retention.yaml
@@ -1,0 +1,14 @@
+- entity: "*"
+  aspect: "*"
+  retention:
+    retentionPolicies:
+      - version:
+          maxVersions: 20
+#- entity: dataset
+#  aspect: datasetProperties
+#  retention:
+#    retentionPolicies:
+#      - version:
+#          maxVersions: 10
+#      - time:
+#          maxAgeInSeconds: 2592000 # 30 days

--- a/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/Constants.java
@@ -29,11 +29,11 @@ public class Constants {
   public static final String CORP_USER_STATUS_ASPECT_NAME = "corpUserStatus";
   public static final String CORP_USER_KEY_ASPECT_NAME = "corpUserKey";
 
-
   /**
    * User Status
    */
   public static final String CORP_USER_STATUS_ACTIVE = "ACTIVE";
 
-  private Constants() { }
+  private Constants() {
+  }
 }

--- a/metadata-utils/src/main/java/com/linkedin/metadata/utils/EntityKeyUtils.java
+++ b/metadata-utils/src/main/java/com/linkedin/metadata/utils/EntityKeyUtils.java
@@ -139,7 +139,7 @@ public class EntityKeyUtils {
     final List<String> urnParts = new ArrayList<>();
     for (RecordDataSchema.Field field : keyAspect.schema().getFields()) {
       Object value = keyAspect.data().get(field.getName());
-      String valueString = value.toString();
+      String valueString = value == null ? "" : value.toString();
       urnParts.add(valueString); // TODO: Determine whether all fields, including urns, should be URL encoded.
     }
     return Urn.createFromTuple(entityName, urnParts);


### PR DESCRIPTION
Add retention to Local DB. To do this: 
1. Added RetentionService that is coupled with EntityService
- Manages retention policies (get, set, delete policies for entity, aspect combo - both optional to set defaults)
- Apply retention policy to a given urn, aspect
- Apply retention policies in batch
2. Created a DataHubRetention entity to store the retention policies. This lets us use all the useful capabilities that an entity has within entity service
3. Setup triggering logic for applying retention. 
a) Each call to setRetention triggers a batchApplyRetention for the affected rows
a) bootstrap step: on start-up, if there are no retention ingested, it sets retention for default based on env variable, which inturn calls batchApplyRetention for all rows

## Checklist
- [v] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [v] Tests for the changes have been added/updated (if applicable)
- [v] Docs related to the changes have been added/updated (if applicable)
