### PR TITLE
feat(snowflake-usage): Generate email address if not exists 

### DIFF
--- a/metadata-ingestion/examples/recipes/snowflake_usage_to_datahub.yml
+++ b/metadata-ingestion/examples/recipes/snowflake_usage_to_datahub.yml
@@ -1,0 +1,23 @@
+---
+# see https://datahubproject.io/docs/metadata-ingestion/source_docs/snowflake/#config-details-1 for complete documentation
+source:
+  type: snowflake-usage
+  config:
+    env: PROD
+    # Coordinates
+    host_port: account_name
+    warehouse: "COMPUTE_WH"
+
+    # Credentials
+    username: user
+    password: pass
+    role: "sysadmin"
+
+    # Options
+    top_n_queries: 10
+    email_domain: mycompany.com
+# see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
+sink:
+  type: datahub-rest
+  config:
+    server: http://localhost:8080

--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -202,7 +202,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `role`             |          |                                                                     | Snowflake role.                                                                  |
 | `env`              |          | `"PROD"`                                                            | Environment to use in namespace when constructing URNs.                          |
 | `bucket_duration`  |          | `"DAY"`                                                             | Duration to bucket usage events by. Can be `"DAY"` or `"HOUR"`.                  |
-| `email_domain`     | ✅        |                                                                     | Email domain of your organisation so users can be displayed on UI appropriately. |
+| `email_domain`     |          |                                                                     | Email domain of your organisation so users can be displayed on UI appropriately. |
 | `start_time`       |          | Last full day in UTC (or hour, depending on `bucket_duration`)      | Earliest date of usage logs to consider.                                         |
 | `end_time`         |          | Last full day in UTC (or hour, depending on `bucket_duration`)      | Latest date of usage logs to consider.                                           |
 | `top_n_queries`    |          | `10`                                                                | Number of top queries to save to each table.                                     |
@@ -210,6 +210,14 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `schema_pattern`   |          |                                                                     | Allow/deny patterns for schema in snowflake dataset names.                       |
 | `view_pattern`     |          |                                                                     | Allow/deny patterns for views in snowflake dataset names.                        |
 | `table_pattern`    |          |                                                                     | Allow/deny patterns for tables in snowflake dataset names.                       |
+
+:::caution
+
+User's without email address will be ignored from usage if you don't set `email_domain` property.
+
+:::
+
+
 
 # Compatibility
 

--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -181,7 +181,7 @@ source:
 
     # Options
     top_n_queries: 10
-
+    email_domain: mycompany.com
 sink:
   # sink configs
 ```

--- a/metadata-ingestion/source_docs/snowflake.md
+++ b/metadata-ingestion/source_docs/snowflake.md
@@ -193,22 +193,23 @@ Snowflake integration also supports prevention of redundant reruns for the same 
 Note that a `.` is used to denote nested fields in the YAML recipe.
 
 
-| Field             | Required | Default                                                             | Description                                                     |
-| ----------------- | -------- | --------------------------------------------------------------------| --------------------------------------------------------------- |
-| `username`        |          |                                                                     | Snowflake username.                                             |
-| `password`        |          |                                                                     | Snowflake password.                                             |
-| `host_port`       | ✅       |                                                                     | Snowflake host URL.                                             |
-| `warehouse`       |          |                                                                     | Snowflake warehouse.                                            |
-| `role`            |          |                                                                     | Snowflake role.                                                 |
-| `env`             |          | `"PROD"`                                                            | Environment to use in namespace when constructing URNs.         |
-| `bucket_duration` |          | `"DAY"`                                                             | Duration to bucket usage events by. Can be `"DAY"` or `"HOUR"`. |
-| `start_time`      |          | Last full day in UTC (or hour, depending on `bucket_duration`)      | Earliest date of usage logs to consider.                        |
-| `end_time`        |          | Last full day in UTC (or hour, depending on `bucket_duration`)      | Latest date of usage logs to consider.                          |
-| `top_n_queries`   |          | `10`                                                                | Number of top queries to save to each table.                    |
-| `database_pattern`|          | `"^UTIL_DB$" `<br />`"^SNOWFLAKE$"`<br />`"^SNOWFLAKE_SAMPLE_DATA$" | Allow/deny patterns for db in snowflake dataset names.          |
-| `schema_pattern`  |          |                                                                     | Allow/deny patterns for schema in snowflake dataset names.      |
-| `view_pattern`     |          |                                                                    | Allow/deny patterns for views in snowflake dataset names.       |
-| `table_pattern`     |          |                                                                   | Allow/deny patterns for tables in snowflake dataset names.       |
+| Field              | Required | Default                                                             | Description                                                                      |
+|--------------------|----------|---------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| `username`         |          |                                                                     | Snowflake username.                                                              |
+| `password`         |          |                                                                     | Snowflake password.                                                              |
+| `host_port`        | ✅        |                                                                     | Snowflake host URL.                                                              |
+| `warehouse`        |          |                                                                     | Snowflake warehouse.                                                             |
+| `role`             |          |                                                                     | Snowflake role.                                                                  |
+| `env`              |          | `"PROD"`                                                            | Environment to use in namespace when constructing URNs.                          |
+| `bucket_duration`  |          | `"DAY"`                                                             | Duration to bucket usage events by. Can be `"DAY"` or `"HOUR"`.                  |
+| `email_domain`     | ✅        |                                                                     | Email domain of your organisation so users can be displayed on UI appropriately. |
+| `start_time`       |          | Last full day in UTC (or hour, depending on `bucket_duration`)      | Earliest date of usage logs to consider.                                         |
+| `end_time`         |          | Last full day in UTC (or hour, depending on `bucket_duration`)      | Latest date of usage logs to consider.                                           |
+| `top_n_queries`    |          | `10`                                                                | Number of top queries to save to each table.                                     |
+| `database_pattern` |          | `"^UTIL_DB$" `<br />`"^SNOWFLAKE$"`<br />`"^SNOWFLAKE_SAMPLE_DATA$" | Allow/deny patterns for db in snowflake dataset names.                           |
+| `schema_pattern`   |          |                                                                     | Allow/deny patterns for schema in snowflake dataset names.                       |
+| `view_pattern`     |          |                                                                     | Allow/deny patterns for views in snowflake dataset names.                        |
+| `table_pattern`    |          |                                                                     | Allow/deny patterns for tables in snowflake dataset names.                       |
 
 # Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -338,11 +338,14 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
 
             if not event_dict["email"] and self.config.email_domain:
                 if not event_dict["user_name"]:
-                    event_dict["user_name"] = "unknown"
+                    logging.warning(
+                        f"The user_name is missing from {event_dict}. Skipping ...."
+                    )
+                    continue
 
                 event_dict[
                     "email"
-                ] = f'{event_dict["user_name"]}@{self.config.email_domain}'
+                ] = f'{event_dict["user_name"]}@{self.config.email_domain}'.lower()
 
             try:  # big hammer try block to ensure we don't fail on parsing events
                 event = SnowflakeJoinedAccessEvent(**event_dict)

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -118,6 +118,7 @@ class SnowflakeUsageConfig(
     database_pattern: AllowDenyPattern = AllowDenyPattern(
         deny=[r"^UTIL_DB$", r"^SNOWFLAKE$", r"^SNOWFLAKE_SAMPLE_DATA$"]
     )
+    email_domain: str
     schema_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     table_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
@@ -334,6 +335,14 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
             event_dict["query_start_time"] = (
                 event_dict["query_start_time"]
             ).astimezone(tz=timezone.utc)
+
+            if not event_dict["email"]:
+                if not event_dict["user_name"]:
+                    event_dict["user_name"] = "unknown"
+
+                event_dict[
+                    "email"
+                ] = f'{event_dict["user_name"]}@{self.config.email_domain}'
 
             try:  # big hammer try block to ensure we don't fail on parsing events
                 event = SnowflakeJoinedAccessEvent(**event_dict)

--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -118,7 +118,7 @@ class SnowflakeUsageConfig(
     database_pattern: AllowDenyPattern = AllowDenyPattern(
         deny=[r"^UTIL_DB$", r"^SNOWFLAKE$", r"^SNOWFLAKE_SAMPLE_DATA$"]
     )
-    email_domain: str
+    email_domain: Optional[str]
     schema_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     table_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
     view_pattern: AllowDenyPattern = AllowDenyPattern.allow_all()
@@ -336,7 +336,7 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
                 event_dict["query_start_time"]
             ).astimezone(tz=timezone.utc)
 
-            if not event_dict["email"]:
+            if not event_dict["email"] and self.config.email_domain:
                 if not event_dict["user_name"]:
                     event_dict["user_name"] = "unknown"
 


### PR DESCRIPTION
This will introduce a breaking change as users will have to specify the `email_domain` config parameter.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
