### PR TITLE
fix(ingest): bigquery-usage - fix remove_extras to remove all partitions

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/bigquery_usage.py
@@ -42,7 +42,9 @@ DEBUG_INCLUDE_FULL_PAYLOADS = False
 # Handle yearly, monthly, daily, or hourly partitioning.
 # See https://cloud.google.com/bigquery/docs/partitioned-tables.
 # This REGEX handles both Partitioned Tables ($ separator) and Sharded Tables (_ separator)
-PARTITIONED_TABLE_REGEX = re.compile(r"^(.+)[\$_](\d{4}|\d{6}|\d{8}|\d{10})$")
+PARTITIONED_TABLE_REGEX = re.compile(
+    r"^(.+)[\$_](\d{4}|\d{6}|\d{8}|\d{10}|__PARTITIONS_SUMMARY__)$"
+)
 
 # Handle table snapshots
 # See https://cloud.google.com/bigquery/docs/table-snapshots-intro.

--- a/metadata-ingestion/tests/integration/bigquery-usage/test_bigquery_usage.py
+++ b/metadata-ingestion/tests/integration/bigquery-usage/test_bigquery_usage.py
@@ -9,6 +9,7 @@ import pytest
 from datahub.ingestion.api.common import PipelineContext
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.ingestion.source.usage.bigquery_usage import (
+    BigQueryTableRef,
     BigQueryUsageConfig,
     BigQueryUsageSource,
 )
@@ -105,3 +106,16 @@ def test_bq_usage_source(pytestconfig, tmp_path):
         output_path=tmp_path / "bigquery_usages.json",
         golden_path=test_resources_dir / "bigquery_usages_golden.json",
     )
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("test_table$20220101", "test_table"),
+        ("test_table$__PARTITIONS_SUMMARY__", "test_table"),
+        ("test_table_20220101", "test_table"),
+    ],
+)
+def test_remove_extras(test_input, expected):
+    table_ref = BigQueryTableRef("test_project", "test_dataset", test_input)
+    assert table_ref.remove_extras().table == expected


### PR DESCRIPTION
Hello ! 

Today I tried using the bigquery-usage source with the following configuration : 

```yaml
source:
  type: bigquery-usage
  config:
    # Coordinates
    projects:
      - dailymotion-rawlogs
    top_n_queries: 10
    query_log_delay: 30

    table_pattern:
      deny:
        - (tmp.+|temp.+)

sink:
  # sink configs
  type: "datahub-kafka"
  config:
    connection:
      bootstrap: "localhost:9092"
      schema_registry_url: "http://localhost:8081"

```

Unfortunately I had this error : 

```
Traceback (most recent call last):
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/ingestion/source/usage/bigquery_usage.py", line 605, in _aggregate_enriched_read_events
    resource = event.resource.remove_extras()
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/ingestion/source/usage/bigquery_usage.py", line 136, in remove_extras
    raise ValueError(
ValueError: Cannot handle projects/dailymotion-rawlogs/datasets/event_mobile/tables/ui_display$__PARTITIONS_SUMMARY__ - poorly formatted table name, contains ['$']

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 1085, in emit
    msg = self.format(record)
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 929, in format
    return fmt.format(record)
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 668, in format
    record.message = record.getMessage()
  File "/usr/local/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/logging/__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/Users/p.genissel/venv/datahub/bin/datahub", line 8, in <module>
    sys.exit(main())
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/entrypoints.py", line 102, in main
    sys.exit(datahub(standalone_mode=False, **kwargs))
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/telemetry/telemetry.py", line 141, in wrapper
    res = func(*args, **kwargs)
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/cli/ingest_cli.py", line 82, in run
    pipeline.run()
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/ingestion/run/pipeline.py", line 153, in run
    for wu in itertools.islice(
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/ingestion/source/usage/bigquery_usage.py", line 397, in get_workunits
    aggregated_info = self._aggregate_enriched_read_events(hydrated_read_events)
  File "/Users/p.genissel/venv/datahub/lib/python3.8/site-packages/datahub/ingestion/source/usage/bigquery_usage.py", line 610, in _aggregate_enriched_read_events
    logger.warning(f"Failed to process event {str(event.resource)}", e)
Message: 'Failed to process event projects/dailymotion-rawlogs/datasets/event_mobile/tables/ui_display$__PARTITIONS_SUMMARY__'
Arguments: (ValueError("Cannot handle projects/dailymotion-rawlogs/datasets/event_mobile/tables/ui_display$__PARTITIONS_SUMMARY__ - poorly formatted table name, contains ['$']"),)
```

This PR means to fix the problem, I added a test to be sure this never happens in the future :) 

Thank you very much for your help ! This project is great !

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
