### PR TITLE
Fix CVE-2021-44228 continued:  log4j constraints to version 2.16.0

### DIFF
--- a/metadata-dao-impl/kafka-producer/build.gradle
+++ b/metadata-dao-impl/kafka-producer/build.gradle
@@ -17,10 +17,10 @@ dependencies {
   testCompile externalDependency.mockito
   
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-events/mxe-registration/build.gradle
+++ b/metadata-events/mxe-registration/build.gradle
@@ -15,10 +15,10 @@ dependencies {
   avroOriginal project(path: ':metadata-models', configuration: 'avroSchema')
   
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-events/mxe-utils-avro-1.7/build.gradle
+++ b/metadata-events/mxe-utils-avro-1.7/build.gradle
@@ -9,10 +9,10 @@ dependencies {
   testCompile project(':metadata-testing:metadata-test-utils')
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-ingestion-examples/common/build.gradle
+++ b/metadata-ingestion-examples/common/build.gradle
@@ -19,10 +19,10 @@ dependencies {
   runtime externalDependency.logbackClassic
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-ingestion-examples/kafka-etl/build.gradle
+++ b/metadata-ingestion-examples/kafka-etl/build.gradle
@@ -22,10 +22,10 @@ dependencies {
   runtime externalDependency.logbackClassic
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-ingestion-examples/mce-cli/build.gradle
+++ b/metadata-ingestion-examples/mce-cli/build.gradle
@@ -28,10 +28,10 @@ dependencies {
   annotationProcessor externalDependency.picocli
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-io/build.gradle
+++ b/metadata-io/build.gradle
@@ -47,10 +47,10 @@ dependencies {
   testAnnotationProcessor externalDependency.lombok
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-service/restli-servlet-impl/build.gradle
+++ b/metadata-service/restli-servlet-impl/build.gradle
@@ -24,10 +24,10 @@ configurations {
 
 dependencies {
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228") 
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-testing/metadata-models-test-utils/build.gradle
+++ b/metadata-testing/metadata-models-test-utils/build.gradle
@@ -12,10 +12,10 @@ dependencies {
   compile externalDependency.neo4jHarness
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-testing/metadata-test-utils/build.gradle
+++ b/metadata-testing/metadata-test-utils/build.gradle
@@ -11,10 +11,10 @@ dependencies {
   compile externalDependency.neo4jHarness
 
   constraints {
-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
-    implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+    implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }

--- a/metadata-utils/build.gradle
+++ b/metadata-utils/build.gradle
@@ -28,10 +28,10 @@ dependencies {
   testCompile project(':metadata-testing:metadata-test-utils')
 
   constraints {
-      implementation("org.apache.logging.log4j:log4j-core:2.15.0") {
+      implementation("org.apache.logging.log4j:log4j-core:2.16.0") {
           because("previous versions are vulnerable to CVE-2021-44228")
       }
-      implementation("org.apache.logging.log4j:log4j-api:2.15.0") {
+      implementation("org.apache.logging.log4j:log4j-api:2.16.0") {
         because("previous versions are vulnerable to CVE-2021-44228")
     }
   }


### PR DESCRIPTION
Title says it. 
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
