### PR TITLE
docs(modeling): Add a link to MXE page inside the Metadata Modeling page

### DIFF
--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -113,7 +113,7 @@ module.exports = {
     "Metadata Modeling": [
       "docs/modeling/metadata-model",
       "docs/modeling/extending-the-metadata-model",
-      "docs/what/mxe.md"
+      "docs/what/mxe",
       // TODO: change the titles of these, removing the "What is..." portion from the sidebar"
       // "docs/what/entity",
       // "docs/what/aspect",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -113,7 +113,11 @@ module.exports = {
     "Metadata Modeling": [
       "docs/modeling/metadata-model",
       "docs/modeling/extending-the-metadata-model",
-      "docs/what/mxe",
+      {
+        label: "Metadata Events",
+        type: "doc",
+        id: "docs/what/mxe",
+      },      
       // TODO: change the titles of these, removing the "What is..." portion from the sidebar"
       // "docs/what/entity",
       // "docs/what/aspect",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -113,11 +113,6 @@ module.exports = {
     "Metadata Modeling": [
       "docs/modeling/metadata-model",
       "docs/modeling/extending-the-metadata-model",
-      {
-        label: "Metadata Events",
-        type: "doc",
-        id: "docs/what/mxe",
-      },      
       // TODO: change the titles of these, removing the "What is..." portion from the sidebar"
       // "docs/what/entity",
       // "docs/what/aspect",

--- a/docs-website/sidebars.js
+++ b/docs-website/sidebars.js
@@ -113,6 +113,7 @@ module.exports = {
     "Metadata Modeling": [
       "docs/modeling/metadata-model",
       "docs/modeling/extending-the-metadata-model",
+      "docs/what/mxe.md"
       // TODO: change the titles of these, removing the "What is..." portion from the sidebar"
       // "docs/what/entity",
       // "docs/what/aspect",

--- a/docs/modeling/metadata-model.md
+++ b/docs/modeling/metadata-model.md
@@ -39,6 +39,8 @@ For example, here are helpful links to the most popular entities in DataHub's me
 * Feature Table (a.k.a. MLFeatureTable): [Profile](https://demo.datahubproject.io/dataset/urn:li:dataset:(urn:li:dataPlatform:datahub,MlFeatureTable,PROD)/Schema?is_lineage_mode=false) [Documentation](https://demo.datahubproject.io/dataset/urn:li:dataset:(urn:li:dataPlatform:datahub,MlFeatureTable,PROD)/Documentation?is_lineage_mode=false)
 * For the full list of entities in the metadata model, browse them [here](https://demo.datahubproject.io/browse/dataset/prod/datahub/entities)
 
+During metadata ingestion, these entities are represented using [metadata events](../what/mxe).
+
 ### Generating documentation for the Metadata Model
 
 The metadata model documentation can be generated and uploaded into a running DataHub instance using the following command below.


### PR DESCRIPTION
A link to the MXE page has been added to the navigation bar and in a suitable place within the Metadata Modeling page.

Earlier discussion on Slack: https://datahubspace.slack.com/archives/C02FWNS2F08/p1637219334130500

/cc @jjoyce0510 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
