### PR TITLE
feat(snowflake-usage): add knob for direct objects accesssed vs base objects accessed

### DIFF
--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -139,18 +139,19 @@ sink:
 
 Note that a `.` is used to denote nested fields in the YAML recipe.
 
-| Field             | Required | Default                                                        | Description                                                     |
-| ----------------- | -------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
-| `username`        |          |                                                                | Snowflake username.                                             |
-| `password`        |          |                                                                | Snowflake password.                                             |
-| `host_port`       | ✅       |                                                                | Snowflake host URL.                                             |
-| `warehouse`       |          |                                                                | Snowflake warehouse.                                            |
-| `role`            |          |                                                                | Snowflake role.                                                 |
-| `env`             |          | `"PROD"`                                                       | Environment to use in namespace when constructing URNs.         |
-| `bucket_duration` |          | `"DAY"`                                                        | Duration to bucket usage events by. Can be `"DAY"` or `"HOUR"`. |
-| `start_time`      |          | Last full day in UTC (or hour, depending on `bucket_duration`) | Earliest date of usage logs to consider.                        |
-| `end_time`        |          | Last full day in UTC (or hour, depending on `bucket_duration`) | Latest date of usage logs to consider.                          |
-| `top_n_queries`   |          | `10`                                                           | Number of top queries to save to each table.                    |
+| Field                         | Required | Default                                                        | Description                                                     |
+| ----------------------------- | -------- | -------------------------------------------------------------- | --------------------------------------------------------------- |
+| `username`                    |          |                                                                | Snowflake username.                                             |
+| `password`                    |          |                                                                | Snowflake password.                                             |
+| `host_port`                   | ✅       |                                                                | Snowflake host URL.                                             |
+| `warehouse`                   |          |                                                                | Snowflake warehouse.                                            |
+| `role`                        |          |                                                                | Snowflake role.                                                 |
+| `env`                         |          | `"PROD"`                                                       | Environment to use in namespace when constructing URNs.         |
+| `bucket_duration`             |          | `"DAY"`                                                        | Duration to bucket usage events by. Can be `"DAY"` or `"HOUR"`. |
+| `start_time`                  |          | Last full day in UTC (or hour, depending on `bucket_duration`) | Earliest date of usage logs to consider.                        |
+| `end_time`                    |          | Last full day in UTC (or hour, depending on `bucket_duration`) | Latest date of usage logs to consider.                          |
+| `top_n_queries`               |          | `10`                                                           | Number of top queries to save to each table.                    |
+| `use_base_objects_accessed`   |          | False                                                          | Applies queries issued to views to the underlying table.        |
 
 ### Compatibility
 

--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -151,7 +151,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `start_time`                  |          | Last full day in UTC (or hour, depending on `bucket_duration`) | Earliest date of usage logs to consider.                        |
 | `end_time`                    |          | Last full day in UTC (or hour, depending on `bucket_duration`) | Latest date of usage logs to consider.                          |
 | `top_n_queries`               |          | `10`                                                           | Number of top queries to save to each table.                    |
-| `use_base_objects_accessed`   |          | False                                                          | Applies queries issued to views to the underlying table.        |
+| `apply_view_usage_to_tables`  |          | False                                                          | Attribute usage of views to the underlying table.               |
 
 ### Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -97,7 +97,6 @@ class SnowflakeUsageConfig(BaseSnowflakeConfig, BaseUsageConfig):
     options: dict = {}
     use_base_objects_accessed: bool = False
 
-
     @pydantic.validator("role", always=True)
     def role_accountadmin(cls, v):
         if not v or v.lower() != "accountadmin":

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -147,7 +147,6 @@ class SnowflakeUsageSource(Source):
 
     def _get_snowflake_history(self) -> Iterable[SnowflakeJoinedAccessEvent]:
         query = self._make_usage_query()
-        print(query)
         engine = self._make_sql_engine()
 
         results = engine.execute(query)

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -33,7 +33,7 @@ SELECT
     query_history.query_text,
     query_history.query_type,
     access_history.base_objects_accessed,
-    -- access_history.direct_objects_accessed, -- might be useful in the future
+    access_history.direct_objects_accessed, -- when dealing with views, direct objects will show the view while base will show the underlying table
     -- query_history.execution_status, -- not really necessary, but should equal "SUCCESS"
     -- query_history.warehouse_name,
     access_history.user_name,
@@ -82,6 +82,7 @@ class SnowflakeJoinedAccessEvent(PermissiveModel):
     query_text: str
     query_type: str
     base_objects_accessed: List[SnowflakeObjectAccessEntry]
+    direct_objects_accessed: List[SnowflakeObjectAccessEntry]
 
     user_name: str
     first_name: Optional[str]
@@ -94,6 +95,8 @@ class SnowflakeJoinedAccessEvent(PermissiveModel):
 class SnowflakeUsageConfig(BaseSnowflakeConfig, BaseUsageConfig):
     env: str = builder.DEFAULT_ENV
     options: dict = {}
+    use_base_objects_accessed: bool = False
+
 
     @pydantic.validator("role", always=True)
     def role_accountadmin(cls, v):
@@ -144,6 +147,7 @@ class SnowflakeUsageSource(Source):
 
     def _get_snowflake_history(self) -> Iterable[SnowflakeJoinedAccessEvent]:
         query = self._make_usage_query()
+        print(query)
         engine = self._make_sql_engine()
 
         results = engine.execute(query)
@@ -161,14 +165,19 @@ class SnowflakeUsageSource(Source):
             if event_dict["query_text"] is None:
                 continue
 
-            def is_unsupported_base_object_accessed(obj: Dict[str, Any]) -> bool:
+            def is_unsupported_object_accessed(obj: Dict[str, Any]) -> bool:
                 unsupported_keys = ["locations"]
                 return any([obj.get(key) is not None for key in unsupported_keys])
 
             event_dict["base_objects_accessed"] = [
                 obj
                 for obj in json.loads(event_dict["base_objects_accessed"])
-                if not is_unsupported_base_object_accessed(obj)
+                if not is_unsupported_object_accessed(obj)
+            ]
+            event_dict["direct_objects_accessed"] = [
+                obj
+                for obj in json.loads(event_dict["direct_objects_accessed"])
+                if not is_unsupported_object_accessed(obj)
             ]
             event_dict["query_start_time"] = (
                 event_dict["query_start_time"]
@@ -195,7 +204,13 @@ class SnowflakeUsageSource(Source):
                 event.query_start_time, self.config.bucket_duration
             )
 
-            for object in event.base_objects_accessed:
+            accessed_data = []
+            if self.config.use_base_objects_accessed:
+                accessed_data = event.base_objects_accessed
+            else:
+                accessed_data = event.direct_objects_accessed
+
+            for object in accessed_data:
                 resource = object.objectName
 
                 agg_bucket = datasets[floored_ts].setdefault(

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -95,7 +95,7 @@ class SnowflakeJoinedAccessEvent(PermissiveModel):
 class SnowflakeUsageConfig(BaseSnowflakeConfig, BaseUsageConfig):
     env: str = builder.DEFAULT_ENV
     options: dict = {}
-    use_base_objects_accessed: bool = False
+    apply_view_usage_to_tables: bool = False
 
     @pydantic.validator("role", always=True)
     def role_accountadmin(cls, v):
@@ -203,7 +203,7 @@ class SnowflakeUsageSource(Source):
             )
 
             accessed_data = []
-            if self.config.use_base_objects_accessed:
+            if self.config.apply_view_usage_to_tables:
                 accessed_data = event.base_objects_accessed
             else:
                 accessed_data = event.direct_objects_accessed


### PR DESCRIPTION
`direct_objects_accessed` will display the view in the case a view is used. `base_objects_accessed` will display the underlying table the view was built off of. For usage, it makes more sense to default to `direct_objects_accessed`. This also includes a knob to use `base_objects_accessed` in the case a user would prefer that.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
