### PR TITLE
refactor(gms auth): Remove base64 decoding of token service signing key 

### DIFF
--- a/metadata-service/auth-impl/build.gradle
+++ b/metadata-service/auth-impl/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
   implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
   runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
-      'io.jsonwebtoken:jjwt-jackson:0.11.2' // or 'io.jsonwebtoken:jjwt-gson:0.11.2' for gson
+      'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
   compile externalDependency.lombok
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
@@ -7,9 +7,9 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -104,8 +104,7 @@ public class TokenService {
     if (this.iss != null) {
       builder.setIssuer(this.iss);
     }
-    byte[] apiKeySecretBytes = Base64.getDecoder().decode(this.signingKey); // Key must be base64'd.
-    final Key signingKey = new SecretKeySpec(apiKeySecretBytes, this.signingAlgorithm.getJcaName());
+    final Key signingKey = new SecretKeySpec(this.signingKey.getBytes(StandardCharsets.UTF_8), this.signingAlgorithm.getJcaName());
     return builder.signWith(signingKey, this.signingAlgorithm).compact();
   }
 

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -104,7 +105,8 @@ public class TokenService {
     if (this.iss != null) {
       builder.setIssuer(this.iss);
     }
-    final Key signingKey = new SecretKeySpec(this.signingKey.getBytes(StandardCharsets.UTF_8), this.signingAlgorithm.getJcaName());
+    byte [] apiKeySecretBytes = this.signingKey.getBytes(StandardCharsets.UTF_8);
+    final Key signingKey = new SecretKeySpec(apiKeySecretBytes, this.signingAlgorithm.getJcaName());
     return builder.signWith(signingKey, this.signingAlgorithm).compact();
   }
 
@@ -117,8 +119,10 @@ public class TokenService {
   public TokenClaims validateAccessToken(@Nonnull final String accessToken) throws TokenException {
     Objects.requireNonNull(accessToken);
     try {
+      byte [] apiKeySecretBytes = this.signingKey.getBytes(StandardCharsets.UTF_8);
+      final String base64Key = Base64.getEncoder().encodeToString(apiKeySecretBytes);
       final Claims claims = (Claims) Jwts.parserBuilder()
-          .setSigningKey(this.signingKey)
+          .setSigningKey(base64Key)
           .build()
           .parse(accessToken)
           .getBody();


### PR DESCRIPTION
**Summary** 

The Token Service requires a 256-bit signing key. We had previously assumed this key would be a Base64'd string, but are changing that to relax the requirements for this signing key as UTF-8 string. After this change, anyone who has enabled Metadata Service Authentication which was released last week will need to regenerate their Personal Access Tokens. 

Why do this? We want to be more flexible in the signing keys we accept to improve usability. We will handle the base64 encode and decode as required within the Token Service. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
