### PR TITLE
fix(search): Fix urn search keyword match

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/search/utils/ESUtils.java
@@ -92,7 +92,8 @@ public class ESUtils {
       // TODO(https://github.com/linkedin/datahub-gma/issues/51): support multiple values a field can take without using
       // delimiters like comma. This is a hack to support equals with URN that has a comma in it.
       if (SearchUtils.isUrn(criterion.getValue())) {
-        filters.should(QueryBuilders.matchQuery(criterion.getField(), criterion.getValue().trim()));
+        // Add keyword index for any URN field types.
+        filters.should(QueryBuilders.matchQuery(criterion.getField() + ".keyword", criterion.getValue().trim()));
         return filters;
       }
 


### PR DESCRIPTION
**Summary**
Previously, we were not correctly using the "keyword" index field for matching searches that filter by URN. This caused us to perform a fuzzy match and match multiple records when filtering by urn (for example, by tag).

This PR fixes by ensuring that URN search filters use the ".keyword" field when matching. 

Slack thread: https://datahubspace.slack.com/archives/C029A3M079U/p1639775100480300 


**Acknowledgements**

Thanks to Ugo Bellavance and Mark Alexandre Allen-Lefebvre for identifying and documenting this issue! 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
