### PR TITLE
fix(ingestion): handle database=None for dbt ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -119,7 +119,7 @@ class DBTColumn:
 
 @dataclass
 class DBTNode:
-    database: str
+    database: Optional[str]
     schema: str
     name: str  # name, identifier
     comment: str
@@ -362,12 +362,16 @@ def loadManifestAndCatalog(
     )
 
 
-def get_db_fqn(database: str, schema: str, name: str) -> str:
-    return f"{database}.{schema}.{name}".replace('"', "")
+def get_db_fqn(database: Optional[str], schema: str, name: str) -> str:
+    if database is not None:
+        fqn = f"{database}.{schema}.{name}"
+    else:
+        fqn = f"{schema}.{name}"
+    return fqn.replace('"', "")
 
 
 def get_urn_from_dbtNode(
-    database: str, schema: str, name: str, target_platform: str, env: str
+    database: Optional[str], schema: str, name: str, target_platform: str, env: str
 ) -> str:
     db_fqn = get_db_fqn(database, schema, name)
     return f"urn:li:dataset:(urn:li:dataPlatform:{target_platform},{db_fqn},{env})"


### PR DESCRIPTION
When using the dbt-spark adapter, 'database' is not set, resulting in a fqn containing "None".
Apart from the cosmetic issue, this also creates a mismatch between the fqn of dbt models and the underlying glue tables (which are just schema.table).

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
