### PR TITLE
Upgrade to logback 1.2.9 to address CVE-2021-42550

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ project.ext.externalDependency = [
     // avro-serde includes dependencies for `kafka-avro-serializer` `kafka-schema-registry-client` and `avro`
     'kafkaAvroSerde': 'io.confluent:kafka-streams-avro-serde:5.5.1',
     'kafkaClients': 'org.apache.kafka:kafka-clients:2.3.0',
-    'logbackClassic': 'ch.qos.logback:logback-classic:1.2.3',
+    'logbackClassic': 'ch.qos.logback:logback-classic:1.2.9',
     'lombok': 'org.projectlombok:lombok:1.18.12',
     'mariadbConnector': 'org.mariadb.jdbc:mariadb-java-client:2.6.0',
     'mavenArtifact': "org.apache.maven:maven-artifact:$mavenVersion",


### PR DESCRIPTION
As per http://slf4j.org/log4shell.html, there is a lesser vulnerability in logback, which DataHub libraries directly consume in favor of log4j. This PR addresses that by bumping to 1.2.9 as recommended. 
## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
