### PR TITLE
feat(Stateful Ingestion-2/3): Client side changes for checkpointing a source job state.

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -311,6 +311,9 @@ entry_points = {
         "datahub-kafka = datahub.ingestion.sink.datahub_kafka:DatahubKafkaSink",
         "datahub-rest = datahub.ingestion.sink.datahub_rest:DatahubRestSink",
     ],
+    "datahub.ingestion.state_provider.plugins": [
+        "datahub = datahub.ingestion.source.state_provider.datahub_ingestion_state_provider:DatahubIngestionStateProvider",
+    ],
     "apache_airflow_provider": ["provider_info=datahub_provider:get_provider_info"],
 }
 

--- a/metadata-ingestion/source_docs/mysql.md
+++ b/metadata-ingestion/source_docs/mysql.md
@@ -38,9 +38,11 @@ sink:
 
 ## Config details
 
-Note that a `.` is used to denote nested fields in the YAML recipe.
+Like all SQL-based sources, the MySQL integration supports:
+- Stale Metadata Deletion: See [here](./stateful_ingestion.md) for more details on configuration.
+- SQL Profiling: See [here](./sql_profiles.md) for more details on configuration.
 
-As a SQL-based service, the Athena integration is also supported by our SQL profiler. See [here](./sql_profiles.md) for more details on configuration.
+Note that a `.` is used to denote nested fields in the YAML recipe.
 
 | Field                       | Required | Default            | Description                                                                                                                                                                             |
 | --------------------------- | -------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/metadata-ingestion/source_docs/redshift.md
+++ b/metadata-ingestion/source_docs/redshift.md
@@ -79,9 +79,11 @@ sink:
 
 ## Config details
 
-Note that a `.` is used to denote nested fields in the YAML recipe.
+Like all SQL-based sources, the Redshift integration supports:
+- Stale Metadata Deletion: See [here](./stateful_ingestion.md) for more details on configuration.
+- SQL Profiling: See [here](./sql_profiles.md) for more details on configuration.
 
-As a SQL-based service, the Athena integration is also supported by our SQL profiler. See [here](./sql_profiles.md) for more details on configuration.
+Note that a `.` is used to denote nested fields in the YAML recipe.
 
 | Field                       | Required | Default            | Description                                                                                                                                                                             |
 |-----------------------------| -------- |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -46,8 +46,11 @@ sink:
 
 ## Config details
 
-Note that a `.` is used to denote nested fields in the YAML recipe.
+Like all SQL-based sources, the Snowflake integration supports:
+- Stale Metadata Deletion: See [here](./stateful_ingestion.md) for more details on configuration.
+- SQL Profiling: See [here](./sql_profiles.md) for more details on configuration.
 
+Note that a `.` is used to denote nested fields in the YAML recipe.
 
 | Field                         | Required | Default                                                                     | Description                                                                                                                                                                             |
 | ----------------------------- | -------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -136,6 +139,8 @@ sink:
 ```
 
 ### Config details
+
+Snowflake integration also supports prevention of redundant reruns for the same data. See [here](./stateful_ingestion.md) for more details on configuration.
 
 Note that a `.` is used to denote nested fields in the YAML recipe.
 

--- a/metadata-ingestion/source_docs/stateful_ingestion.md
+++ b/metadata-ingestion/source_docs/stateful_ingestion.md
@@ -1,0 +1,137 @@
+# Stateful Ingestion
+The stateful ingestion feature enables sources to be configured to save custom checkpoint states from their
+runs, and query these states back from subsequent runs to make decisions about the current run based on the state saved 
+from the previous run(s) using a supported ingestion state provider. This is an explicit opt-in feature and is not enabled
+by default.
+
+## Config details
+
+Note that a `.` is used to denote nested fields in the YAML recipe.
+
+| Field                                                        | Required | Default                                                                                                          | Description                                                                                                                                                 |
+|--------------------------------------------------------------| -------- |------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `source.config.stateful_ingestion.enabled`                   |          | False                                                                                                            | The type of the ingestion state provider registered with datahub.                                                                                           |
+| `source.conifg.stateful_ingestion.ignore_old_state`          |          | False                                                                                                            | If set to True, ignores the previous checkpoint state.                                                                                                      | 
+| `source.conifg.stateful_ingestion.ignore_new_state`          |          | False                                                                                                            | If set to True, ignores the current checkpoint state.                                                                                                       | 
+| `source.conifg.stateful_ingestion.max_checkpoint_state_size` |          | 2^24 (16MB)                                                                                                      | The maximum size of the checkpoint state in bytes.                                                                                                          | 
+| `source.conifg.stateful_ingestion.state_provider`            |          | The default [datahub ingestion state provider](#datahub-ingestion-state-provider) configuration. | The ingestion state provider configuration.                                                                                                                 | 
+| `pipeline_name`                                              |    ✅    |                                                                                                                  | The name of the ingestion pipeline the checkpoint states of various source connector job runs are saved/retrieved against via the ingestion state provider. | 
+
+NOTE: If either `dry-run` or `preview` mode are set, stateful ingestion will be turned off regardless of the rest of the configuration.
+## Use-cases powered by stateful ingestion.
+Following is the list of current use-cases powered by stateful ingestion in datahub.
+### Removal of stale tables and views.
+Stateful ingestion can be used to automatically soft delete the tables and views that are seen in a previous run
+but absent in the current run (they are either deleted or no longer desired).
+#### Supported sources
+* All sql based sources.
+#### Additional config details
+
+Note that a `.` is used to denote nested fields in the YAML recipe.
+
+| Field                                      | Required | Default | Description                                                                                                                                  |
+|--------------------------------------------| -------- |---------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `stateful_ingestion.remove_stale_metadata` |          | True    | Soft-deletes the tables and views that were found in the last successful run but missing in the current run with stateful_ingestion enabled. |
+#### Sample configuration
+```yaml
+source:
+  type: "snowflake"
+  config:
+    username: <user_name>
+    password: <password>
+    host_port: <host_port>
+    warehouse: <ware_house>
+    role: <role>
+    include_tables: True
+    include_views: True
+    # Rest of the source specific params ...
+    ## Stateful Ingestion config ##
+    stateful_ingestion:
+        enabled: True # False by default
+        remove_stale_metadata: True # default value
+        ## Default state_provider configuration ##
+        # state_provider:
+            # type: "datahub" # default value
+            # This section is needed if the pipeline-level `datahub_api` is not configured.
+            # config:  # default value
+            #    datahub_api: 
+            #        server: "http://localhost:8080"
+
+# The pipeline_name is mandatory for stateful ingestion and the state is tied to this.
+# If this is changed after using with stateful ingestion, the previous state will not be available to the next run.
+pipeline_name: "my_snowflake_pipeline_1"
+
+# Pipeline-level datahub_api configuration.
+datahub_api: # Optional. But if provided, this config will be used by the "datahub" ingestion state provider.
+    server: "http://localhost:8080"
+    
+sink:
+  type: "datahub-rest"
+  config:
+    server: 'http://localhost:8080'
+```
+
+### Prevent redundant reruns for usage source.
+Typically, the usage runs are configured to fetch the usage data for the previous day(or hour) for each run. Once a usage
+run has finished, subsequent runs until the following day would be fetching the same usage data. With stateful ingestion,
+the redundant fetches can be avoided even if the ingestion job is scheduled to run more frequently than the granularity of
+usage ingestion.
+#### Supported sources
+* Snowflake Usage source.
+#### Additional config details
+
+Note that a `.` is used to denote nested fields in the YAML recipe.
+
+| Field                            | Required | Default | Description                                                                                                                               |
+|----------------------------------| -------- |---------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| `stateful_ingestion.force_rerun` |          | False   | Custom-alias for `stateful_ingestion.ignore_old_state`. Prevents a rerun for the same time window if there was a previous successful run. |
+#### Sample Configuration
+```yaml
+source:
+  type: "snowflake-usage"
+  config:
+    username: <user_name>
+    password: <password>
+    role: <role>
+    host_port: <host_port>
+    warehouse: <ware_house>
+    # Rest of the source specific params ...
+    ## Stateful Ingestion config ##
+    stateful_ingestion:
+        enabled: True # default is false
+        force_rerun: False # Specific to this source(alias for ignore_old_state), used to override default behavior if True.
+
+# The pipeline_name is mandatory for stateful ingestion and the state is tied to this.
+# If this is changed after using with stateful ingestion, the previous state will not be available to the next run.
+pipeline_name: "my_snowflake_usage_ingestion_pipeline_1"
+sink:
+  type: "datahub-rest"
+  config:
+    server: 'http://localhost:8080'
+```
+
+## The Ingestion State Provider
+The ingestion state provider is responsible for saving and retrieving the ingestion state associated with the ingestion runs
+of various jobs inside the source connector of the ingestion pipeline. An ingestion state provider needs to implement the
+[IngestionStateProvider](https://github.com/linkedin/datahub/blob/master/metadata-ingestion/src/datahub/ingestion/api/ingestion_state_provider.py) interface and
+register itself with datahub by adding an entry under `datahub.ingestion.state_provider.plugins` key of the entry_points section in [setup.py](https://github.com/linkedin/datahub/blob/master/metadata-ingestion/setup.py) with its type and implementation class as shown below.
+```python
+entry_points = {
+    # <snip other keys>"
+    "datahub.ingestion.state_provider.plugins": [
+        "datahub = datahub.ingestion.source.state_provider.datahub_ingestion_state_provider:DatahubIngestionStateProvider",
+    ]
+}
+```
+
+### Datahub Ingestion State Provider
+This is the state provider implementation that is avialble out of the box. It's type is `datahub` and it is implemented on top
+of the `datahub_api` client and the timeseries aspect capabilities of the datahub-backend.
+#### Config details
+
+Note that a `.` is used to denote nested fields in the YAML recipe.
+
+| Field                                                    | Required | Default                                                                                                                                                                                                                                 | Description                                                      |
+|----------------------------------------------------------| -------- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| `state_provider.type`   |          | `datahub`                                                                                                                                                                                                                               | The type of the ingestion state provider registered with datahub |
+| `state_provider.config` |          | The `datahub_api` config if set at pipeline level. Otherwise, the default `DatahubClientConfig`. See the [defaults](https://github.com/linkedin/datahub/blob/master/metadata-ingestion/src/datahub/ingestion/graph/client.py#L19) here. | The configuration required for initializing the state provider.  |

--- a/metadata-ingestion/source_docs/stateful_ingestion.md
+++ b/metadata-ingestion/source_docs/stateful_ingestion.md
@@ -4,6 +4,20 @@ runs, and query these states back from subsequent runs to make decisions about t
 from the previous run(s) using a supported ingestion state provider. This is an explicit opt-in feature and is not enabled
 by default.
 
+**_NOTE_**: This feature requires the server to be `statefulIngestion` capable. This is a feature of metadata service with version >= `0.8.20`. 
+
+To check if you are running a stateful ingestion capable server:
+```console
+curl http://<datahub-gms-endpoint>/config
+
+{
+models: { },
+statefulIngestionCapable: true, # <-- this should be present and true
+retention: "true",
+noCode: "true"
+}
+```
+
 ## Config details
 
 Note that a `.` is used to denote nested fields in the YAML recipe.

--- a/metadata-ingestion/src/datahub/ingestion/api/common.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/common.py
@@ -28,11 +28,16 @@ class WorkUnit(_WorkUnitId, metaclass=ABCMeta):
 
 
 class PipelineContext:
-    run_id: str
-    graph: Optional[DataHubGraph]
-
     def __init__(
-        self, run_id: str, datahub_api: Optional[DatahubClientConfig] = None
+        self,
+        run_id: str,
+        datahub_api: Optional[DatahubClientConfig] = None,
+        pipeline_name: Optional[str] = None,
+        dry_run: bool = False,
+        preview_mode: bool = False,
     ) -> None:
         self.run_id = run_id
         self.graph = DataHubGraph(datahub_api) if datahub_api is not None else None
+        self.pipeline_name = pipeline_name
+        self.dry_run_mode = dry_run
+        self.preview_mode = preview_mode

--- a/metadata-ingestion/src/datahub/ingestion/api/ingestion_state_provider.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/ingestion_state_provider.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, NewType, Optional
+
+from datahub.ingestion.api.common import PipelineContext
+from datahub.metadata.schema_classes import DatahubIngestionCheckpointClass
+
+JobId = NewType("JobId", str)
+
+
+class IngestionStateProvider(ABC):
+    """Abstract base class for all ingestion state providers."""
+
+    @classmethod
+    @abstractmethod
+    def create(
+        cls, config_dict: Dict[str, Any], ctx: PipelineContext
+    ) -> "IngestionStateProvider":
+        pass
+
+    def get_latest_checkpoint(
+        self,
+        pipeline_name: str,
+        platform_instance_id: str,
+        job_name: JobId,
+    ) -> Optional[DatahubIngestionCheckpointClass]:
+        pass
+
+    def commit_checkpoints(
+        self, job_checkpoints: Dict[JobId, DatahubIngestionCheckpointClass]
+    ) -> None:
+        pass

--- a/metadata-ingestion/src/datahub/ingestion/graph/client.py
+++ b/metadata-ingestion/src/datahub/ingestion/graph/client.py
@@ -5,6 +5,7 @@ from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from avrogen.dict_wrapper import DictWrapper
+from requests.adapters import Response
 from requests.models import HTTPError
 
 from datahub.configuration.common import ConfigModel, OperationalError
@@ -13,6 +14,7 @@ from datahub.metadata.schema_classes import DatasetUsageStatisticsClass, Ownersh
 
 # This bound isn't tight, but it's better than nothing.
 Aspect = TypeVar("Aspect", bound=DictWrapper)
+
 logger = logging.getLogger(__name__)
 
 
@@ -57,6 +59,30 @@ class DataHubGraph(DatahubRestEmitter):
                     "Unable to get metadata from DataHub", {"message": str(e)}
                 ) from e
 
+    def _post_generic(self, url: str, payload_dict: Dict) -> Dict:
+        payload = json.dumps(payload_dict)
+        logger.debug(payload)
+        try:
+            response: Response = self._session.post(url, payload)
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as e:
+            try:
+                info = response.json()
+                raise OperationalError(
+                    "Unable to get metadata from DataHub", info
+                ) from e
+            except JSONDecodeError:
+                # If we can't parse the JSON, just raise the original error.
+                raise OperationalError(
+                    "Unable to get metadata from DataHub", {"message": str(e)}
+                ) from e
+
+    @staticmethod
+    def _guess_entity_type(urn: str) -> str:
+        assert urn.startswith("urn:li:"), "urns must start with urn:li:"
+        return urn.split(":")[2]
+
     def get_aspect(
         self,
         entity_urn: str,
@@ -78,6 +104,9 @@ class DataHubGraph(DatahubRestEmitter):
             raise OperationalError(
                 f"Failed to find {aspect_type_name} in response {response_json}"
             )
+
+    def get_config(self) -> Dict[str, Any]:
+        return self._get_generic(f"{self.config.server}/config")
 
     def get_ownership(self, entity_urn: str) -> Optional[OwnershipClass]:
         return self.get_aspect(
@@ -146,3 +175,35 @@ class DataHubGraph(DatahubRestEmitter):
         except Exception as e:
             logger.error("Error while fetching entity urns.", e)
             return None
+
+    def get_latest_timeseries_value(
+        self,
+        entity_urn: str,
+        aspect_name: str,
+        aspect_type: Type[Aspect],
+        filter_criteria_map: Dict[str, str],
+    ) -> Optional[Aspect]:
+        filter_criteria = [
+            {"field": k, "value": v, "condition": "EQUAL"}
+            for k, v in filter_criteria_map.items()
+        ]
+        query_body = {
+            "urn": entity_urn,
+            "entity": self._guess_entity_type(entity_urn),
+            "aspect": aspect_name,
+            "latestValue": True,
+            "filter": {"or": [{"and": filter_criteria}]},
+        }
+        end_point = f"{self.config.server}/aspects?action=getTimeseriesAspectValues"
+        resp: Dict = self._post_generic(end_point, query_body)
+        values: list = resp.get("value", {}).get("values")
+        if values:
+            assert len(values) == 1
+            aspect_json: str = values[0].get("aspect", {}).get("value")
+            if aspect_json:
+                return aspect_type.from_obj(json.loads(aspect_json), tuples=False)
+            else:
+                raise OperationalError(
+                    f"Failed to find {aspect_type} in response {aspect_json}"
+                )
+        return None

--- a/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
+++ b/metadata-ingestion/src/datahub/ingestion/run/pipeline.py
@@ -39,6 +39,7 @@ class PipelineConfig(ConfigModel):
     transformers: Optional[List[DynamicTypedConfig]]
     run_id: str = "__DEFAULT_RUN_ID"
     datahub_api: Optional[DatahubClientConfig] = None
+    pipeline_name: Optional[str] = None
 
     @validator("run_id", pre=True, always=True)
     def run_id_should_be_semantic(
@@ -101,7 +102,11 @@ class Pipeline:
         self.dry_run = dry_run
         self.preview_mode = preview_mode
         self.ctx = PipelineContext(
-            run_id=self.config.run_id, datahub_api=self.config.datahub_api
+            run_id=self.config.run_id,
+            datahub_api=self.config.datahub_api,
+            pipeline_name=self.config.pipeline_name,
+            dry_run=dry_run,
+            preview_mode=preview_mode,
         )
 
         source_type = self.config.source.type
@@ -161,8 +166,8 @@ class Pipeline:
             extractor.close()
             if not self.dry_run:
                 self.sink.handle_work_unit_end(wu)
-        self.source.close()
         self.sink.close()
+        self.source.close()
 
     def transform(self, records: Iterable[RecordEnvelope]) -> Iterable[RecordEnvelope]:
         """

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_common.py
@@ -12,6 +12,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 from urllib.parse import quote_plus
 
@@ -21,12 +22,27 @@ from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql import sqltypes as types
 
-from datahub.configuration.common import AllowDenyPattern, ConfigModel
-from datahub.emitter.mce_builder import DEFAULT_ENV
+from datahub.configuration.common import AllowDenyPattern
+from datahub.emitter.mce_builder import (
+    DEFAULT_ENV,
+    make_data_platform_urn,
+    make_dataset_urn,
+)
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.common import PipelineContext
-from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.state.checkpoint import Checkpoint
+from datahub.ingestion.source.state.sql_common_state import (
+    BaseSQLAlchemyCheckpointState,
+)
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    JobId,
+    StatefulIngestionConfig,
+    StatefulIngestionConfigBase,
+    StatefulIngestionSourceBase,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.common import StatusClass
 from datahub.metadata.com.linkedin.pegasus2avro.metadata.snapshot import DatasetSnapshot
 from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 from datahub.metadata.com.linkedin.pegasus2avro.schema import (
@@ -125,6 +141,7 @@ class SQLSourceReport(SourceReport):
     views_scanned: int = 0
     entities_profiled: int = 0
     filtered: List[str] = field(default_factory=list)
+    soft_deleted_stale_entities: List[str] = field(default_factory=list)
 
     query_combiner: Optional[SQLAlchemyQueryCombinerReport] = None
 
@@ -150,8 +167,21 @@ class SQLSourceReport(SourceReport):
     ) -> None:
         self.query_combiner = query_combiner_report
 
+    def report_stale_entity_soft_deleted(self, urn: str) -> None:
+        self.soft_deleted_stale_entities.append(urn)
 
-class SQLAlchemyConfig(ConfigModel):
+
+class SQLAlchemyStatefulIngestionConfig(StatefulIngestionConfig):
+    """
+    Specialization of basic StatefulIngestionConfig to adding custom config.
+    This will be used to override the stateful_ingestion config param of StatefulIngestionConfigBase
+    in the SQLAlchemyConfig.
+    """
+
+    remove_stale_metadata: bool = True
+
+
+class SQLAlchemyConfig(StatefulIngestionConfigBase):
     env: str = DEFAULT_ENV
     options: dict = {}
     # Although the 'table_pattern' enables you to skip everything from certain schemas,
@@ -169,6 +199,8 @@ class SQLAlchemyConfig(ConfigModel):
     from datahub.ingestion.source.ge_data_profiler import GEProfilingConfig
 
     profiling: GEProfilingConfig = GEProfilingConfig()
+    # Custom Stateful Ingestion settings
+    stateful_ingestion: Optional[SQLAlchemyStatefulIngestionConfig] = None
 
     @pydantic.root_validator()
     def ensure_profiling_pattern_is_passed_to_profiling(
@@ -300,7 +332,7 @@ def get_schema_metadata(
 
     schema_metadata = SchemaMetadata(
         schemaName=dataset_name,
-        platform=f"urn:li:dataPlatform:{platform}",
+        platform=make_data_platform_urn(platform),
         version=0,
         hash="",
         platformSchema=MySqlDDL(tableSchema=""),
@@ -312,11 +344,11 @@ def get_schema_metadata(
     return schema_metadata
 
 
-class SQLAlchemySource(Source):
+class SQLAlchemySource(StatefulIngestionSourceBase):
     """A Base class for all SQL Sources that use SQLAlchemy to extend"""
 
     def __init__(self, config: SQLAlchemyConfig, ctx: PipelineContext, platform: str):
-        super().__init__(ctx)
+        super(SQLAlchemySource, self).__init__(config, ctx)
         self.config = config
         self.platform = platform
         self.report = SQLSourceReport()
@@ -332,8 +364,100 @@ class SQLAlchemySource(Source):
             inspector = inspect(conn)
             yield inspector
 
+    def is_checkpointing_enabled(self, job_id: JobId) -> bool:
+        if (
+            job_id == self.get_default_ingestion_job_id()
+            and self.is_stateful_ingestion_configured()
+            and self.config.stateful_ingestion
+            and self.config.stateful_ingestion.remove_stale_metadata
+        ):
+            return True
+
+        return False
+
+    def get_default_ingestion_job_id(self) -> JobId:
+        """
+        Default ingestion job name that sql_common provides.
+        Subclasses can override as needed.
+        """
+        return JobId("common_ingest_from_sql_source")
+
+    def create_checkpoint(self, job_id: JobId) -> Optional[Checkpoint]:
+        """
+        Create the custom checkpoint with empty state for the job.
+        """
+        assert self.ctx.pipeline_name is not None
+        if job_id == self.get_default_ingestion_job_id():
+            return Checkpoint(
+                job_name=job_id,
+                pipeline_name=self.ctx.pipeline_name,
+                platform_instance_id=self.get_platform_instance_id(),
+                run_id=self.ctx.run_id,
+                config=self.config,
+                state=BaseSQLAlchemyCheckpointState(),
+            )
+        return None
+
     def get_schema_names(self, inspector):
         return inspector.get_schema_names()
+
+    def get_platform_instance_id(self) -> str:
+        """
+        The source identifier such as the specific source host address required for stateful ingestion.
+        Individual subclasses need to override this method appropriately.
+        """
+        config_dict = self.config.dict()
+        host_port = config_dict.get("host_port", "no_host_port")
+        database = config_dict.get("database", "no_database")
+        return f"{self.platform}_{host_port}_{database}"
+
+    def gen_removed_entity_workunits(self) -> Iterable[MetadataWorkUnit]:
+        last_checkpoint = self.get_last_checkpoint(
+            self.get_default_ingestion_job_id(), BaseSQLAlchemyCheckpointState
+        )
+        cur_checkpoint = self.get_current_checkpoint(
+            self.get_default_ingestion_job_id()
+        )
+        if (
+            self.config.stateful_ingestion
+            and self.config.stateful_ingestion.remove_stale_metadata
+            and last_checkpoint is not None
+            and last_checkpoint.state is not None
+            and cur_checkpoint is not None
+            and cur_checkpoint.state is not None
+        ):
+            logger.debug("Checking for stale entity removal.")
+
+            def soft_delete_dataset(urn: str, type: str) -> Iterable[MetadataWorkUnit]:
+                logger.info(f"Soft-deleting stale entity of type {type} - {urn}.")
+                mcp = MetadataChangeProposalWrapper(
+                    entityType="dataset",
+                    entityUrn=urn,
+                    changeType=ChangeTypeClass.UPSERT,
+                    aspectName="status",
+                    aspect=StatusClass(removed=True),
+                )
+                wu = MetadataWorkUnit(id=f"soft-delete-{type}-{urn}", mcp=mcp)
+                self.report.report_workunit(wu)
+                self.report.report_stale_entity_soft_deleted(urn)
+                yield wu
+
+            last_checkpoint_state = cast(
+                BaseSQLAlchemyCheckpointState, last_checkpoint.state
+            )
+            cur_checkpoint_state = cast(
+                BaseSQLAlchemyCheckpointState, cur_checkpoint.state
+            )
+
+            for table_urn in last_checkpoint_state.get_table_urns_not_in(
+                cur_checkpoint_state
+            ):
+                yield from soft_delete_dataset(table_urn, "table")
+
+            for view_urn in last_checkpoint_state.get_view_urns_not_in(
+                cur_checkpoint_state
+            ):
+                yield from soft_delete_dataset(view_urn, "view")
 
     def get_workunits(self) -> Iterable[Union[MetadataWorkUnit, SqlWorkUnit]]:
         sql_config = self.config
@@ -373,6 +497,10 @@ class SQLAlchemySource(Source):
             if profiler and profile_requests:
                 yield from self.loop_profiler(profile_requests, profiler)
 
+        if self.is_stateful_ingestion_configured():
+            # Clean up stale entities.
+            yield from self.gen_removed_entity_workunits()
+
     def standardize_schema_table_names(
         self, schema: str, entity: str
     ) -> Tuple[str, str]:
@@ -391,7 +519,7 @@ class SQLAlchemySource(Source):
         else:
             return f"{schema}.{entity}"
 
-    def get_foreign_key_metadata(self, datasetUrn, fk_dict, inspector):
+    def get_foreign_key_metadata(self, dataset_urn, fk_dict, inspector):
         referred_dataset_name = self.get_identifier(
             schema=fk_dict["referred_schema"],
             entity=fk_dict["referred_table"],
@@ -399,10 +527,12 @@ class SQLAlchemySource(Source):
         )
 
         source_fields = [
-            f"urn:li:schemaField:({datasetUrn},{f})"
+            f"urn:li:schemaField:({dataset_urn},{f})"
             for f in fk_dict["constrained_columns"]
         ]
-        foreign_dataset = f"urn:li:dataset:(urn:li:dataPlatform:{self.platform},{referred_dataset_name},{self.config.env})"
+        foreign_dataset = make_dataset_urn(
+            self.platform, referred_dataset_name, self.config.env
+        )
         foreign_fields = [
             f"urn:li:schemaField:({foreign_dataset},{f})"
             for f in fk_dict["referred_columns"]
@@ -438,6 +568,7 @@ class SQLAlchemySource(Source):
                 self.report.report_dropped(dataset_name)
                 continue
 
+            columns = []
             try:
                 columns = inspector.get_columns(table, schema)
                 if len(columns) == 0:
@@ -472,11 +603,20 @@ class SQLAlchemySource(Source):
                 # The "properties" field is a non-standard addition to SQLAlchemy's interface.
                 properties = table_info.get("properties", {})
 
-            datasetUrn = f"urn:li:dataset:(urn:li:dataPlatform:{self.platform},{dataset_name},{self.config.env})"
+            dataset_urn = make_dataset_urn(self.platform, dataset_name, self.config.env)
             dataset_snapshot = DatasetSnapshot(
-                urn=datasetUrn,
-                aspects=[],
+                urn=dataset_urn,
+                aspects=[StatusClass(removed=False)],
             )
+            if self.is_stateful_ingestion_configured():
+                cur_checkpoint = self.get_current_checkpoint(
+                    self.get_default_ingestion_job_id()
+                )
+                if cur_checkpoint is not None:
+                    checkpoint_state = cast(
+                        BaseSQLAlchemyCheckpointState, cur_checkpoint.state
+                    )
+                    checkpoint_state.add_table_urn(dataset_urn)
 
             if description is not None or properties:
                 dataset_properties = DatasetPropertiesClass(
@@ -488,13 +628,13 @@ class SQLAlchemySource(Source):
             pk_constraints: dict = inspector.get_pk_constraint(table, schema)
             try:
                 foreign_keys = [
-                    self.get_foreign_key_metadata(datasetUrn, fk_rec, inspector)
+                    self.get_foreign_key_metadata(dataset_urn, fk_rec, inspector)
                     for fk_rec in inspector.get_foreign_keys(table, schema)
                 ]
             except KeyError:
                 # certain databases like MySQL cause issues due to lower-case/upper-case irregularities
                 logger.debug(
-                    f"{datasetUrn}: failure in foreign key extraction... skipping"
+                    f"{dataset_urn}: failure in foreign key extraction... skipping"
                 )
                 foreign_keys = []
 
@@ -611,10 +751,22 @@ class SQLAlchemySource(Source):
             properties["view_definition"] = view_definition
             properties["is_view"] = "True"
 
+            dataset_urn = make_dataset_urn(self.platform, dataset_name, self.config.env)
             dataset_snapshot = DatasetSnapshot(
-                urn=f"urn:li:dataset:(urn:li:dataPlatform:{self.platform},{dataset_name},{self.config.env})",
-                aspects=[],
+                urn=dataset_urn,
+                aspects=[StatusClass(removed=False)],
             )
+
+            if self.is_stateful_ingestion_configured():
+                cur_checkpoint = self.get_current_checkpoint(
+                    self.get_default_ingestion_job_id()
+                )
+                if cur_checkpoint is not None:
+                    checkpoint_state = cast(
+                        BaseSQLAlchemyCheckpointState, cur_checkpoint.state
+                    )
+                    checkpoint_state.add_view_urn(dataset_urn)
+
             if description is not None or properties:
                 dataset_properties = DatasetPropertiesClass(
                     description=description,
@@ -673,15 +825,17 @@ class SQLAlchemySource(Source):
             if profile is None:
                 continue
             dataset_name = request.pretty_name
+            dataset_urn = make_dataset_urn(self.platform, dataset_name, self.config.env)
             mcp = MetadataChangeProposalWrapper(
                 entityType="dataset",
-                entityUrn=f"urn:li:dataset:(urn:li:dataPlatform:{self.platform},{dataset_name},{self.config.env})",
+                entityUrn=dataset_urn,
                 changeType=ChangeTypeClass.UPSERT,
                 aspectName="datasetProfile",
                 aspect=profile,
             )
             wu = MetadataWorkUnit(id=f"profile-{dataset_name}", mcp=mcp)
             self.report.report_workunit(wu)
+
             yield wu
 
     def prepare_profiler_args(self, schema: str, table: str) -> dict:
@@ -694,4 +848,6 @@ class SQLAlchemySource(Source):
         return self.report
 
     def close(self):
-        pass
+        if self.is_stateful_ingestion_configured():
+            # Commit the checkpoints for this run
+            self.commit_checkpoints()

--- a/metadata-ingestion/src/datahub/ingestion/source/state/checkpoint.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/checkpoint.py
@@ -1,0 +1,149 @@
+import bz2
+import functools
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional, Type
+
+import pydantic
+
+from datahub.configuration.common import ConfigModel
+from datahub.metadata.schema_classes import (
+    DatahubIngestionCheckpointClass,
+    IngestionCheckpointStateClass,
+)
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class CheckpointStateBase(ConfigModel):
+    """
+    Base class for ingestion checkpoint state.
+    NOTE: We use the pydantic based ConfigModel as base here so that
+    we can leverage built-in functionality for including/excluding fields in the
+    serialization along with potential validation for specific sources.
+    """
+
+    version: str = pydantic.Field(default="1.0")
+    serde: str = pydantic.Field(default="utf-8")
+
+    def to_bytes(
+        self,
+        compressor: Callable[[bytes], bytes] = functools.partial(
+            bz2.compress, compresslevel=9
+        ),
+        max_allowed_state_size: int = 2 ** 22,  # 4MB
+    ) -> bytes:
+        """
+        NOTE: Binary compression cannot be turned on yet as the current MCPs encode the GeneralizedAspect
+        payload using Json encoding which does not support bytes type data. For V1, we go with the utf-8 encoding.
+        This also means that double serialization also is not possible to encode version and serde separate from the
+        binary state payload. Binary content-type needs to be supported for encoding the GenericAspect to do this.
+        """
+
+        json_str_self = self.json(exclude={"version", "serde"})
+        encoded_bytes = json_str_self.encode("utf-8")
+        if len(encoded_bytes) > max_allowed_state_size:
+            raise ValueError(
+                f"The state size has exceeded the max_allowed_state_size of {max_allowed_state_size}"
+            )
+
+        return encoded_bytes
+
+    @staticmethod
+    def from_bytes_to_dict(
+        data_bytes: bytes, decompressor: Callable[[bytes], bytes] = bz2.decompress
+    ) -> Dict[str, Any]:
+        """Helper method for sub-classes to use."""
+        # uncompressed_data: bytes = decompressor(data_bytes)
+        # json_str = uncompressed_data.decode('utf-8')
+        json_str = data_bytes.decode("utf-8")
+        return json.loads(json_str)
+
+
+@dataclass
+class Checkpoint:
+    """
+    Ingestion Run Checkpoint class. This is a more convenient abstraction for use in the python ingestion code,
+    providing a strongly typed state object vs the opaque blob in the PDL, and the config persisted as the first-class
+    ConfigModel object.
+    """
+
+    job_name: str
+    pipeline_name: str
+    platform_instance_id: str
+    run_id: str
+    config: ConfigModel
+    state: CheckpointStateBase
+
+    @classmethod
+    def create_from_checkpoint_aspect(
+        cls,
+        job_name: str,
+        checkpoint_aspect: Optional[DatahubIngestionCheckpointClass],
+        config_class: Type[ConfigModel],
+        state_class: Type[CheckpointStateBase],
+    ) -> Optional["Checkpoint"]:
+        if checkpoint_aspect is None:
+            return None
+        try:
+            # Construct the config
+            config_as_dict = json.loads(checkpoint_aspect.config)
+            config_obj = config_class.parse_obj(config_as_dict)
+
+            # Construct the state
+            state_as_dict = (
+                CheckpointStateBase.from_bytes_to_dict(checkpoint_aspect.state.payload)
+                if checkpoint_aspect.state.payload is not None
+                else {}
+            )
+            state_as_dict["version"] = checkpoint_aspect.state.formatVersion
+            state_as_dict["serde"] = checkpoint_aspect.state.serde
+            state_obj = state_class.parse_obj(state_as_dict)
+        except Exception as e:
+            logger.error(
+                "Failed to construct checkpoint class from checkpoint aspect.", e
+            )
+        else:
+            # Construct the deserialized Checkpoint object from the raw aspect.
+            checkpoint = cls(
+                job_name=job_name,
+                pipeline_name=checkpoint_aspect.pipelineName,
+                platform_instance_id=checkpoint_aspect.platformInstanceId,
+                run_id=checkpoint_aspect.runId,
+                config=config_obj,
+                state=state_obj,
+            )
+            logger.info(
+                f"Successfully constructed last checkpoint state for job {job_name}"
+            )
+            return checkpoint
+        return None
+
+    def to_checkpoint_aspect(
+        self, max_allowed_state_size: int
+    ) -> Optional[DatahubIngestionCheckpointClass]:
+        try:
+            checkpoint_state = IngestionCheckpointStateClass(
+                formatVersion=self.state.version,
+                serde=self.state.serde,
+                payload=self.state.to_bytes(
+                    max_allowed_state_size=max_allowed_state_size
+                ),
+            )
+            checkpoint_aspect = DatahubIngestionCheckpointClass(
+                timestampMillis=int(datetime.utcnow().timestamp() * 1000),
+                pipelineName=self.pipeline_name,
+                platformInstanceId=self.platform_instance_id,
+                runId=self.run_id,
+                config=self.config.json(),
+                state=checkpoint_state,
+            )
+            return checkpoint_aspect
+        except Exception as e:
+            logger.error(
+                "Failed to construct the checkpoint aspect from checkpoint object", e
+            )
+
+        return None

--- a/metadata-ingestion/src/datahub/ingestion/source/state/sql_common_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/sql_common_state.py
@@ -1,0 +1,61 @@
+from typing import Iterable, List
+
+import pydantic
+
+from datahub.emitter.mce_builder import dataset_urn_to_key, make_dataset_urn
+from datahub.ingestion.source.state.checkpoint import CheckpointStateBase
+
+
+class BaseSQLAlchemyCheckpointState(CheckpointStateBase):
+    """
+    Base class for representing the checkpoint state for all SQLAlchemy based sources.
+    Stores all tables and views being ingested and is used to remove any stale entities.
+    Subclasses can define additional state as appropriate.
+    """
+
+    encoded_table_urns: List[str] = pydantic.Field(default_factory=list)
+    encoded_view_urns: List[str] = pydantic.Field(default_factory=list)
+
+    @staticmethod
+    def _get_separator() -> str:
+        # Unique small string not allowed in URNs.
+        return "||"
+
+    @staticmethod
+    def _get_lightweight_repr(dataset_urn: str) -> str:
+        """Reduces the amount of text in the URNs for smaller state footprint."""
+        SEP = BaseSQLAlchemyCheckpointState._get_separator()
+        key = dataset_urn_to_key(dataset_urn)
+        assert key is not None
+        return f"{key.platform}{SEP}{key.name}{SEP}{key.origin}"
+
+    @staticmethod
+    def _get_urns_not_in(
+        encoded_urns_1: List[str], encoded_urns_2: List[str]
+    ) -> Iterable[str]:
+        difference = set(encoded_urns_1) - set(encoded_urns_2)
+        for encoded_urn in difference:
+            platform, name, env = encoded_urn.split(
+                BaseSQLAlchemyCheckpointState._get_separator()
+            )
+            yield make_dataset_urn(platform, name, env)
+
+    def get_table_urns_not_in(
+        self, checkpoint: "BaseSQLAlchemyCheckpointState"
+    ) -> Iterable[str]:
+        yield from self._get_urns_not_in(
+            self.encoded_table_urns, checkpoint.encoded_table_urns
+        )
+
+    def get_view_urns_not_in(
+        self, checkpoint: "BaseSQLAlchemyCheckpointState"
+    ) -> Iterable[str]:
+        yield from self._get_urns_not_in(
+            checkpoint.encoded_view_urns, self.encoded_view_urns
+        )
+
+    def add_table_urn(self, table_urn: str) -> None:
+        self.encoded_table_urns.append(self._get_lightweight_repr(table_urn))
+
+    def add_view_urn(self, view_urn: str) -> None:
+        self.encoded_view_urns.append(self._get_lightweight_repr(view_urn))

--- a/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/stateful_ingestion_base.py
@@ -1,0 +1,214 @@
+import logging
+from typing import Any, Dict, Optional, Type
+
+import pydantic
+
+from datahub.configuration.common import (
+    ConfigModel,
+    ConfigurationError,
+    DynamicTypedConfig,
+)
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.ingestion_state_provider import IngestionStateProvider, JobId
+from datahub.ingestion.api.source import Source
+from datahub.ingestion.source.state.checkpoint import Checkpoint, CheckpointStateBase
+from datahub.ingestion.source.state_provider.datahub_ingestion_state_provider import (
+    DatahubIngestionStateProviderConfig,
+)
+from datahub.ingestion.source.state_provider.state_provider_registry import (
+    ingestion_state_provider_registry,
+)
+from datahub.metadata.schema_classes import DatahubIngestionCheckpointClass
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class StatefulIngestionConfig(ConfigModel):
+    """
+    Basic Stateful Ingestion Specific Configuration for any source.
+    """
+
+    enabled: bool = False
+    max_checkpoint_state_size: int = 2 ** 24  # 16MB
+    state_provider: Optional[DynamicTypedConfig] = DynamicTypedConfig(
+        type="datahub", config=DatahubIngestionStateProviderConfig()
+    )
+    ignore_old_state: bool = False
+    ignore_new_state: bool = False
+
+    @pydantic.root_validator()
+    def validate_config(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("enabled"):
+            if values.get("state_provider") is None:
+                raise ConfigurationError(
+                    "Must specify state_provider configuration if stateful ingestion is enabled."
+                )
+        return values
+
+
+class StatefulIngestionConfigBase(ConfigModel):
+    """
+    Base configuration class for stateful ingestion for source configs to inherit from.
+    """
+
+    stateful_ingestion: Optional[StatefulIngestionConfig] = None
+
+
+class StatefulIngestionSourceBase(Source):
+    """
+    Defines the base class for all stateful sources.
+    """
+
+    def __init__(
+        self, config: StatefulIngestionConfigBase, ctx: PipelineContext
+    ) -> None:
+        super().__init__(ctx)
+        self.stateful_ingestion_config = config.stateful_ingestion
+        self.source_config_type = type(config)
+        self.last_checkpoints: Dict[JobId, Optional[Checkpoint]] = {}
+        self.cur_checkpoints: Dict[JobId, Optional[Checkpoint]] = {}
+        self._initialize_state_provider()
+
+    def _initialize_state_provider(self) -> None:
+        self.ingestion_state_provider: Optional[IngestionStateProvider] = None
+        if (
+            self.stateful_ingestion_config is not None
+            and self.stateful_ingestion_config.state_provider is not None
+            and self.stateful_ingestion_config.enabled
+        ):
+            if self.ctx.pipeline_name is None:
+                raise ConfigurationError(
+                    "pipeline_name must be provided if stateful ingestion is enabled."
+                )
+            state_provider_class = ingestion_state_provider_registry.get(
+                self.stateful_ingestion_config.state_provider.type
+            )
+            self.ingestion_state_provider = state_provider_class.create(
+                self.stateful_ingestion_config.state_provider.dict().get("config", {}),
+                self.ctx,
+            )
+            if self.stateful_ingestion_config.ignore_old_state:
+                logger.warning(
+                    "The 'ignore_old_state' config is True. The old checkpoint state will not be provided."
+                )
+            if self.stateful_ingestion_config.ignore_new_state:
+                logger.warning(
+                    "The 'ignore_new_state' config is True. The new checkpoint state will not be created."
+                )
+
+            logger.debug(
+                f"Successfully created {self.stateful_ingestion_config.state_provider.type} state provider."
+            )
+
+    def is_stateful_ingestion_configured(self) -> bool:
+        if (
+            self.stateful_ingestion_config is not None
+            and self.stateful_ingestion_config.enabled
+            and self.ingestion_state_provider is not None
+        ):
+            return True
+        return False
+
+    # Basic methods that sub-classes must implement
+    def create_checkpoint(self, job_id: JobId) -> Optional[Checkpoint]:
+        raise NotImplementedError("Sub-classes must implement this method.")
+
+    def get_platform_instance_id(self) -> str:
+        raise NotImplementedError("Sub-classes must implement this method.")
+
+    def is_checkpointing_enabled(self, job_id: JobId) -> bool:
+        """
+        Sub-classes should override this method to tell if checkpointing is enabled for this run.
+        For instance, currently all of the SQL based sources use checkpointing for stale entity removal.
+        They would turn it on only if remove_stale_metadata=True. Otherwise, the feature won't work correctly.
+        """
+        raise NotImplementedError("Sub-classes must implement this method.")
+
+    def _get_last_checkpoint(
+        self, job_id: JobId, checkpoint_state_class: Type[CheckpointStateBase]
+    ) -> Optional[Checkpoint]:
+        """
+        This is a template method implementation for querying the last checkpoint state.
+        """
+        last_checkpoint: Optional[Checkpoint] = None
+        if self.is_stateful_ingestion_configured():
+            # Obtain the latest checkpoint from GMS for this job.
+            last_checkpoint_aspect = self.ingestion_state_provider.get_latest_checkpoint(  # type: ignore
+                pipeline_name=self.ctx.pipeline_name,  # type: ignore
+                platform_instance_id=self.get_platform_instance_id(),
+                job_name=job_id,
+            )
+            # Convert it to a first-class Checkpoint object.
+            last_checkpoint = Checkpoint.create_from_checkpoint_aspect(
+                job_name=job_id,
+                checkpoint_aspect=last_checkpoint_aspect,
+                config_class=self.source_config_type,
+                state_class=checkpoint_state_class,
+            )
+        return last_checkpoint
+
+    # Base-class implementations for common state management tasks.
+    def get_last_checkpoint(
+        self, job_id: JobId, checkpoint_state_class: Type[CheckpointStateBase]
+    ) -> Optional[Checkpoint]:
+        if not self.is_stateful_ingestion_configured() or (
+            self.stateful_ingestion_config
+            and self.stateful_ingestion_config.ignore_old_state
+        ):
+            return None
+
+        if JobId not in self.last_checkpoints:
+            self.last_checkpoints[job_id] = self._get_last_checkpoint(
+                job_id, checkpoint_state_class
+            )
+        return self.last_checkpoints[job_id]
+
+    def get_current_checkpoint(self, job_id: JobId) -> Optional[Checkpoint]:
+        if not self.is_stateful_ingestion_configured():
+            return None
+
+        if job_id not in self.cur_checkpoints:
+            self.cur_checkpoints[job_id] = (
+                self.create_checkpoint(job_id)
+                if self.is_checkpointing_enabled(job_id)
+                else None
+            )
+        return self.cur_checkpoints[job_id]
+
+    def commit_checkpoints(self) -> None:
+        if not self.is_stateful_ingestion_configured():
+            return None
+        if (
+            self.stateful_ingestion_config
+            and self.stateful_ingestion_config.ignore_new_state
+        ):
+            logger.info(
+                "The `ignore_new_state` config is True. Not committing current checkpoint."
+            )
+            return None
+        if self.ctx.dry_run_mode or self.ctx.preview_mode:
+            logger.warning(
+                f"Will not be committing checkpoints in dry_run_mode(={self.ctx.dry_run_mode})"
+                f" or preview_mode(={self.ctx.preview_mode})."
+            )
+            return None
+        job_checkpoint_aspects: Dict[JobId, DatahubIngestionCheckpointClass] = {}
+        for job_name, job_checkpoint in self.cur_checkpoints.items():
+            if job_checkpoint is None:
+                continue
+            try:
+                checkpoint_aspect = job_checkpoint.to_checkpoint_aspect(
+                    self.stateful_ingestion_config.max_checkpoint_state_size  # type: ignore
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to convert checkpoint to aspect for job {job_name}. It will not be committed.",
+                    e,
+                )
+            else:
+                if checkpoint_aspect is not None:
+                    job_checkpoint_aspects[job_name] = checkpoint_aspect
+
+        self.ingestion_state_provider.commit_checkpoints(  # type: ignore
+            job_checkpoints=job_checkpoint_aspects
+        )

--- a/metadata-ingestion/src/datahub/ingestion/source/state/usage_common_state.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state/usage_common_state.py
@@ -1,0 +1,12 @@
+from datahub.ingestion.source.state.checkpoint import CheckpointStateBase
+
+
+class BaseUsageCheckpointState(CheckpointStateBase):
+    """
+    Base class for representing the checkpoint state for all usage based sources.
+    Stores the last successful run's begin and end timestamps.
+    Subclasses can define additional state as appropriate.
+    """
+
+    begin_timestamp_millis: int
+    end_timestamp_millis: int

--- a/metadata-ingestion/src/datahub/ingestion/source/state_provider/datahub_ingestion_state_provider.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state_provider/datahub_ingestion_state_provider.py
@@ -1,0 +1,219 @@
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import datahub.emitter.mce_builder as builder
+from datahub.configuration.common import ConfigModel, ConfigurationError
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.ingestion_state_provider import IngestionStateProvider, JobId
+from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.metadata.schema_classes import (
+    CalendarIntervalClass,
+    ChangeTypeClass,
+    DataFlowSnapshotClass,
+    DatahubIngestionCheckpointClass,
+    DatahubIngestionRunSummaryClass,
+    DataJobInfoClass,
+    JobStatusClass,
+    MetadataChangeEventClass,
+    StatusClass,
+    TimeWindowSizeClass,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DatahubIngestionStateProviderConfig(ConfigModel):
+    datahub_api: Optional[DatahubClientConfig] = DatahubClientConfig()
+
+
+class DatahubIngestionStateProvider(IngestionStateProvider):
+    orchestrator_name: str = "datahub"
+
+    def __init__(self, graph: DataHubGraph):
+        self.graph = graph
+        if not self._is_server_stateful_ingestion_capable():
+            raise ConfigurationError(
+                "Datahub server is not capable of supporting stateful ingestion."
+                " Please consider upgrading to the latest server version to use this feature."
+            )
+
+    @classmethod
+    def create(
+        cls, config_dict: Dict[str, Any], ctx: PipelineContext
+    ) -> IngestionStateProvider:
+        if ctx.graph:
+            return cls(ctx.graph)
+        elif config_dict is None:
+            raise ConfigurationError("Missing provider configuration")
+        else:
+            provider_config = DatahubIngestionStateProviderConfig.parse_obj(config_dict)
+            if provider_config.datahub_api:
+                graph = DataHubGraph(provider_config.datahub_api)
+                return cls(graph)
+            else:
+                raise ConfigurationError(
+                    "Missing datahub_api. Provide either a global one or under the state_provider."
+                )
+
+    def _is_server_stateful_ingestion_capable(self) -> bool:
+        server_config = self.graph.get_config() if self.graph else None
+        if server_config and server_config.get("statefulIngestionCapable"):
+            return True
+        return False
+
+    def get_latest_checkpoint(
+        self,
+        pipeline_name: str,
+        platform_instance_id: str,
+        job_name: JobId,
+    ) -> Optional[DatahubIngestionCheckpointClass]:
+
+        logger.info(
+            f"Querying for the latest ingestion checkpoint for pipelineName:'{pipeline_name}',"
+            f" platformInstanceId:'{platform_instance_id}', job_name:'{job_name}'"
+        )
+
+        data_job_urn = builder.make_data_job_urn(
+            self.orchestrator_name, pipeline_name, job_name
+        )
+        latest_checkpoint: Optional[
+            DatahubIngestionCheckpointClass
+        ] = self.graph.get_latest_timeseries_value(
+            entity_urn=data_job_urn,
+            aspect_name="datahubIngestionCheckpoint",
+            filter_criteria_map={
+                "pipelineName": pipeline_name,
+                "platformInstanceId": platform_instance_id,
+            },
+            aspect_type=DatahubIngestionCheckpointClass,
+        )
+        if latest_checkpoint:
+            logger.info(
+                f"The last committed ingestion checkpoint for pipelineName:'{pipeline_name}',"
+                f" platformInstanceId:'{platform_instance_id}', job_name:'{job_name}' found with start_time:"
+                f" {datetime.fromtimestamp(latest_checkpoint.timestampMillis/1000, tz=timezone.utc)} and a"
+                f" bucket duration of {latest_checkpoint.eventGranularity}."
+            )
+            return latest_checkpoint
+        else:
+            logger.info(
+                f"No committed ingestion checkpoint for pipelineName:'{pipeline_name}',"
+                f" platformInstanceId:'{platform_instance_id}', job_name:'{job_name}' found"
+            )
+
+        return None
+
+    def commit_checkpoints(
+        self, job_checkpoints: Dict[JobId, DatahubIngestionCheckpointClass]
+    ) -> None:
+        for job_name, checkpoint in job_checkpoints.items():
+            # Emit the DataFlowSnapshot MCE
+            dataflow_urn = builder.make_data_flow_urn(
+                self.orchestrator_name, checkpoint.pipelineName
+            )
+
+            dataflow_snapshot = DataFlowSnapshotClass(
+                urn=dataflow_urn,
+                aspects=[StatusClass(removed=False)],
+            )
+            self.graph.emit_mce(
+                MetadataChangeEventClass(proposedSnapshot=dataflow_snapshot)
+            )
+
+            # Emit the ingestion state for each job
+            datajob_urn = builder.make_data_job_urn(
+                self.orchestrator_name,
+                checkpoint.pipelineName,
+                job_name,
+            )
+
+            logger.info(
+                f"Committing ingestion checkpoint for pipeline:'{checkpoint.pipelineName}',"
+                f"instance:'{checkpoint.platformInstanceId}', job:'{job_name}'"
+            )
+            self.graph.emit_mcp(
+                MetadataChangeProposalWrapper(
+                    entityType="dataJob",
+                    entityUrn=datajob_urn,
+                    aspectName="datahubIngestionCheckpoint",
+                    aspect=checkpoint,
+                    changeType=ChangeTypeClass.UPSERT,
+                )
+            )
+
+            # Emit the DataJobInfo aspect
+            data_job_info = DataJobInfoClass(
+                name=job_name,
+                type="datahub-ingestion-python",
+                flowUrn=dataflow_urn,
+                status=JobStatusClass.COMPLETED,
+            )
+
+            self.graph.emit_mcp(
+                MetadataChangeProposalWrapper(
+                    entityType="dataJob",
+                    entityUrn=datajob_urn,
+                    aspectName="dataJobInfo",
+                    aspect=data_job_info,
+                    changeType=ChangeTypeClass.UPSERT,
+                )
+            )
+            logger.info(
+                f"Committed ingestion checkpoint for pipeline:'{checkpoint.pipelineName}',"
+                f"instance:'{checkpoint.platformInstanceId}', job:'{job_name}'"
+            )
+
+    @staticmethod
+    def get_end_time(ingestion_state: DatahubIngestionRunSummaryClass) -> int:
+        start_time_millis = ingestion_state.timestampMillis
+        granularity = ingestion_state.eventGranularity
+        granularity_millis = (
+            DatahubIngestionStateProvider.get_granularity_to_millis(granularity)
+            if granularity is not None
+            else 0
+        )
+        return start_time_millis + granularity_millis
+
+    @staticmethod
+    def get_time_window_size(interval_str: str) -> TimeWindowSizeClass:
+        to_calendar_interval: Dict[str, str] = {
+            "s": CalendarIntervalClass.SECOND,
+            "m": CalendarIntervalClass.MINUTE,
+            "h": CalendarIntervalClass.HOUR,
+            "d": CalendarIntervalClass.DAY,
+            "W": CalendarIntervalClass.WEEK,
+            "M": CalendarIntervalClass.MONTH,
+            "Q": CalendarIntervalClass.QUARTER,
+            "Y": CalendarIntervalClass.YEAR,
+        }
+        interval_pattern = re.compile(r"(\d+)([s|m|h|d|W|M|Q|Y])")
+        token_search = interval_pattern.search(interval_str)
+        if token_search is None:
+            raise ValueError("Invalid interval string:", interval_str)
+        (multiples_str, unit_str) = (token_search.group(1), token_search.group(2))
+        if not multiples_str or not unit_str:
+            raise ValueError("Invalid interval string:", interval_str)
+        unit = to_calendar_interval.get(unit_str)
+        if not unit:
+            raise ValueError("Invalid time unit token:", unit_str)
+        return TimeWindowSizeClass(unit=unit, multiple=int(multiples_str))
+
+    @staticmethod
+    def get_granularity_to_millis(granularity: TimeWindowSizeClass) -> int:
+        to_millis_from_interval: Dict[str, int] = {
+            CalendarIntervalClass.SECOND: 1000,
+            CalendarIntervalClass.MINUTE: 60 * 1000,
+            CalendarIntervalClass.HOUR: 60 * 60 * 1000,
+            CalendarIntervalClass.DAY: 24 * 60 * 60 * 1000,
+            CalendarIntervalClass.WEEK: 7 * 24 * 60 * 60 * 1000,
+            CalendarIntervalClass.MONTH: 31 * 7 * 24 * 60 * 60 * 1000,
+            CalendarIntervalClass.QUARTER: 90 * 7 * 24 * 60 * 60 * 1000,
+            CalendarIntervalClass.YEAR: 365 * 7 * 24 * 60 * 60 * 1000,
+        }
+        units_to_millis = to_millis_from_interval.get(str(granularity.unit), None)
+        if not units_to_millis:
+            raise ValueError("Invalid unit", granularity.unit)
+        return granularity.multiple * units_to_millis

--- a/metadata-ingestion/src/datahub/ingestion/source/state_provider/state_provider_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/state_provider/state_provider_registry.py
@@ -1,0 +1,10 @@
+from datahub.ingestion.api.ingestion_state_provider import IngestionStateProvider
+from datahub.ingestion.api.registry import PluginRegistry
+
+ingestion_state_provider_registry = PluginRegistry[IngestionStateProvider]()
+ingestion_state_provider_registry.register_from_entrypoint(
+    "datahub.ingestion.state_provider.plugins"
+)
+
+# These sinks are always enabled
+assert ingestion_state_provider_registry.get("datahub")

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -1,11 +1,9 @@
 import collections
-import dataclasses
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, cast
 
-import pydantic
 import pydantic.dataclasses
 from pydantic import BaseModel
 from sqlalchemy import create_engine
@@ -14,9 +12,18 @@ from sqlalchemy.engine import Engine
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import AllowDenyPattern
 from datahub.configuration.time_window_config import get_time_bucket
-from datahub.ingestion.api.source import Source, SourceReport
+from datahub.ingestion.api.common import PipelineContext
+from datahub.ingestion.api.source import SourceReport
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.sql.snowflake import BaseSnowflakeConfig
+from datahub.ingestion.source.state.checkpoint import Checkpoint
+from datahub.ingestion.source.state.stateful_ingestion_base import (
+    JobId,
+    StatefulIngestionConfig,
+    StatefulIngestionConfigBase,
+    StatefulIngestionSourceBase,
+)
+from datahub.ingestion.source.state.usage_common_state import BaseUsageCheckpointState
 from datahub.ingestion.source.usage.usage_common import (
     BaseUsageConfig,
     GenericAggregatedDataset,
@@ -93,7 +100,19 @@ class SnowflakeJoinedAccessEvent(PermissiveModel):
     role_name: str
 
 
-class SnowflakeUsageConfig(BaseSnowflakeConfig, BaseUsageConfig):
+class SnowflakeStatefulIngestionConfig(StatefulIngestionConfig):
+    """
+    Specialization of basic StatefulIngestionConfig to adding custom config.
+    This will be used to override the stateful_ingestion config param of StatefulIngestionConfigBase
+    in the SnowflakeUsageConfig.
+    """
+
+    ignore_old_state = pydantic.Field(False, alias="force_rerun")
+
+
+class SnowflakeUsageConfig(
+    BaseSnowflakeConfig, BaseUsageConfig, StatefulIngestionConfigBase
+):
     env: str = builder.DEFAULT_ENV
     options: dict = {}
     database_pattern: AllowDenyPattern = AllowDenyPattern(
@@ -103,6 +122,7 @@ class SnowflakeUsageConfig(BaseSnowflakeConfig, BaseUsageConfig):
     table_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     apply_view_usage_to_tables: bool = False
+    stateful_ingestion: Optional[SnowflakeStatefulIngestionConfig] = None
 
     @pydantic.validator("role", always=True)
     def role_accountadmin(cls, v):
@@ -119,30 +139,115 @@ class SnowflakeUsageConfig(BaseSnowflakeConfig, BaseUsageConfig):
         return super().get_sql_alchemy_url(database="snowflake")
 
 
-@dataclasses.dataclass
-class SnowflakeUsageSource(Source):
-    config: SnowflakeUsageConfig
-    report: SourceReport = dataclasses.field(default_factory=SourceReport)
+class SnowflakeUsageSource(StatefulIngestionSourceBase):
+    def __init__(self, config: SnowflakeUsageConfig, ctx: PipelineContext):
+        super(SnowflakeUsageSource, self).__init__(config, ctx)
+        self.config: SnowflakeUsageConfig = config
+        self.report: SourceReport = SourceReport()
 
     @classmethod
     def create(cls, config_dict, ctx):
         config = SnowflakeUsageConfig.parse_obj(config_dict)
-        return cls(ctx, config)
+        return cls(config, ctx)
+
+    # Stateful Ingestion Overrides.
+    def is_checkpointing_enabled(self, job_id: JobId) -> bool:
+        if job_id == self.get_default_ingestion_job_id():
+            assert self.config.stateful_ingestion
+            return self.config.stateful_ingestion.enabled
+        return False
+
+    def get_default_ingestion_job_id(self) -> JobId:
+        """
+        Default ingestion job name for snowflake_usage.
+        """
+        return JobId("snowflake_usage_ingestion")
+
+    def get_platform_instance_id(self) -> str:
+        return self.config.host_port
+
+    def create_checkpoint(self, job_id: JobId) -> Optional[Checkpoint]:
+        """
+        Create the custom checkpoint with empty state for the job.
+        """
+        assert self.ctx.pipeline_name
+        if job_id == self.get_default_ingestion_job_id():
+            return Checkpoint(
+                job_name=job_id,
+                pipeline_name=self.ctx.pipeline_name,
+                platform_instance_id=self.get_platform_instance_id(),
+                run_id=self.ctx.run_id,
+                config=self.config,
+                state=BaseUsageCheckpointState(
+                    begin_timestamp_millis=int(
+                        self.config.start_time.timestamp() * 1000
+                    ),
+                    end_timestamp_millis=int(self.config.end_time.timestamp() * 1000),
+                ),
+            )
+        return None
+
+    def _should_skip_this_run(self) -> bool:
+        # Check if forced rerun.
+        if (
+            self.config.stateful_ingestion
+            and self.config.stateful_ingestion.ignore_old_state
+        ):
+            return False
+        # Determine from the last check point state
+        last_successful_pipeline_run_end_time_millis: Optional[int] = None
+        last_checkpoint = self.get_last_checkpoint(
+            self.get_default_ingestion_job_id(), BaseUsageCheckpointState
+        )
+        if last_checkpoint and last_checkpoint.state:
+            state = cast(BaseUsageCheckpointState, last_checkpoint.state)
+            last_successful_pipeline_run_end_time_millis = state.end_timestamp_millis
+
+        if (
+            last_successful_pipeline_run_end_time_millis is not None
+            and int(self.config.start_time.timestamp() * 1000)
+            <= last_successful_pipeline_run_end_time_millis
+        ):
+            logger.info(
+                f"Skippig this run, since the last run's bucket duration end: "
+                f"{datetime.fromtimestamp(last_successful_pipeline_run_end_time_millis/1000, tz=timezone.utc)}"
+                f" is later than the current start_time: {self.config.start_time}"
+            )
+            return True
+        return False
+
+    def _get_last_successful_run_end(self) -> Optional[int]:
+        last_checkpoint = self.get_last_checkpoint(
+            self.get_default_ingestion_job_id(), BaseUsageCheckpointState
+        )
+        if last_checkpoint and last_checkpoint.state:
+            state = cast(BaseUsageCheckpointState, last_checkpoint.state)
+            return state.end_timestamp_millis
+        return None
+
+    def _init_checkpoints(self):
+        self.get_current_checkpoint(self.get_default_ingestion_job_id())
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        access_events = self._get_snowflake_history()
-        aggregated_info = self._aggregate_access_events(access_events)
+        skip_this_run: bool = self._should_skip_this_run()
+        if not skip_this_run:
+            # Initialize the checkpoints
+            self._init_checkpoints()
+            # Generate the workunits.
+            access_events = self._get_snowflake_history()
+            aggregated_info = self._aggregate_access_events(access_events)
 
-        for time_bucket in aggregated_info.values():
-            for aggregate in time_bucket.values():
-                wu = self._make_usage_stat(aggregate)
-                self.report.report_workunit(wu)
-                yield wu
+            for time_bucket in aggregated_info.values():
+                for aggregate in time_bucket.values():
+                    wu = self._make_usage_stat(aggregate)
+                    self.report.report_workunit(wu)
+                    yield wu
 
     def _make_usage_query(self) -> str:
+        start_time = int(self.config.start_time.timestamp() * 1000)
+        end_time = int(self.config.end_time.timestamp() * 1000)
         return SNOWFLAKE_USAGE_SQL_TEMPLATE.format(
-            start_time_millis=int(self.config.start_time.timestamp() * 1000),
-            end_time_millis=int(self.config.end_time.timestamp() * 1000),
+            start_time_millis=start_time, end_time_millis=end_time
         )
 
     def _make_sql_engine(self) -> Engine:
@@ -285,4 +390,5 @@ class SnowflakeUsageSource(Source):
         return self.report
 
     def close(self):
-        pass
+        # Checkpoint this run
+        self.commit_checkpoints()

--- a/metadata-ingestion/tests/integration/hive/hive_mces_golden.json
+++ b/metadata-ingestion/tests/integration/hive/hive_mces_golden.json
@@ -6,11 +6,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1._test_table_underscore,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:27 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:50 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/_test_table_underscore",
@@ -20,7 +25,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1638726627",
+                            "Table Parameters: transient_lastDdlTime": "1639442870",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -120,11 +125,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1.array_struct_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:28 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:50 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/array_struct_test",
@@ -134,7 +144,7 @@
                             "Table Parameters: numRows": "1",
                             "Table Parameters: rawDataSize": "32",
                             "Table Parameters: totalSize": "33",
-                            "Table Parameters: transient_lastDdlTime": "1638726632",
+                            "Table Parameters: transient_lastDdlTime": "1639442875",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -272,11 +282,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1.map_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:33 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:56 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/map_test",
@@ -286,7 +301,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1638726633",
+                            "Table Parameters: transient_lastDdlTime": "1639442876",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -389,11 +404,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1.nested_struct_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:33 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:56 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/nested_struct_test",
@@ -403,7 +423,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1638726633",
+                            "Table Parameters: transient_lastDdlTime": "1639442876",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -571,11 +591,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1.pokes,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:23 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:46 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/pokes",
@@ -584,7 +609,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "5812",
-                            "Table Parameters: transient_lastDdlTime": "1638726625",
+                            "Table Parameters: transient_lastDdlTime": "1639442868",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -684,11 +709,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1.struct_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:28 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:50 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/struct_test",
@@ -698,7 +728,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1638726628",
+                            "Table Parameters: transient_lastDdlTime": "1639442870",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
@@ -834,11 +864,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:hive,db1.union_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "Database:": "db1",
                             "Owner:": "root",
-                            "CreateTime:": "Sun Dec 05 17:50:33 UTC 2021",
+                            "CreateTime:": "Tue Dec 14 00:47:56 UTC 2021",
                             "LastAccessTime:": "UNKNOWN",
                             "Retention:": "0",
                             "Location:": "hdfs://namenode:8020/user/hive/warehouse/db1.db/union_test",
@@ -848,7 +883,7 @@
                             "Table Parameters: numRows": "0",
                             "Table Parameters: rawDataSize": "0",
                             "Table Parameters: totalSize": "0",
-                            "Table Parameters: transient_lastDdlTime": "1638726633",
+                            "Table Parameters: transient_lastDdlTime": "1639442876",
                             "SerDe Library:": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
                             "InputFormat:": "org.apache.hadoop.mapred.TextInputFormat",
                             "OutputFormat:": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",

--- a/metadata-ingestion/tests/integration/mysql/mysql_mces_golden.json
+++ b/metadata-ingestion/tests/integration/mysql/mysql_mces_golden.json
@@ -6,6 +6,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,datacharmer.employees,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "datacharmer.employees",
                         "platform": "urn:li:dataPlatform:mysql",
@@ -44,7 +49,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "birth_date",
@@ -60,7 +66,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "first_name",
@@ -76,7 +83,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "last_name",
@@ -92,7 +100,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "gender",
@@ -108,7 +117,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "hire_date",
@@ -124,7 +134,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -139,6 +150,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -148,6 +161,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,datacharmer.salaries,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "datacharmer.salaries",
@@ -187,7 +205,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "salary",
@@ -203,7 +222,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "from_date",
@@ -219,7 +239,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "to_date",
@@ -235,7 +256,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -250,6 +272,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -259,6 +283,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,metagalaxy.metadata_aspect,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "metagalaxy.metadata_aspect",
@@ -298,7 +327,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "aspect",
@@ -314,7 +344,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "version",
@@ -330,7 +361,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "metadata",
@@ -346,7 +378,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "createdon",
@@ -362,7 +395,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "createdby",
@@ -378,7 +412,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "createdfor",
@@ -394,7 +429,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -409,6 +445,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -418,6 +456,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,metagalaxy.metadata_index,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {},
@@ -466,7 +509,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "urn",
@@ -482,7 +526,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "aspect",
@@ -498,7 +543,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "path",
@@ -514,7 +560,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "longVal",
@@ -530,7 +577,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "stringVal",
@@ -546,7 +594,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "doubleVal",
@@ -562,7 +611,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -577,6 +627,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -586,6 +638,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,metagalaxy.metadata_index_view,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
@@ -637,7 +694,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "urn",
@@ -653,7 +711,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "path",
@@ -669,7 +728,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "doubleVal",
@@ -685,7 +745,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -700,6 +761,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -709,6 +772,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,northwind.customers,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "northwind.customers",
@@ -748,7 +816,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "company",
@@ -764,7 +833,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "last_name",
@@ -780,7 +850,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "first_name",
@@ -796,7 +867,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "email_address",
@@ -812,7 +884,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "priority",
@@ -828,7 +901,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -843,6 +917,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -852,6 +928,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,northwind.orders,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "northwind.orders",
@@ -891,7 +972,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "description",
@@ -907,7 +989,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "customer_id",
@@ -923,7 +1006,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -949,6 +1033,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -958,6 +1044,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mysql,test_cases.test_empty,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "test_cases.test_empty",
@@ -997,7 +1088,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -1012,6 +1104,8 @@
     "systemMetadata": {
         "lastObserved": 1586847600000,
         "runId": "mysql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },

--- a/metadata-ingestion/tests/integration/sql_server/mssql_mces_golden.json
+++ b/metadata-ingestion/tests/integration/sql_server/mssql_mces_golden.json
@@ -6,6 +6,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,DemoData.dbo.Products,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "DemoData.dbo.Products",
                         "platform": "urn:li:dataPlatform:mssql",
@@ -44,7 +49,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "ProductName",
@@ -60,7 +66,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -75,6 +82,8 @@
     "systemMetadata": {
         "lastObserved": 1615443388097,
         "runId": "mssql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -84,6 +93,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,DemoData.Foo.Items,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "DemoData.Foo.Items",
@@ -123,7 +137,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "ItemName",
@@ -139,7 +154,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -154,6 +170,8 @@
     "systemMetadata": {
         "lastObserved": 1615443388097,
         "runId": "mssql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -163,6 +181,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,DemoData.Foo.Persons,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "DemoData.Foo.Persons",
@@ -202,7 +225,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "LastName",
@@ -218,7 +242,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "FirstName",
@@ -234,7 +259,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "Age",
@@ -250,7 +276,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -265,6 +292,8 @@
     "systemMetadata": {
         "lastObserved": 1615443388097,
         "runId": "mssql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 },
@@ -274,6 +303,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:mssql,DemoData.Foo.SalesReason,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "DemoData.Foo.SalesReason",
@@ -313,7 +347,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": true
+                                "isPartOfKey": true,
+                                "jsonProps": null
                             },
                             {
                                 "fieldPath": "Name",
@@ -329,7 +364,8 @@
                                 "recursive": false,
                                 "globalTags": null,
                                 "glossaryTerms": null,
-                                "isPartOfKey": false
+                                "isPartOfKey": false,
+                                "jsonProps": null
                             }
                         ],
                         "primaryKeys": null,
@@ -355,6 +391,8 @@
     "systemMetadata": {
         "lastObserved": 1615443388097,
         "runId": "mssql-test",
+        "registryName": null,
+        "registryVersion": null,
         "properties": null
     }
 }

--- a/metadata-ingestion/tests/integration/trino/trino_hive_mces_golden.json
+++ b/metadata-ingestion/tests/integration/trino/trino_hive_mces_golden.json
@@ -6,6 +6,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.array_struct_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "column_stats_accurate": "{\"BASIC_STATS\":\"true\"}",
@@ -15,7 +20,7 @@
                             "numrows": "1",
                             "rawdatasize": "32",
                             "totalsize": "33",
-                            "transient_lastddltime": "1638688532"
+                            "transient_lastddltime": "1639443036"
                         },
                         "externalUrl": null,
                         "description": "This table has array of structs",
@@ -145,6 +150,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.map_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "column_stats_accurate": "{\"BASIC_STATS\":\"true\"}",
@@ -152,7 +162,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1638688536"
+                            "transient_lastddltime": "1639443040"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -247,6 +257,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.nested_struct_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "column_stats_accurate": "{\"BASIC_STATS\":\"true\"}",
@@ -254,7 +269,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1638688535"
+                            "transient_lastddltime": "1639443039"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -414,9 +429,14 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.pokes,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "transient_lastddltime": "1638688524"
+                            "transient_lastddltime": "1639443026"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -525,6 +545,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.struct_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "column_stats_accurate": "{\"BASIC_STATS\":\"true\"}",
@@ -532,7 +557,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1638688528"
+                            "transient_lastddltime": "1639443031"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -660,11 +685,16 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.struct_test_view_materialized,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "numfiles": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1638688535"
+                            "transient_lastddltime": "1639443039"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -792,6 +822,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1._test_table_underscore,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "column_stats_accurate": "{\"BASIC_STATS\":\"true\"}",
@@ -799,7 +834,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1638688527"
+                            "transient_lastddltime": "1639443031"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -891,6 +926,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.union_test,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
                             "column_stats_accurate": "{\"BASIC_STATS\":\"true\"}",
@@ -898,7 +938,7 @@
                             "numrows": "0",
                             "rawdatasize": "0",
                             "totalsize": "0",
-                            "transient_lastddltime": "1638688536"
+                            "transient_lastddltime": "1639443040"
                         },
                         "externalUrl": null,
                         "description": null,
@@ -1094,9 +1134,14 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,hivedb.db1.array_struct_test_view,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
                         "customProperties": {
-                            "transient_lastddltime": "1638688535",
+                            "transient_lastddltime": "1639443039",
                             "view_definition": "SELECT \"property_id\", \"service\"\nFROM \"db1\".\"array_struct_test\"",
                             "is_view": "True"
                         },

--- a/metadata-ingestion/tests/integration/trino/trino_mces_golden.json
+++ b/metadata-ingestion/tests/integration/trino/trino_mces_golden.json
@@ -6,6 +6,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,library_catalog.librarydb.book,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "library_catalog.librarydb.book",
                         "platform": "urn:li:dataPlatform:trino",
@@ -159,6 +164,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,library_catalog.librarydb.issue_history,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "library_catalog.librarydb.issue_history",
                         "platform": "urn:li:dataPlatform:trino",
@@ -276,6 +286,11 @@
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,library_catalog.librarydb.member,PROD)",
             "aspects": [
                 {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
+                {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "library_catalog.librarydb.member",
                         "platform": "urn:li:dataPlatform:trino",
@@ -358,6 +373,11 @@
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
             "urn": "urn:li:dataset:(urn:li:dataPlatform:trino,library_catalog.librarydb.book_in_circulation,PROD)",
             "aspects": [
+                {
+                    "com.linkedin.pegasus2avro.common.Status": {
+                        "removed": false
+                    }
+                },
                 {
                     "com.linkedin.pegasus2avro.schema.SchemaMetadata": {
                         "schemaName": "library_catalog.librarydb.book_in_circulation",

--- a/metadata-models/src/main/pegasus/com/linkedin/datajob/datahub/DatahubIngestionCheckpoint.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/datajob/datahub/DatahubIngestionCheckpoint.pdl
@@ -40,5 +40,6 @@ record DatahubIngestionCheckpoint includes TimeseriesAspectBase {
   /**
    * The run identifier of this job.
    */
+  @TimeseriesField = {}
   runId: string
 }

--- a/smoke-test/requirements.txt
+++ b/smoke-test/requirements.txt
@@ -1,3 +1,3 @@
 pytest>=6.2
 pytest-dependency>=0.5.1
--e ../metadata-ingestion[datahub-rest,datahub-kafka]
+-e ../metadata-ingestion[datahub-rest,datahub-kafka,mysql]

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -1,10 +1,17 @@
 import time
+import urllib
+from typing import Any, Dict, Optional, cast
 
 import pytest
 import requests
-import urllib
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text
+
 from datahub.cli.docker import check_local_docker_containers
 from datahub.ingestion.run.pipeline import Pipeline
+from datahub.ingestion.source.sql.mysql import MySQLConfig, MySQLSource
+from datahub.ingestion.source.sql.sql_common import BaseSQLAlchemyCheckpointState
+from datahub.ingestion.source.state.checkpoint import Checkpoint
 from tests.utils import ingest_file_via_rest
 
 GMS_ENDPOINT = "http://localhost:8080"
@@ -1271,3 +1278,98 @@ def test_generate_personal_access_token(frontend_session):
 
     assert res_data
     assert "errors" in res_data # Assert the request fails
+
+
+@pytest.mark.dependency(depends=["test_healthchecks"])
+def test_stateful_ingestion(wait_for_healthchecks):
+    def create_mysql_engine(mysql_source_config_dict: Dict[str, Any]) -> Any:
+        mysql_config = MySQLConfig.parse_obj(mysql_source_config_dict)
+        url = mysql_config.get_sql_alchemy_url()
+        return create_engine(url)
+
+    def create_table(engine: Any, name:str, defn:str) -> None:
+        create_table_query = text(f"CREATE TABLE IF NOT EXISTS {name}{defn};")
+        engine.execute(create_table_query)
+
+    def drop_table(engine: Any, table_name: str) -> None:
+        drop_table_query = text(f"DROP TABLE {table_name};")
+        engine.execute(drop_table_query)
+
+    def get_current_checkpoint_from_pipeline(
+            pipeline_config_dict: Dict[str, Any]
+    ) -> Optional[Checkpoint]:
+        pipeline = Pipeline.create(pipeline_config_dict)
+        pipeline.run()
+        pipeline.raise_from_status()
+        mysql_source = cast(MySQLSource, pipeline.source)
+        return mysql_source.get_current_checkpoint(
+            mysql_source.get_default_ingestion_job_id()
+        )
+
+    source_config_dict: Dict[str, Any] = {
+            "username": "datahub",
+            "password": "datahub",
+            "database": "datahub",
+            "stateful_ingestion": {
+                "enabled": True,
+                "remove_stale_metadata": True,
+                "state_provider": {
+                    "type": "datahub",
+                    "config": {"datahub_api": {"server": "http://localhost:8080"}},
+                },
+            },
+        }
+
+    pipeline_config_dict: Dict[str, Any] = {
+            "source": {
+                "type": "mysql",
+                "config": source_config_dict,
+            },
+            "sink": {
+                "type": "datahub-rest",
+                "config": {"server": "http://localhost:8080"},
+            },
+            "pipeline_name": "mysql_stateful_ingestion_smoke_test_pipeline",
+        }
+
+    # 1. Setup the SQL engine
+    mysql_engine = create_mysql_engine(source_config_dict)
+
+    # 2. Create test tables for first run of the  pipeline.
+    table_prefix = "stateful_ingestion_test"
+    table_defs = {
+        f"{table_prefix}_t1": "(id INT, name VARCHAR(10))",
+        f"{table_prefix}_t2": "(id INT)"
+    }
+    table_names = sorted(table_defs.keys())
+    for table_name, defn in table_defs.items():
+        create_table(mysql_engine, table_name, defn)
+
+    # 3. Do the first run of the pipeline and get the default job's checkpoint.
+    checkpoint1 = get_current_checkpoint_from_pipeline(
+        pipeline_config_dict=pipeline_config_dict
+    )
+    assert checkpoint1
+
+    # 4. Drop table t1 created during step 2 + rerun the pipeline and get the checkpoint state.
+    drop_table(mysql_engine, table_names[0])
+    checkpoint2 = get_current_checkpoint_from_pipeline(
+        pipeline_config_dict=pipeline_config_dict
+    )
+    assert checkpoint2
+
+    # 5. Perform all assertions on the states
+    state1 = cast(BaseSQLAlchemyCheckpointState, checkpoint1.state)
+    state2 = cast(BaseSQLAlchemyCheckpointState, checkpoint2.state)
+    difference_urns = list(state1.get_table_urns_not_in(state2))
+    assert len(difference_urns) == 1
+    assert (
+        difference_urns[0]
+        == "urn:li:dataset:(urn:li:dataPlatform:mysql,datahub.stateful_ingestion_test_t1,PROD)"
+    )
+
+    # 6. Perform all assertions on the config.
+    assert checkpoint1.config == checkpoint2.config
+
+    # 7. Cleanup table t2 as well to prevent other tests that rely on data in the smoke-test world.
+    drop_table(mysql_engine, table_names[1])

--- a/smoke-test/tests/utils.py
+++ b/smoke-test/tests/utils.py
@@ -7,7 +7,7 @@ from datahub.ingestion.run.pipeline import Pipeline
 GMS_ENDPOINT = "http://localhost:8080"
 FRONTEND_ENDPOINT = "http://localhost:9002"
 
-def ingest_file_via_rest(filename: str):
+def ingest_file_via_rest(filename: str) -> None:
     pipeline = Pipeline.create(
         {
             "source": {
@@ -24,7 +24,7 @@ def ingest_file_via_rest(filename: str):
     pipeline.raise_from_status()
 
 
-def delete_urns_from_file(filename: str):
+def delete_urns_from_file(filename: str) -> None:
     session = requests.Session()
     session.headers.update(
         {


### PR DESCRIPTION
1. Adds the datahub ingestion state provider for committing and retrieving checkpoint states.
2. Support for stale table/view removal for SQL based sources with stateful ingestion.
3. Skipping reruns for snowflake_usage connector with stateful ingestion.
4. Feature [documentation](https://github.com/linkedin/datahub/blob/5796935cf0526fc8d98a6e7d0c8e9fe020ef0a14/metadata-ingestion/source_docs/stateful_ingestion.md).
5. Integration tests.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
