### PR TITLE
test(ingest): fix pytest warning for class starting with `Test`

### DIFF
--- a/metadata-ingestion/tests/unit/test_usage_common.py
+++ b/metadata-ingestion/tests/unit/test_usage_common.py
@@ -12,9 +12,9 @@ from datahub.ingestion.source.usage.usage_common import (
 )
 from datahub.metadata.schema_classes import DatasetUsageStatisticsClass
 
-TestTableRef = str
+_TestTableRef = str
 
-TestAggregatedDataset = GenericAggregatedDataset[TestTableRef]
+_TestAggregatedDataset = GenericAggregatedDataset[_TestTableRef]
 
 
 def test_add_one_query_without_columns():
@@ -27,7 +27,7 @@ def test_add_one_query_without_columns():
 
     resource = "test_db.test_schema.test_table"
 
-    ta = TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
+    ta = _TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
     ta.add_read_entry(
         test_email,
         test_query,
@@ -52,7 +52,7 @@ def test_multiple_query_without_columns():
 
     resource = "test_db.test_schema.test_table"
 
-    ta = TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
+    ta = _TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
     ta.add_read_entry(
         test_email,
         test_query,
@@ -88,7 +88,7 @@ def test_make_usage_workunit():
 
     resource = "test_db.test_schema.test_table"
 
-    ta = TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
+    ta = _TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
     ta.add_read_entry(
         test_email,
         test_query,
@@ -117,7 +117,7 @@ def test_query_trimming():
 
     resource = "test_db.test_schema.test_table"
 
-    ta = TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
+    ta = _TestAggregatedDataset(bucket_start_time=floored_ts, resource=resource)
     ta.total_budget_for_query_list = total_budget_for_query_list
 
     ta.add_read_entry(


### PR DESCRIPTION
Pytest tries to treat classes of the form `Test*` as classes with tests, which is incorrect here. Adding the underscore prefix resolves the issue.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
