### PR TITLE
feat(transform): adds simple add dataset properties transform

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_properties.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Type
+from typing import Any, Dict, Type
 
 import datahub.emitter.mce_builder as builder
 from datahub.configuration.common import ConfigModel
@@ -35,7 +35,10 @@ class AddDatasetProperties(DatasetTransformer):
     config: AddDatasetPropertiesConfig
 
     def __init__(
-        self, config: AddDatasetPropertiesConfig, ctx: PipelineContext, **resolver_args
+        self,
+        config: AddDatasetPropertiesConfig,
+        ctx: PipelineContext,
+        **resolver_args: Dict[str, Any],
     ):
         self.ctx = ctx
         self.config = config
@@ -50,7 +53,7 @@ class AddDatasetProperties(DatasetTransformer):
         if not isinstance(mce.proposedSnapshot, DatasetSnapshotClass):
             return mce
 
-        properties_to_add = self.config.add_properties_resolver_class(
+        properties_to_add = self.config.add_properties_resolver_class(  # type: ignore
             **self.resolver_args
         ).get_properties_to_add(mce.proposedSnapshot)
         if properties_to_add:

--- a/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_properties.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/add_dataset_properties.py
@@ -34,7 +34,9 @@ class AddDatasetProperties(DatasetTransformer):
     ctx: PipelineContext
     config: AddDatasetPropertiesConfig
 
-    def __init__(self, config: AddDatasetPropertiesConfig, ctx: PipelineContext, **resolver_args):
+    def __init__(
+        self, config: AddDatasetPropertiesConfig, ctx: PipelineContext, **resolver_args
+    ):
         self.ctx = ctx
         self.config = config
         self.resolver_args = resolver_args
@@ -48,11 +50,9 @@ class AddDatasetProperties(DatasetTransformer):
         if not isinstance(mce.proposedSnapshot, DatasetSnapshotClass):
             return mce
 
-        properties_to_add = (
-            self.config.add_properties_resolver_class(**self.resolver_args).get_properties_to_add(
-                mce.proposedSnapshot
-            )
-        )
+        properties_to_add = self.config.add_properties_resolver_class(
+            **self.resolver_args
+        ).get_properties_to_add(mce.proposedSnapshot)
         if properties_to_add:
             properties = builder.get_or_add_aspect(
                 mce, DatasetPropertiesClass(customProperties={})
@@ -81,12 +81,12 @@ class SimpleAddDatasetProperties(AddDatasetProperties):
         generic_config = AddDatasetPropertiesConfig(
             add_properties_resolver_class=SimpleAddDatasetPropertiesResolverClass
         )
-        resolver_args = {
-            "properties": config.properties
-        }
+        resolver_args = {"properties": config.properties}
         super().__init__(generic_config, ctx, **resolver_args)
 
     @classmethod
-    def create(cls, config_dict: dict, ctx: PipelineContext) -> "SimpleAddDatasetProperties":
+    def create(
+        cls, config_dict: dict, ctx: PipelineContext
+    ) -> "SimpleAddDatasetProperties":
         config = SimpleAddDatasetPropertiesConfig.parse_obj(config_dict)
         return cls(config, ctx)

--- a/metadata-ingestion/src/datahub/ingestion/transformer/transform_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/transformer/transform_registry.py
@@ -8,7 +8,10 @@ from datahub.ingestion.transformer.add_dataset_ownership import (
     PatternAddDatasetOwnership,
     SimpleAddDatasetOwnership,
 )
-from datahub.ingestion.transformer.add_dataset_properties import AddDatasetProperties
+from datahub.ingestion.transformer.add_dataset_properties import (
+    AddDatasetProperties,
+    SimpleAddDatasetProperties,
+)
 from datahub.ingestion.transformer.add_dataset_tags import (
     AddDatasetTags,
     PatternAddDatasetTags,
@@ -45,3 +48,4 @@ transform_registry.register("simple_add_dataset_terms", SimpleAddDatasetTerms)
 transform_registry.register("pattern_add_dataset_terms", PatternAddDatasetTerms)
 
 transform_registry.register("add_dataset_properties", AddDatasetProperties)
+transform_registry.register("simple_add_dataset_properties", SimpleAddDatasetProperties)

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -17,6 +17,7 @@ from datahub.ingestion.transformer.add_dataset_ownership import (
 from datahub.ingestion.transformer.add_dataset_properties import (
     AddDatasetProperties,
     AddDatasetPropertiesResolverBase,
+    SimpleAddDatasetProperties,
 )
 from datahub.ingestion.transformer.add_dataset_tags import (
     AddDatasetTags,
@@ -75,7 +76,7 @@ def make_dataset_with_properties() -> models.MetadataChangeEventClass:
             urn="urn:li:dataset:(urn:li:dataPlatform:bigquery,example1,PROD)",
             aspects=[
                 models.StatusClass(removed=False),
-                models.DatasetPropertiesClass(customProperties=EXISTING_PROPERTIES),
+                models.DatasetPropertiesClass(customProperties=EXISTING_PROPERTIES.copy()),
             ],
         ),
     )
@@ -638,6 +639,38 @@ def test_add_dataset_properties(mock_time):
     assert custom_properties.customProperties == {
         **EXISTING_PROPERTIES,
         **PROPERTIES_TO_ADD,
+    }
+
+
+def test_simple_add_dataset_properties(mock_time):
+    dataset_mce = make_dataset_with_properties()
+
+    new_properties = {
+        "new-simple-property": "new-value"
+    }
+    transformer = SimpleAddDatasetProperties.create(
+        {
+            "properties": new_properties,
+        },
+        PipelineContext(run_id="test-simple-properties"),
+    )
+
+    outputs = list(
+        transformer.transform(
+            [RecordEnvelope(input, metadata={}) for input in [dataset_mce]]
+        )
+    )
+    assert len(outputs) == 1
+
+    custom_properties = builder.get_aspect_if_available(
+        outputs[0].record, models.DatasetPropertiesClass
+    )
+
+    print(str(custom_properties))
+    assert custom_properties is not None
+    assert custom_properties.customProperties == {
+        **EXISTING_PROPERTIES,
+        **new_properties,
     }
 
 

--- a/metadata-ingestion/tests/unit/test_transform_dataset.py
+++ b/metadata-ingestion/tests/unit/test_transform_dataset.py
@@ -76,7 +76,9 @@ def make_dataset_with_properties() -> models.MetadataChangeEventClass:
             urn="urn:li:dataset:(urn:li:dataPlatform:bigquery,example1,PROD)",
             aspects=[
                 models.StatusClass(removed=False),
-                models.DatasetPropertiesClass(customProperties=EXISTING_PROPERTIES.copy()),
+                models.DatasetPropertiesClass(
+                    customProperties=EXISTING_PROPERTIES.copy()
+                ),
             ],
         ),
     )
@@ -645,9 +647,7 @@ def test_add_dataset_properties(mock_time):
 def test_simple_add_dataset_properties(mock_time):
     dataset_mce = make_dataset_with_properties()
 
-    new_properties = {
-        "new-simple-property": "new-value"
-    }
+    new_properties = {"new-simple-property": "new-value"}
     transformer = SimpleAddDatasetProperties.create(
         {
             "properties": new_properties,


### PR DESCRIPTION
There is already a transform to add custom properties to a dataset by using a callback function.
This PR is adding a simple one on top of the existing one. The new one allows for adding custom properties from the configuration. The same pattern (callback + simple version) has been followed in other transforms too.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
