### PR TITLE
Fix CVE-2021-44228

### DIFF
--- a/metadata-dao-impl/kafka-producer/build.gradle
+++ b/metadata-dao-impl/kafka-producer/build.gradle
@@ -15,4 +15,13 @@ dependencies {
   annotationProcessor externalDependency.lombok
 
   testCompile externalDependency.mockito
+  
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }

--- a/metadata-events/mxe-registration/build.gradle
+++ b/metadata-events/mxe-registration/build.gradle
@@ -13,6 +13,15 @@ dependencies {
   testCompile project(':metadata-testing:metadata-test-utils')
 
   avroOriginal project(path: ':metadata-models', configuration: 'avroSchema')
+  
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }
 
 // copy original MXE avro schema from metadata-models to resources

--- a/metadata-events/mxe-utils-avro-1.7/build.gradle
+++ b/metadata-events/mxe-utils-avro-1.7/build.gradle
@@ -7,6 +7,15 @@ dependencies {
 
   testCompile externalDependency.gmaDaoApi
   testCompile project(':metadata-testing:metadata-test-utils')
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }
 
 // copy original MXE avro schema from metadata-events to resources

--- a/metadata-ingestion-examples/common/build.gradle
+++ b/metadata-ingestion-examples/common/build.gradle
@@ -17,4 +17,13 @@ dependencies {
   annotationProcessor externalDependency.lombok
 
   runtime externalDependency.logbackClassic
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }

--- a/metadata-ingestion-examples/kafka-etl/build.gradle
+++ b/metadata-ingestion-examples/kafka-etl/build.gradle
@@ -20,6 +20,15 @@ dependencies {
   annotationProcessor externalDependency.lombok
 
   runtime externalDependency.logbackClassic
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }
 
 bootJar {

--- a/metadata-ingestion-examples/mce-cli/build.gradle
+++ b/metadata-ingestion-examples/mce-cli/build.gradle
@@ -26,6 +26,16 @@ dependencies {
 
   annotationProcessor externalDependency.lombok
   annotationProcessor externalDependency.picocli
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
+
 }
 
 bootJar {

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -45,6 +45,15 @@ dependencies {
   testCompile project(':test-models')
 
   testAnnotationProcessor externalDependency.lombok
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }
 
 test {

--- a/metadata-service/restli-servlet-impl/build.gradle
+++ b/metadata-service/restli-servlet-impl/build.gradle
@@ -23,6 +23,15 @@ configurations {
 }
 
 dependencies {
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228") 
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
+
   compile project(':metadata-service:restli-api')
   compile project(path: ':metadata-service:restli-api', configuration: 'dataTemplate')
   compile project(':li-utils')

--- a/metadata-testing/metadata-models-test-utils/build.gradle
+++ b/metadata-testing/metadata-models-test-utils/build.gradle
@@ -10,4 +10,13 @@ dependencies {
   compile externalDependency.jacksonDataBind
   compile externalDependency.lombok
   compile externalDependency.neo4jHarness
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }

--- a/metadata-testing/metadata-test-utils/build.gradle
+++ b/metadata-testing/metadata-test-utils/build.gradle
@@ -9,4 +9,13 @@ dependencies {
   compile externalDependency.jacksonDataBind
   compile externalDependency.lombok
   compile externalDependency.neo4jHarness
+
+  constraints {
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
 }

--- a/metadata-utils/build.gradle
+++ b/metadata-utils/build.gradle
@@ -26,4 +26,14 @@ dependencies {
 
   testCompile project(':test-models')
   testCompile project(':metadata-testing:metadata-test-utils')
+
+  constraints {
+      implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+          because("previous versions are vulnerable to CVE-2021-44228")
+      }
+      implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+        because("previous versions are vulnerable to CVE-2021-44228")
+    }
+  }
+  
 }


### PR DESCRIPTION
A [vulnerability ](https://www.lunasec.io/docs/blog/log4j-zero-day/)has been identified in `log4j`. The latest version `2.15.0` fixes the vulnerability.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
