### PR TITLE
refactor(test): replace `CliRunner` with `run_datahub_cmd` method

### DIFF
--- a/metadata-ingestion/tests/integration/hive/test_hive.py
+++ b/metadata-ingestion/tests/integration/hive/test_hive.py
@@ -1,12 +1,10 @@
 import subprocess
 
 import pytest
-from click.testing import CliRunner
 from freezegun import freeze_time
 
-from datahub.entrypoints import datahub
-from tests.test_helpers import fs_helpers, mce_helpers
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 
 FROZEN_TIME = "2020-04-14 07:00:00"
@@ -27,11 +25,10 @@ def test_hive_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         subprocess.run(command, shell=True, check=True)
 
         # Run the metadata ingestion pipeline.
-        runner = CliRunner()
-        with fs_helpers.isolated_filesystem(tmp_path):
-            config_file = (test_resources_dir / "hive_to_file.yml").resolve()
-            result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-            assert_result_ok(result)
+        config_file = (test_resources_dir / "hive_to_file.yml").resolve()
+        run_datahub_cmd(
+            ["ingest", "-c", f"{config_file}"], tmp_path=tmp_path, check_result=True
+        )
 
         # Verify the output.
         mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/hive/test_hive.py
+++ b/metadata-ingestion/tests/integration/hive/test_hive.py
@@ -26,9 +26,7 @@ def test_hive_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
 
         # Run the metadata ingestion pipeline.
         config_file = (test_resources_dir / "hive_to_file.yml").resolve()
-        run_datahub_cmd(
-            ["ingest", "-c", f"{config_file}"], tmp_path=tmp_path, check_result=True
-        )
+        run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
 
         # Verify the output.
         mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -183,11 +183,7 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
 
         # Run the metadata ingestion pipeline.
         config_file = (test_resources_dir / "kafka_connect_to_file.yml").resolve()
-        run_datahub_cmd(
-            ["ingest", "-c", f"{config_file}"],
-            tmp_path=tmp_path,
-            check_result=True,
-        )
+        run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
 
         # Verify the output.
         mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
+++ b/metadata-ingestion/tests/integration/kafka-connect/test_kafka_connect.py
@@ -2,12 +2,10 @@ import time
 
 import pytest
 import requests
-from click.testing import CliRunner
 from freezegun import freeze_time
 
-from datahub.entrypoints import datahub
-from tests.test_helpers import fs_helpers, mce_helpers
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 
 FROZEN_TIME = "2021-10-25 13:00:00"
@@ -184,13 +182,12 @@ def test_kafka_connect_ingest(docker_compose_runner, pytestconfig, tmp_path, moc
         time.sleep(45)
 
         # Run the metadata ingestion pipeline.
-        runner = CliRunner()
-        with fs_helpers.isolated_filesystem(tmp_path):
-            print(tmp_path)
-            config_file = (test_resources_dir / "kafka_connect_to_file.yml").resolve()
-            result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-            # import pdb;pdb.set_trace();
-            assert_result_ok(result)
+        config_file = (test_resources_dir / "kafka_connect_to_file.yml").resolve()
+        run_datahub_cmd(
+            ["ingest", "-c", f"{config_file}"],
+            tmp_path=tmp_path,
+            check_result=True,
+        )
 
         # Verify the output.
         mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/kafka/test_kafka.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka.py
@@ -28,11 +28,7 @@ def test_kafka_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
 
         # Run the metadata ingestion pipeline.
         config_file = (test_resources_dir / "kafka_to_file.yml").resolve()
-        run_datahub_cmd(
-            ["ingest", "-c", f"{config_file}"],
-            tmp_path=tmp_path,
-            check_result=True,
-        )
+        run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
 
         # Verify the output.
         mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/kafka/test_kafka.py
+++ b/metadata-ingestion/tests/integration/kafka/test_kafka.py
@@ -1,11 +1,10 @@
 import subprocess
 
 import pytest
-from click.testing import CliRunner
 from freezegun import freeze_time
 
-from datahub.entrypoints import datahub
-from tests.test_helpers import fs_helpers, mce_helpers
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 
 FROZEN_TIME = "2020-04-14 07:00:00"
@@ -28,11 +27,12 @@ def test_kafka_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         subprocess.run(command, shell=True, check=True)
 
         # Run the metadata ingestion pipeline.
-        runner = CliRunner()
-        with fs_helpers.isolated_filesystem(tmp_path):
-            config_file = (test_resources_dir / "kafka_to_file.yml").resolve()
-            result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-            assert result.exit_code == 0
+        config_file = (test_resources_dir / "kafka_to_file.yml").resolve()
+        run_datahub_cmd(
+            ["ingest", "-c", f"{config_file}"],
+            tmp_path=tmp_path,
+            check_result=True,
+        )
 
         # Verify the output.
         mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/mysql/test_mysql.py
+++ b/metadata-ingestion/tests/integration/mysql/test_mysql.py
@@ -27,6 +27,6 @@ def test_mysql_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         # Verify the output.
         mce_helpers.check_golden_file(
             pytestconfig,
-            output_path="mysql_mces.json",
+            output_path=tmp_path / "mysql_mces.json",
             golden_path=test_resources_dir / "mysql_mces_golden.json",
         )

--- a/metadata-ingestion/tests/integration/mysql/test_mysql.py
+++ b/metadata-ingestion/tests/integration/mysql/test_mysql.py
@@ -21,9 +21,7 @@ def test_mysql_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         # Run the metadata ingestion pipeline.
         config_file = (test_resources_dir / "mysql_to_file.yml").resolve()
         run_datahub_cmd(
-            ["ingest", "--strict-warnings", "-c", f"{config_file}"],
-            tmp_path=tmp_path,
-            check_result=True,
+            ["ingest", "--strict-warnings", "-c", f"{config_file}"], tmp_path=tmp_path
         )
 
         # Verify the output.

--- a/metadata-ingestion/tests/integration/mysql/test_mysql.py
+++ b/metadata-ingestion/tests/integration/mysql/test_mysql.py
@@ -1,10 +1,8 @@
 import pytest
-from click.testing import CliRunner
 from freezegun import freeze_time
 
-from datahub.entrypoints import datahub
-from tests.test_helpers import fs_helpers, mce_helpers
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 
 FROZEN_TIME = "2020-04-14 07:00:00"
@@ -21,17 +19,16 @@ def test_mysql_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         wait_for_port(docker_services, "testmysql", 3306)
 
         # Run the metadata ingestion pipeline.
-        runner = CliRunner()
-        with fs_helpers.isolated_filesystem(tmp_path):
-            config_file = (test_resources_dir / "mysql_to_file.yml").resolve()
-            result = runner.invoke(
-                datahub, ["ingest", "--strict-warnings", "-c", f"{config_file}"]
-            )
-            assert_result_ok(result)
+        config_file = (test_resources_dir / "mysql_to_file.yml").resolve()
+        run_datahub_cmd(
+            ["ingest", "--strict-warnings", "-c", f"{config_file}"],
+            tmp_path=tmp_path,
+            check_result=True,
+        )
 
-            # Verify the output.
-            mce_helpers.check_golden_file(
-                pytestconfig,
-                output_path="mysql_mces.json",
-                golden_path=test_resources_dir / "mysql_mces_golden.json",
-            )
+        # Verify the output.
+        mce_helpers.check_golden_file(
+            pytestconfig,
+            output_path="mysql_mces.json",
+            golden_path=test_resources_dir / "mysql_mces_golden.json",
+        )

--- a/metadata-ingestion/tests/integration/openapi/test_openapi.py
+++ b/metadata-ingestion/tests/integration/openapi/test_openapi.py
@@ -1,10 +1,8 @@
 import pytest
-from click.testing import CliRunner
 from freezegun import freeze_time
 
-from datahub.entrypoints import datahub
-from tests.test_helpers import fs_helpers, mce_helpers
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 
 FROZEN_TIME = "2020-04-14 07:00:00"
 
@@ -15,15 +13,16 @@ def test_openapi_ingest(pytestconfig, tmp_path):
     test_resources_dir = pytestconfig.rootpath / "tests/integration/openapi"
 
     # Run the metadata ingestion pipeline.
-    runner = CliRunner()
-    with fs_helpers.isolated_filesystem(tmp_path):
-        config_file = (test_resources_dir / "openapi_to_file.yml").resolve()
-        result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-        assert_result_ok(result)
+    config_file = (test_resources_dir / "openapi_to_file.yml").resolve()
+    run_datahub_cmd(
+        ["ingest", "-c", f"{config_file}"],
+        tmp_path=tmp_path,
+        check_result=True,
+    )
 
-        # Verify the output.
-        mce_helpers.check_golden_file(
-            pytestconfig,
-            output_path="/tmp/openapi_mces.json",
-            golden_path=test_resources_dir / "openapi_mces_golden.json",
-        )
+    # Verify the output.
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path="/tmp/openapi_mces.json",
+        golden_path=test_resources_dir / "openapi_mces_golden.json",
+    )

--- a/metadata-ingestion/tests/integration/openapi/test_openapi.py
+++ b/metadata-ingestion/tests/integration/openapi/test_openapi.py
@@ -14,11 +14,7 @@ def test_openapi_ingest(pytestconfig, tmp_path):
 
     # Run the metadata ingestion pipeline.
     config_file = (test_resources_dir / "openapi_to_file.yml").resolve()
-    run_datahub_cmd(
-        ["ingest", "-c", f"{config_file}"],
-        tmp_path=tmp_path,
-        check_result=True,
-    )
+    run_datahub_cmd(["ingest", "-c", f"{config_file}"], tmp_path=tmp_path)
 
     # Verify the output.
     mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/sql_server/test_sql_server.py
+++ b/metadata-ingestion/tests/integration/sql_server/test_sql_server.py
@@ -32,9 +32,7 @@ def test_mssql_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         # Run the metadata ingestion pipeline.
         config_file = (test_resources_dir / "mssql_to_file.yml").resolve()
         run_datahub_cmd(
-            ["ingest", "-c", f"{config_file}"],
-            tmp_path=tmp_path,
-            check_result=True,
+            ["ingest", "-c", f"{config_file}"], tmp_path=tmp_path, check_result=True
         )
 
         # Verify the output.

--- a/metadata-ingestion/tests/integration/sql_server/test_sql_server.py
+++ b/metadata-ingestion/tests/integration/sql_server/test_sql_server.py
@@ -2,11 +2,9 @@ import subprocess
 import time
 
 import pytest
-from click.testing import CliRunner
 
-from datahub.entrypoints import datahub
-from tests.test_helpers import fs_helpers, mce_helpers
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 
 
@@ -33,14 +31,15 @@ def test_mssql_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
 
         # Run the metadata ingestion pipeline.
         config_file = (test_resources_dir / "mssql_to_file.yml").resolve()
-        runner = CliRunner()
-        with fs_helpers.isolated_filesystem(tmp_path):
-            result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-            assert_result_ok(result)
+        run_datahub_cmd(
+            ["ingest", "-c", f"{config_file}"],
+            tmp_path=tmp_path,
+            check_result=True,
+        )
 
-            # Verify the output.
-            mce_helpers.check_golden_file(
-                pytestconfig,
-                output_path="./mssql_mces.json",
-                golden_path=test_resources_dir / "mssql_mces_golden.json",
-            )
+        # Verify the output.
+        mce_helpers.check_golden_file(
+            pytestconfig,
+            output_path="./mssql_mces.json",
+            golden_path=test_resources_dir / "mssql_mces_golden.json",
+        )

--- a/metadata-ingestion/tests/integration/sql_server/test_sql_server.py
+++ b/metadata-ingestion/tests/integration/sql_server/test_sql_server.py
@@ -38,6 +38,6 @@ def test_mssql_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         # Verify the output.
         mce_helpers.check_golden_file(
             pytestconfig,
-            output_path="./mssql_mces.json",
+            output_path=tmp_path / "mssql_mces.json",
             golden_path=test_resources_dir / "mssql_mces_golden.json",
         )

--- a/metadata-ingestion/tests/integration/trino/test_trino.py
+++ b/metadata-ingestion/tests/integration/trino/test_trino.py
@@ -3,12 +3,10 @@ import sys
 
 import pytest
 import requests
-from click.testing import CliRunner
 from freezegun import freeze_time
 
-from datahub.entrypoints import datahub
 from tests.test_helpers import fs_helpers, mce_helpers
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.docker_helpers import wait_for_port
 
 FROZEN_TIME = "2021-09-23 12:00:00"
@@ -38,13 +36,14 @@ def test_trino_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
         subprocess.run(command, shell=True, check=True)
 
         # Run the metadata ingestion pipeline.
-        runner = CliRunner()
         with fs_helpers.isolated_filesystem(tmp_path):
 
             # Run the metadata ingestion pipeline for trino catalog referring to postgres database
             config_file = (test_resources_dir / "trino_to_file.yml").resolve()
-            result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-            assert_result_ok(result)
+            run_datahub_cmd(
+                ["ingest", "-c", f"{config_file}"],
+                check_result=True,
+            )
             # Verify the output.
             mce_helpers.check_golden_file(
                 pytestconfig,
@@ -58,8 +57,10 @@ def test_trino_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
 
             # Run the metadata ingestion pipeline for trino catalog referring to hive database
             config_file = (test_resources_dir / "trino_hive_to_file.yml").resolve()
-            result = runner.invoke(datahub, ["ingest", "-c", f"{config_file}"])
-            assert_result_ok(result)
+            run_datahub_cmd(
+                ["ingest", "-c", f"{config_file}"],
+                check_result=True,
+            )
 
             # Verify the output.
             mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/integration/trino/test_trino.py
+++ b/metadata-ingestion/tests/integration/trino/test_trino.py
@@ -40,10 +40,7 @@ def test_trino_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
 
             # Run the metadata ingestion pipeline for trino catalog referring to postgres database
             config_file = (test_resources_dir / "trino_to_file.yml").resolve()
-            run_datahub_cmd(
-                ["ingest", "-c", f"{config_file}"],
-                check_result=True,
-            )
+            run_datahub_cmd(["ingest", "-c", f"{config_file}"])
             # Verify the output.
             mce_helpers.check_golden_file(
                 pytestconfig,
@@ -57,10 +54,7 @@ def test_trino_ingest(docker_compose_runner, pytestconfig, tmp_path, mock_time):
 
             # Run the metadata ingestion pipeline for trino catalog referring to hive database
             config_file = (test_resources_dir / "trino_hive_to_file.yml").resolve()
-            run_datahub_cmd(
-                ["ingest", "-c", f"{config_file}"],
-                check_result=True,
-            )
+            run_datahub_cmd(["ingest", "-c", f"{config_file}"])
 
             # Verify the output.
             mce_helpers.check_golden_file(

--- a/metadata-ingestion/tests/test_helpers/click_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/click_helpers.py
@@ -1,7 +1,29 @@
-from click.testing import Result
+from pathlib import Path
+from typing import List, Optional
+
+from click.testing import CliRunner, Result
+
+from datahub.entrypoints import datahub
+from tests.test_helpers import fs_helpers
 
 
 def assert_result_ok(result: Result) -> None:
     if result.exception:
         raise result.exception
     assert result.exit_code == 0
+
+
+def run_datahub_cmd(
+    command: List[str], tmp_path: Optional[Path] = None, check_result: bool = True
+) -> Result:
+    runner = CliRunner()
+
+    if tmp_path is None:
+        result = runner.invoke(datahub, command)
+    else:
+        with fs_helpers.isolated_filesystem(tmp_path):
+            result = runner.invoke(datahub, command)
+
+    if check_result:
+        assert_result_ok(result)
+    return result

--- a/metadata-ingestion/tests/test_helpers/fs_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/fs_helpers.py
@@ -1,9 +1,11 @@
 import contextlib
 import os
+import pathlib
+from typing import Iterator
 
 
 @contextlib.contextmanager
-def isolated_filesystem(temp_dir):
+def isolated_filesystem(temp_dir: pathlib.Path) -> Iterator[None]:
     cwd = os.getcwd()
 
     os.chdir(temp_dir)

--- a/metadata-ingestion/tests/unit/serde/test_serde.py
+++ b/metadata-ingestion/tests/unit/serde/test_serde.py
@@ -114,10 +114,7 @@ def test_serde_to_avro(pytestconfig: PytestConfig, json_filename: str) -> None:
 def test_check_mce_schema(pytestconfig: PytestConfig, json_filename: str) -> None:
     json_file_path = pytestconfig.rootpath / json_filename
 
-    run_datahub_cmd(
-        ["check", "mce-file", f"{json_file_path}"],
-        check_result=True,
-    )
+    run_datahub_cmd(["check", "mce-file", f"{json_file_path}"])
 
 
 @pytest.mark.parametrize(

--- a/metadata-ingestion/tests/unit/serde/test_serde.py
+++ b/metadata-ingestion/tests/unit/serde/test_serde.py
@@ -4,17 +4,16 @@ import pathlib
 
 import fastavro
 import pytest
-from click.testing import CliRunner
 from freezegun import freeze_time
 
 import datahub.metadata.schema_classes as models
 from datahub.cli.json_file import check_mce_file
-from datahub.entrypoints import datahub
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.source.file import iterate_mce_file
 from datahub.metadata.schema_classes import MetadataChangeEventClass
 from datahub.metadata.schemas import getMetadataChangeEventSchema
 from tests.test_helpers import mce_helpers
+from tests.test_helpers.click_helpers import run_datahub_cmd
 from tests.test_helpers.type_helpers import PytestConfig
 
 FROZEN_TIME = "2021-07-22 18:54:06"
@@ -115,9 +114,10 @@ def test_serde_to_avro(pytestconfig: PytestConfig, json_filename: str) -> None:
 def test_check_mce_schema(pytestconfig: PytestConfig, json_filename: str) -> None:
     json_file_path = pytestconfig.rootpath / json_filename
 
-    runner = CliRunner()
-    result = runner.invoke(datahub, ["check", "mce-file", f"{json_file_path}"])
-    assert result.exit_code == 0
+    run_datahub_cmd(
+        ["check", "mce-file", f"{json_file_path}"],
+        check_result=True,
+    )
 
 
 @pytest.mark.parametrize(

--- a/metadata-ingestion/tests/unit/test_check.py
+++ b/metadata-ingestion/tests/unit/test_check.py
@@ -1,17 +1,13 @@
-from click.testing import CliRunner
-
-from datahub.entrypoints import datahub
+from tests.test_helpers.click_helpers import run_datahub_cmd
 
 
 def test_cli_help():
-    runner = CliRunner()
-    result = runner.invoke(datahub, ["--help"])
+    result = run_datahub_cmd(["--help"], check_result=True)
     assert result.output
 
 
 def test_cli_version():
-    runner = CliRunner()
-    result = runner.invoke(datahub, ["--debug", "version"])
+    result = run_datahub_cmd(["--debug", "version"], check_result=True)
     assert result.output
 
 
@@ -19,6 +15,5 @@ def test_check_local_docker():
     # This just verifies that it runs without error.
     # We don't actually know what environment this will be run in, so
     # we can't depend on the output. Eventually, we should mock the docker SDK.
-    runner = CliRunner()
-    result = runner.invoke(datahub, ["check", "local-docker"])
+    result = run_datahub_cmd(["check", "local-docker"], check_result=False)
     assert result.output

--- a/metadata-ingestion/tests/unit/test_check.py
+++ b/metadata-ingestion/tests/unit/test_check.py
@@ -2,12 +2,12 @@ from tests.test_helpers.click_helpers import run_datahub_cmd
 
 
 def test_cli_help():
-    result = run_datahub_cmd(["--help"], check_result=True)
+    result = run_datahub_cmd(["--help"])
     assert result.output
 
 
 def test_cli_version():
-    result = run_datahub_cmd(["--debug", "version"], check_result=True)
+    result = run_datahub_cmd(["--debug", "version"])
     assert result.output
 
 

--- a/metadata-ingestion/tests/unit/test_plugin_system.py
+++ b/metadata-ingestion/tests/unit/test_plugin_system.py
@@ -33,7 +33,7 @@ def test_list_all(verbose: bool) -> None:
     args = ["check", "plugins"]
     if verbose:
         args.append("--verbose")
-    result = run_datahub_cmd(args, check_result=True)
+    result = run_datahub_cmd(args)
     assert len(result.output.splitlines()) > 20
 
 

--- a/metadata-ingestion/tests/unit/test_plugin_system.py
+++ b/metadata-ingestion/tests/unit/test_plugin_system.py
@@ -1,8 +1,6 @@
 import pytest
-from click.testing import CliRunner
 
 from datahub.configuration.common import ConfigurationError
-from datahub.entrypoints import datahub
 from datahub.ingestion.api.registry import PluginRegistry
 from datahub.ingestion.api.sink import Sink
 from datahub.ingestion.extractor.extractor_registry import extractor_registry
@@ -10,7 +8,7 @@ from datahub.ingestion.sink.console import ConsoleSink
 from datahub.ingestion.sink.sink_registry import sink_registry
 from datahub.ingestion.source.source_registry import source_registry
 from datahub.ingestion.transformer.transform_registry import transform_registry
-from tests.test_helpers.click_helpers import assert_result_ok
+from tests.test_helpers.click_helpers import run_datahub_cmd
 
 
 @pytest.mark.parametrize(
@@ -32,12 +30,10 @@ def test_registry_nonempty(registry):
 )
 def test_list_all(verbose: bool) -> None:
     # This just verifies that it runs without error.
-    runner = CliRunner()
     args = ["check", "plugins"]
     if verbose:
         args.append("--verbose")
-    result = runner.invoke(datahub, args)
-    assert_result_ok(result)
+    result = run_datahub_cmd(args, check_result=True)
     assert len(result.output.splitlines()) > 20
 
 


### PR DESCRIPTION
This should streamline our integration tests a bit.

It will also prevent us from forgetting to call `assert_result_ok`.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
