### PR TITLE
fix(ingest): Handle string redshift type

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -277,8 +277,10 @@ def _get_schema_column_info(self, connection, schema=None, **kw):
                    replace(
                    replace(
                    replace(
+                   replace(
                    replace(external_type, 'decimal', 'numeric'),
                     'varchar', 'character varying'),
+                    'string', 'character varying'),
                     'char(', 'character('),
                     'float', 'real'),
                     'double', 'float')
@@ -296,8 +298,10 @@ def _get_schema_column_info(self, connection, schema=None, **kw):
                    replace(
                    replace(
                    replace(
+                   replace(
                    replace(external_type, 'decimal', 'numeric'),
                     'varchar', 'character varying'),
+                    'string', 'character varying'),
                     'char(', 'character('),
                     'float', 'real'),
                     'double', 'float')


### PR DESCRIPTION
When a table is backed with Glue metastore, it can happen a column has string type and sqlalchemy does not know about it.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
