### PR TITLE
doc(transforms): adds doc for simple_add_dataset_properties transformer

### DIFF
--- a/metadata-ingestion/transformers.md
+++ b/metadata-ingestion/transformers.md
@@ -270,6 +270,19 @@ class MyPropertiesResolver(AddDatasetPropertiesResolverBase):
         return properties
 ```
 
+There also exists `simple_add_dataset_properties` transformer for directly assigning properties from the configuration.
+`properties` field is a dictionary of string values. Note in case of any key collision, the value in the config will
+overwrite the previous value.
+
+```yaml
+transformers:
+  - type: "simple_add_dataset_properties"
+    config:
+      properties:
+        prop1: value1
+        prop2: value2
+```
+
 ## Writing a custom transformer from scratch
 
 In the above couple of examples, we use classes that have already been implemented in the ingestion framework. However, it’s common for more advanced cases to pop up where custom code is required, for instance if you'd like to utilize conditional logic or rewrite properties. In such cases, we can add our own modules and define the arguments it takes as a custom transformer.


### PR DESCRIPTION
This is just adding the missing doc for the transform added here https://github.com/linkedin/datahub/pull/3778

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
