### PR TITLE
fix(ingestion): Make url an optional field of the DefaultConfig for business glossary

### DIFF
--- a/docs/modeling/metadata-model.md
+++ b/docs/modeling/metadata-model.md
@@ -39,7 +39,7 @@ For example, here are helpful links to the most popular entities in DataHub's me
 * Feature Table (a.k.a. MLFeatureTable): [Profile](https://demo.datahubproject.io/dataset/urn:li:dataset:(urn:li:dataPlatform:datahub,MlFeatureTable,PROD)/Schema?is_lineage_mode=false) [Documentation](https://demo.datahubproject.io/dataset/urn:li:dataset:(urn:li:dataPlatform:datahub,MlFeatureTable,PROD)/Documentation?is_lineage_mode=false)
 * For the full list of entities in the metadata model, browse them [here](https://demo.datahubproject.io/browse/dataset/prod/datahub/entities)
 
-During metadata ingestion, these entities are represented using [metadata events](../what/mxe).
+During metadata ingestion, these entities are represented using [metadata events](../what/mxe.md).
 
 ### Generating documentation for the Metadata Model
 

--- a/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/metadata/business_glossary.py
@@ -52,8 +52,8 @@ class DefaultConfig(ConfigModel):
     """Holds defaults for populating fields in glossary terms"""
 
     source: str
-    url: str
     owners: Owners
+    url: Optional[str] = None
     source_type: Optional[str] = "INTERNAL"
 
 


### PR DESCRIPTION
Makes the url field of the DefaultConfig of business glossary optional to keep it consistent with the [documentation](https://github.com/linkedin/datahub/blob/master/metadata-ingestion/source_docs/business_glossary.md#business-glossary-file-format) as well as the definition of [GlossaryTermInfo  aspect](https://github.com/linkedin/datahub/blob/master/metadata-models/src/main/pegasus/com/linkedin/glossary/GlossaryTermInfo.pdl#L44).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
