### PR TITLE
feat(ingestion): Mode retry wait logic to avoid hitting Mode API rate limit

### DIFF
--- a/metadata-ingestion/examples/recipes/mode_to_datahub.yml
+++ b/metadata-ingestion/examples/recipes/mode_to_datahub.yml
@@ -2,12 +2,16 @@
 source:
   type: "mode"
   config:
-    token: 9fa6a90fcd33
-    password: a03bcbc011d6f77c585f5682
+    token: token
+    password: password
     connect_uri: https://app.mode.com/
-    workspace: "petabloc"
+    workspace: "workspace"
     default_schema: "public"
     owner_username_instead_of_email: False
+    api_options:
+      retry_backoff_multiplier: 2
+      max_retry_interval: 10
+      max_attempts: 5
 
 # see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
 sink:

--- a/metadata-ingestion/source_docs/mode.md
+++ b/metadata-ingestion/source_docs/mode.md
@@ -85,6 +85,11 @@ source:
     # Options
     workspace: "datahub"
     default_schema: "public"
+    owner_username_instead_of_email: False
+    api_options:
+      retry_backoff_multiplier: 2
+      max_retry_interval: 10
+      max_attempts: 5
 
 sink:
   # sink configs
@@ -92,16 +97,27 @@ sink:
 
 ## Config details
 
-| Field                             | Required | Default                  | Description                                                       |
-|-----------------------------------| -------- |--------------------------|-------------------------------------------------------------------|
-| `connect_uri`                     |    ✅     | `"https://app.mode.com"` | Mode host URL.                                                    |
-| `token`                           |    ✅     |                          | Mode user token.                                                  |
-| `password`                        |    ✅     |                          | Mode password for authentication.                                 |
-| `default_schema`                  |          | `public`                 | Default schema to use when schema is not provided in an SQL query |
-| `env`                             |          | `"PROD"`                 | Environment to use in namespace when constructing URNs.           |
-| `owner_username_instead_of_email` |          | `True`                   | Use username for owner URN instead of Email                       |
+| Field                             | Required | Default                  | Description                                                                                       |
+|-----------------------------------| -------- |--------------------------|---------------------------------------------------------------------------------------------------|
+| `connect_uri`                     |    ✅    | `"https://app.mode.com"` | Mode host URL.                                                                                    |
+| `token`                           |    ✅    |                          | Mode user token.                                                                                  |
+| `password`                        |    ✅    |                          | Mode password for authentication.                                                                 |
+| `default_schema`                  |          | `public`                 | Default schema to use when schema is not provided in an SQL query                                 |
+| `env`                             |          | `"PROD"`                 | Environment to use in namespace when constructing URNs.                                           |
+| `owner_username_instead_of_email` |          | `True`                   | Use username for owner URN instead of Email                                                       |
+| `api_options`                     |          |                          | Retry/Wait settings for Mode API to avoid "Too many Requests" error. See Mode API Options below   |
 
 See Mode's [Authentication documentation](https://mode.com/developer/api-reference/authentication/) on how to generate `token` and `password`.
+
+<br/>
+
+#### Mode API Options
+| Field                      | Required | Default | Description                                              |
+|----------------------------|----------|---------|----------------------------------------------------------|
+| `retry_backoff_multiplier` |          | `1`     | Multiplier for exponential backoff when waiting to retry |
+| `max_retry_interval`       |          | `10`    | Maximum interval to wait when retrying                   |
+| `max_attempts`             |          | `5`     | Maximum number of attempts to retry before failing       |
+
 
 ## Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -1,12 +1,15 @@
 import re
+import time
 from functools import lru_cache
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 import dateutil.parser as dp
 import requests
+import tenacity
 from pydantic import validator
 from requests.models import HTTPBasicAuth, HTTPError
 from sqllineage.runner import LineageRunner
+from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigModel
@@ -36,6 +39,12 @@ from datahub.metadata.schema_classes import (
 from datahub.utilities import config_clean
 
 
+class ModeAPIConfig(ConfigModel):
+    retry_backoff_multiplier: Union[int, float] = 2
+    max_retry_interval: Union[int, float] = 10
+    max_attempts: int = 5
+
+
 class ModeConfig(ConfigModel):
     # See https://mode.com/developer/api-reference/authentication/
     # for authentication
@@ -45,11 +54,16 @@ class ModeConfig(ConfigModel):
     workspace: Optional[str] = None
     default_schema: str = "public"
     owner_username_instead_of_email: Optional[bool] = True
+    api_options: ModeAPIConfig = ModeAPIConfig()
     env: str = builder.DEFAULT_ENV
 
     @validator("connect_uri")
     def remove_trailing_slash(cls, v):
         return config_clean.remove_trailing_slashes(v)
+
+
+class HTTPError429(HTTPError):
+    pass
 
 
 class ModeSource(Source):
@@ -76,8 +90,7 @@ class ModeSource(Source):
 
         # Test the connection
         try:
-            test_response = self.session.get(f"{self.config.connect_uri}/api/account")
-            test_response.raise_for_status()
+            self._get_request_json(f"{self.config.connect_uri}/api/account")
         except HTTPError as http_error:
             self.report.report_failure(
                 key="mode-session",
@@ -169,12 +182,21 @@ class ModeSource(Source):
 
     @lru_cache(maxsize=None)
     def _get_creator(self, href: str) -> str:
-        user = self.session.get(f"{self.config.connect_uri}{href}")
-        user_json = user.json()
-        if self.config.owner_username_instead_of_email:
-            return user_json.get("username", "unknown")
-        else:
-            return user_json.get("email", "unknown")
+        user = ""
+        try:
+            user_json = self._get_request_json(f"{self.config.connect_uri}{href}")
+            user = (
+                user_json.get("username", "unknown")
+                if self.config.owner_username_instead_of_email
+                else user_json.get("email", "unknown")
+            )
+        except HTTPError as http_error:
+            self.report.report_failure(
+                key="mode-user",
+                reason=f"Unable to retrieve user for {href}, "
+                f"Reason: {str(http_error)}",
+            )
+        return user
 
     def _get_chart_urns(self, report_token: str) -> list:
         chart_urns = []
@@ -193,9 +215,7 @@ class ModeSource(Source):
     def _get_space_name_and_tokens(self) -> dict:
         space_info = {}
         try:
-            workspace_response = self.session.get(f"{self.workspace_uri}/spaces")
-            workspace_response.raise_for_status()
-            payload = workspace_response.json()
+            payload = self._get_request_json(f"{self.workspace_uri}/spaces")
             spaces = payload.get("_embedded", {}).get("spaces", {})
 
             for s in spaces:
@@ -334,9 +354,19 @@ class ModeSource(Source):
     def _get_platform_and_dbname(
         self, data_source_id: int
     ) -> Union[Tuple[str, str], Tuple[None, None]]:
-        ds_response = self.session.get(f"{self.workspace_uri}/data_sources")
-        ds_json = ds_response.json()
-        data_sources = ds_json.get("_embedded", {}).get("data_sources", {})
+
+        data_sources = {}
+        try:
+            ds_json = self._get_request_json(f"{self.workspace_uri}/data_sources")
+            data_sources = ds_json.get("_embedded", {}).get("data_sources", [])
+        except HTTPError as http_error:
+            self.report.report_failure(
+                key=f"mode-datasource-{data_source_id}",
+                reason=f"No data sources found for datasource id: "
+                f"{data_source_id}, "
+                f"Reason: {str(http_error)}",
+            )
+
         if not data_sources:
             self.report.report_failure(
                 key=f"mode-datasource-{data_source_id}",
@@ -398,9 +428,9 @@ class ModeSource(Source):
     @lru_cache(maxsize=None)
     def _get_definition(self, definition_name):
         try:
-            definition_response = self.session.get(f"{self.workspace_uri}/definitions")
-            definition_response.raise_for_status()
-            definition_json = definition_response.json()
+            definition_json = self._get_request_json(
+                f"{self.workspace_uri}/definitions"
+            )
             definitions = definition_json.get("_embedded", {}).get("definitions", [])
             for definition in definitions:
                 if definition.get("name", "") == definition_name:
@@ -538,11 +568,9 @@ class ModeSource(Source):
     def _get_reports(self, space_token: str) -> list:
         reports = []
         try:
-            reports_response = self.session.get(
+            reports_json = self._get_request_json(
                 f"{self.workspace_uri}/spaces/{space_token}/reports"
             )
-            reports_response.raise_for_status()
-            reports_json = reports_response.json()
             reports = reports_json.get("_embedded", {}).get("reports", {})
         except HTTPError as http_error:
             self.report.report_failure(
@@ -556,11 +584,9 @@ class ModeSource(Source):
     def _get_queries(self, report_token: str) -> list:
         queries = []
         try:
-            queries_response = self.session.get(
+            queries_json = self._get_request_json(
                 f"{self.workspace_uri}/reports/{report_token}/queries"
             )
-            queries_response.raise_for_status()
-            queries_json = queries_response.json()
             queries = queries_json.get("_embedded", {}).get("queries", {})
         except HTTPError as http_error:
             self.report.report_failure(
@@ -574,12 +600,10 @@ class ModeSource(Source):
     def _get_charts(self, report_token: str, query_token: str) -> list:
         charts = []
         try:
-            chart_response = self.session.get(
+            charts_json = self._get_request_json(
                 f"{self.workspace_uri}/reports/{report_token}"
                 f"/queries/{query_token}/charts"
             )
-            chart_response.raise_for_status()
-            charts_json = chart_response.json()
             charts = charts_json.get("_embedded", {}).get("charts", {})
         except HTTPError as http_error:
             self.report.report_failure(
@@ -590,6 +614,36 @@ class ModeSource(Source):
                 f"Reason: {str(http_error)}",
             )
         return charts
+
+    def _get_request_json(self, url: str) -> Dict:
+        r = tenacity.Retrying(
+            wait=wait_exponential(
+                multiplier=self.config.api_options.retry_backoff_multiplier,
+                max=self.config.api_options.max_retry_interval,
+            ),
+            retry=retry_if_exception_type(HTTPError429),
+            stop=stop_after_attempt(self.config.api_options.max_attempts),
+        )
+
+        @r.wraps
+        def get_request():
+            try:
+                response = self.session.get(url)
+                response.raise_for_status()
+                return response.json()
+            except HTTPError as http_error:
+                error_response = http_error.response
+                if error_response.status_code == 429:
+                    # respect Retry-After
+                    sleep_time = error_response.headers.get("retry-after")
+                    if sleep_time is not None:
+                        time.sleep(sleep_time)
+                    raise HTTPError429
+
+                raise http_error
+            return {}
+
+        return get_request()
 
     def emit_dashboard_mces(self) -> Iterable[MetadataWorkUnit]:
         for space_token, space_name in self.space_tokens.items():

--- a/metadata-ingestion/src/datahub/ingestion/source/mode.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/mode.py
@@ -355,7 +355,7 @@ class ModeSource(Source):
         self, data_source_id: int
     ) -> Union[Tuple[str, str], Tuple[None, None]]:
 
-        data_sources = {}
+        data_sources = []
         try:
             ds_json = self._get_request_json(f"{self.workspace_uri}/data_sources")
             data_sources = ds_json.get("_embedded", {}).get("data_sources", [])


### PR DESCRIPTION
Implement exponential backoff retry logic when accessing Mode API to avoid HTTP error 429: "Too many API request".
See Datahub Mode connector [Config Details](https://github.com/jawadqu/datahub/blob/62a0f5e9740fb7cc1cc157ae7fdcb06dbb479156/metadata-ingestion/source_docs/mode.md#config-details) on how to customize these settings.

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
