### PR TITLE
fix(recommendations): don't show a `0` character when there are no suggestions

### DIFF
--- a/datahub-web-react/src/app/search/SearchResultsRecommendations.tsx
+++ b/datahub-web-react/src/app/search/SearchResultsRecommendations.tsx
@@ -54,7 +54,7 @@ export const SearchResultsRecommendations = ({ userUrn, query, filters }: Props)
     const recommendationModules = data?.listRecommendations?.modules;
     return (
         <>
-            {recommendationModules && recommendationModules.length && (
+            {recommendationModules && !!recommendationModules.length && (
                 <RecommendationsContainer>
                     <RecommendationTitle level={3}>More you may be interested in</RecommendationTitle>
                     {recommendationModules &&


### PR DESCRIPTION
`0` is not truthy in javascript but it is considered valid html content. in this case, it will exit the `&&` chain but return `0`, which renders. Transforming it into a boolean with `!!`, we will no longer render an artifact because `false` is rendered the same as `null`-- with nothing.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
