### PR TITLE
fix(elastic): allow more time for re-indexing tasks

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -100,7 +100,7 @@ public class ESIndexBuilder {
       long millisToWait60Minutes = 1000 * 60 * 60;
       Boolean reindexTaskCompleted = false;
 
-      while((System.currentTimeMillis() - startTime) < millisToWait60Minutes) {
+      while ((System.currentTimeMillis() - startTime) < millisToWait60Minutes) {
         log.info("Reindexing from {} to {} in progress...", indexName, tempIndexName);
         ListTasksRequest request = new ListTasksRequest();
         ListTasksResponse tasks = searchClient.tasks().list(request, RequestOptions.DEFAULT);

--- a/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/elasticsearch/indexbuilder/ESIndexBuilder.java
@@ -13,6 +13,8 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
@@ -25,10 +27,10 @@ import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.tasks.TaskSubmissionResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.ReindexRequest;
-
 
 @Slf4j
 @RequiredArgsConstructor
@@ -89,9 +91,33 @@ public class ESIndexBuilder {
     String tempIndexName = indexName + "_" + System.currentTimeMillis();
     createIndex(tempIndexName, mappings, finalSettings);
     try {
-      searchClient.reindex(
-          new ReindexRequest().setSourceIndices(indexName).setDestIndex(tempIndexName),
-          RequestOptions.DEFAULT);
+      TaskSubmissionResponse reindexTask;
+      reindexTask = searchClient.submitReindexTask(new ReindexRequest().setSourceIndices(indexName).setDestIndex(tempIndexName),
+              RequestOptions.DEFAULT);
+
+      // wait up to 5 minutes for the task to complete
+      long startTime = System.currentTimeMillis();
+      long millisToWait60Minutes = 1000 * 60 * 60;
+      Boolean reindexTaskCompleted = false;
+
+      while((System.currentTimeMillis() - startTime) < millisToWait60Minutes) {
+        log.info("Reindexing from {} to {} in progress...", indexName, tempIndexName);
+        ListTasksRequest request = new ListTasksRequest();
+        ListTasksResponse tasks = searchClient.tasks().list(request, RequestOptions.DEFAULT);
+        if (tasks.getTasks().stream().noneMatch(task -> task.getTaskId().toString().equals(reindexTask.getTask()))) {
+          log.info("Reindexing {} to {} task has completed, will now check if reindex was successful", indexName, tempIndexName);
+          reindexTaskCompleted = true;
+          break;
+        }
+        try {
+          Thread.sleep(5000);
+        } catch (InterruptedException e) {
+          log.info("Trouble sleeping while reindexing {} to {}: Exception {}. Retrying...", indexName, tempIndexName, e.toString());
+        }
+      }
+      if (!reindexTaskCompleted) {
+        throw new RuntimeException(String.format("Reindex from %s to %s failed-- task exceeded 60 minute limit", indexName, tempIndexName));
+      }
     } catch (Exception e) {
       log.info("Failed to reindex {} to {}: Exception {}", indexName, tempIndexName, e.toString());
       searchClient.indices().delete(new DeleteIndexRequest().indices(tempIndexName), RequestOptions.DEFAULT);


### PR DESCRIPTION
Previously, reindexing tasks would timeout after the ES rest client's 30 second limit. This PR ups the wait time to an hour.

Other attempted solutions:
- increase the timeout of the sync reindex call (this did not seem possible)
- use waitForComplete = true in the ListTaskRequest. This did not appear to abide by the timeout i set despite my efforts. It also threw exceptions after 30s, even when the timeout was set to be larger.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
