### PR TITLE
feat(lineage): allow for expanding of lineage node titles in the lineage explorer

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -20,6 +20,7 @@ const PreviewImage = styled(Image)`
 const EntityTitle = styled(Typography.Title)`
     &&& {
         margin-bottom: 0;
+        word-break: break-all;
     }
 `;
 

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { Group } from '@vx/group';
 import { LinkHorizontal } from '@vx/shape';
 import styled from 'styled-components';
@@ -8,6 +8,8 @@ import { IconStyleType } from '../entity/Entity';
 import { NodeData, Direction, VizNode, EntitySelectParams } from './types';
 import { ANTD_GRAY } from '../entity/shared/constants';
 import { capitalizeFirstLetter } from '../shared/capitalizeFirstLetter';
+import { nodeHeightFromTitleLength } from './utils/nodeHeightFromTitleLength';
+import { LineageExplorerContext } from './utils/LineageExplorerContext';
 
 const CLICK_DELAY_THRESHOLD = 1000;
 const DRAG_DISTANCE_THRESHOLD = 20;
@@ -76,6 +78,7 @@ export default function LineageEntityNode({
     direction: Direction;
     nodesToRenderByUrn: Record<string, VizNode>;
 }) {
+    const { expandTitles } = useContext(LineageExplorerContext);
     const [isExpanding, setIsExpanding] = useState(false);
     const [expandHover, setExpandHover] = useState(false);
 
@@ -93,6 +96,8 @@ export default function LineageEntityNode({
         }),
         [],
     );
+
+    const nodeHeight = nodeHeightFromTitleLength(expandTitles ? node.data.name : node.data.name.charAt(0)) - 40;
 
     return (
         <PointerGroup data-testid={`node-${node.data.urn}-${direction}`} top={node.x} left={node.y}>
@@ -139,13 +144,13 @@ export default function LineageEntityNode({
                     >
                         <circle
                             fill="none"
-                            cy={centerY + height / 2}
+                            cy={centerY + nodeHeight / 2}
                             cx={direction === Direction.Upstream ? centerX - 10 : centerX + width + 10}
                             r="20"
                         />
                         <circle
                             fill="none"
-                            cy={centerY + height / 2}
+                            cy={centerY + nodeHeight / 2}
                             cx={direction === Direction.Upstream ? centerX - 30 : centerX + width + 30}
                             r="30"
                         />
@@ -200,7 +205,7 @@ export default function LineageEntityNode({
                 }}
             >
                 <rect
-                    height={height}
+                    height={nodeHeight}
                     width={width}
                     y={centerY}
                     x={centerX}
@@ -252,16 +257,31 @@ export default function LineageEntityNode({
                             {capitalizeFirstLetter(node.data.subtype || node.data.type)}
                         </tspan>
                     </UnselectableText>
-                    <UnselectableText
-                        dy="1em"
-                        x={textX}
-                        fontSize={14}
-                        fontFamily="Manrope"
-                        textAnchor="start"
-                        fill={isCenterNode ? '#1890FF' : 'black'}
-                    >
-                        {truncate(getLastTokenOfTitle(node.data.name), 16)}
-                    </UnselectableText>
+                    {expandTitles ? (
+                        <foreignObject x={textX} width="125" height="200">
+                            <p
+                                style={{
+                                    marginTop: '-2px',
+                                    fontSize: 14,
+                                    width: 125,
+                                    wordBreak: 'break-all',
+                                }}
+                            >
+                                {node.data.name}
+                            </p>
+                        </foreignObject>
+                    ) : (
+                        <UnselectableText
+                            dy="1em"
+                            x={textX}
+                            fontSize={14}
+                            fontFamily="Manrope"
+                            textAnchor="start"
+                            fill={isCenterNode ? '#1890FF' : 'black'}
+                        >
+                            {truncate(getLastTokenOfTitle(node.data.name), 16)}
+                        </UnselectableText>
+                    )}
                 </Group>
                 {unexploredHiddenChildren && isHovered ? (
                     <UnselectableText

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -97,7 +97,7 @@ export default function LineageEntityNode({
         [],
     );
 
-    const nodeHeight = nodeHeightFromTitleLength(expandTitles ? node.data.name : node.data.name.charAt(0)) - 40;
+    const nodeHeight = nodeHeightFromTitleLength(expandTitles ? node.data.name : undefined);
 
     return (
         <PointerGroup data-testid={`node-${node.data.urn}-${direction}`} top={node.x} left={node.y}>

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -57,7 +57,7 @@ const MultilineTitleText = styled.p`
     margin-top: -2px;
     font-size: 14px;
     width: 125px;
-    word-break: 'break-all';
+    word-break: break-all;
 `;
 
 export default function LineageEntityNode({

--- a/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
+++ b/datahub-web-react/src/app/lineage/LineageEntityNode.tsx
@@ -53,6 +53,13 @@ const UnselectableText = styled.text`
     user-select: none;
 `;
 
+const MultilineTitleText = styled.p`
+    margin-top: -2px;
+    font-size: 14px;
+    width: 125px;
+    word-break: 'break-all';
+`;
+
 export default function LineageEntityNode({
     node,
     isSelected,
@@ -259,16 +266,7 @@ export default function LineageEntityNode({
                     </UnselectableText>
                     {expandTitles ? (
                         <foreignObject x={textX} width="125" height="200">
-                            <p
-                                style={{
-                                    marginTop: '-2px',
-                                    fontSize: 14,
-                                    width: 125,
-                                    wordBreak: 'break-all',
-                                }}
-                            >
-                                {node.data.name}
-                            </p>
+                            <MultilineTitleText>{node.data.name}</MultilineTitleText>
                         </foreignObject>
                     ) : (
                         <UnselectableText

--- a/datahub-web-react/src/app/lineage/LineageTree.tsx
+++ b/datahub-web-react/src/app/lineage/LineageTree.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { TransformMatrix } from '@vx/zoom/lib/types';
 
 import { NodeData, Direction, EntitySelectParams, TreeProps } from './types';
 import LineageTreeNodeAndEdgeRenderer from './LineageTreeNodeAndEdgeRenderer';
 import layoutTree from './utils/layoutTree';
+import { LineageExplorerContext } from './utils/LineageExplorerContext';
 
 type LineageTreeProps = {
     data: NodeData;
@@ -41,6 +42,7 @@ export default function LineageTree({
     setDraggedNodes,
 }: LineageTreeProps) {
     const [xCanvasScale, setXCanvasScale] = useState(1);
+    const { expandTitles } = useContext(LineageExplorerContext);
 
     useEffect(() => {
         setXCanvasScale(1);
@@ -49,8 +51,8 @@ export default function LineageTree({
     let dragState: { urn: string; x: number; y: number } | undefined;
 
     const { nodesToRender, edgesToRender, nodesByUrn, layers } = useMemo(
-        () => layoutTree(data, direction, draggedNodes, canvasHeight),
-        [data, direction, draggedNodes, canvasHeight],
+        () => layoutTree(data, direction, draggedNodes, canvasHeight, expandTitles),
+        [data, direction, draggedNodes, canvasHeight, expandTitles],
     );
 
     const dragContinue = (event: MouseEvent) => {

--- a/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
+++ b/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
@@ -89,7 +89,7 @@ export default function LineageVizInsideZoom({
     selectedEntity,
     width,
     height,
-}: Props): JSX.Element {
+}: Props) {
     const [draggedNodes, setDraggedNodes] = useState<Record<string, { x: number; y: number }>>({});
 
     const [hoveredEntity, setHoveredEntity] = useState<EntitySelectParams | undefined>(undefined);

--- a/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
+++ b/datahub-web-react/src/app/lineage/LineageVizInsideZoom.tsx
@@ -1,13 +1,15 @@
 import React, { SVGProps, useEffect, useMemo, useState } from 'react';
 import { PlusOutlined, MinusOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
-import { Button } from 'antd';
+import { Button, Switch } from 'antd';
 import { ProvidedZoom, TransformMatrix } from '@vx/zoom/lib/types';
 
 import LineageTree from './LineageTree';
 import constructTree from './utils/constructTree';
 import { Direction, EntityAndType, EntitySelectParams, FetchedEntity } from './types';
 import { useEntityRegistry } from '../useEntityRegistry';
+import { ANTD_GRAY } from '../entity/shared/constants';
+import { LineageExplorerContext } from './utils/LineageExplorerContext';
 
 const ZoomContainer = styled.div`
     position: relative;
@@ -17,6 +19,25 @@ const ZoomControls = styled.div`
     position: absolute;
     top: 20px;
     right: 20px;
+`;
+
+const DisplayControls = styled.div`
+    padding: 8px;
+    position: absolute;
+    bottom: 30px;
+    right: 20px;
+    background-color: white;
+    border: 1px solid ${ANTD_GRAY[4.5]};
+    border-radius: 5px;
+    box-shadow: 0px 0px 4px 0px #0000001a;
+`;
+
+const ControlsTitle = styled.div`
+    margin-bottom: 12px;
+`;
+
+const ControlsSwitch = styled(Switch)`
+    margin-right: 8px;
 `;
 
 const ZoomButton = styled(Button)`
@@ -68,11 +89,12 @@ export default function LineageVizInsideZoom({
     selectedEntity,
     width,
     height,
-}: Props) {
+}: Props): JSX.Element {
     const [draggedNodes, setDraggedNodes] = useState<Record<string, { x: number; y: number }>>({});
 
     const [hoveredEntity, setHoveredEntity] = useState<EntitySelectParams | undefined>(undefined);
     const [isDraggingNode, setIsDraggingNode] = useState(false);
+    const [showExpandedTitles, setShowExpandedTitles] = useState(false);
 
     const entityRegistry = useEntityRegistry();
 
@@ -98,144 +120,154 @@ export default function LineageVizInsideZoom({
     }, [entityAndType?.entity?.urn]);
 
     return (
-        <ZoomContainer>
-            <ZoomControls>
-                <ZoomButton onClick={() => zoom.scale({ scaleX: 1.2, scaleY: 1.2 })}>
-                    <PlusOutlined />
-                </ZoomButton>
-                <Button onClick={() => zoom.scale({ scaleX: 0.8, scaleY: 0.8 })}>
-                    <MinusOutlined />
-                </Button>
-            </ZoomControls>
-            <RootSvg
-                width={width}
-                height={height}
-                onMouseDown={zoom.dragStart}
-                onMouseUp={zoom.dragEnd}
-                onMouseMove={(e) => {
-                    if (!isDraggingNode) {
-                        zoom.dragMove(e);
-                    }
-                }}
-                onTouchStart={zoom.dragStart}
-                onTouchMove={(e) => {
-                    if (!isDraggingNode) {
-                        zoom.dragMove(e);
-                    }
-                }}
-                onTouchEnd={zoom.dragEnd}
-                isDragging={zoom.isDragging}
-            >
-                <defs>
-                    <marker
-                        id="triangle-downstream"
-                        viewBox="0 0 10 10"
-                        refX="10"
-                        refY="5"
-                        markerUnits="strokeWidth"
-                        markerWidth="10"
-                        markerHeight="10"
-                        orient="auto"
-                    >
-                        <path d="M 0 0 L 10 5 L 0 10 z" fill="#BFBFBF" />
-                    </marker>
-                    <marker
-                        id="triangle-upstream"
-                        viewBox="0 0 10 10"
-                        refX="0"
-                        refY="5"
-                        markerUnits="strokeWidth"
-                        markerWidth="10"
-                        markerHeight="10"
-                        orient="auto"
-                    >
-                        <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#BFBFBF" />
-                    </marker>
-                    <marker
-                        id="triangle-downstream-highlighted"
-                        viewBox="0 0 10 10"
-                        refX="10"
-                        refY="5"
-                        markerUnits="strokeWidth"
-                        markerWidth="10"
-                        markerHeight="10"
-                        orient="auto"
-                    >
-                        <path d="M 0 0 L 10 5 L 0 10 z" fill="#1890FF" />
-                    </marker>
-                    <marker
-                        id="triangle-upstream-highlighted"
-                        viewBox="0 0 10 10"
-                        refX="0"
-                        refY="5"
-                        markerUnits="strokeWidth"
-                        markerWidth="10"
-                        markerHeight="10"
-                        orient="auto"
-                    >
-                        <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#1890FF" />
-                    </marker>
-                    <linearGradient id="gradient-Downstream" x1="1" x2="0" y1="0" y2="0">
-                        <stop offset="0%" stopColor="#1890FF" />
-                        <stop offset="100%" stopColor="#1890FF" stopOpacity="0" />
-                    </linearGradient>
-                    <linearGradient id="gradient-Upstream" x1="0" x2="1" y1="0" y2="0">
-                        <stop offset="0%" stopColor="#1890FF" />
-                        <stop offset="100%" stopColor="#1890FF" stopOpacity="0" />
-                    </linearGradient>
-                    <filter id="shadow1">
-                        <feDropShadow
-                            dx="0"
-                            dy="0"
-                            stdDeviation="4"
-                            floodColor="rgba(72, 106, 108, 0.15)"
-                            floodOpacity="1"
-                        />
-                    </filter>
-                    <filter id="shadow1-selected">
-                        <feDropShadow
-                            dx="0"
-                            dy="0"
-                            stdDeviation="6"
-                            floodColor="rgba(24, 144, 255, .15)"
-                            floodOpacity="1"
-                        />
-                    </filter>
-                </defs>
-                <rect width={width} height={height} fill="#fafafa" />
-                <LineageTree
-                    data={upstreamData}
-                    zoom={zoom}
-                    onEntityClick={onEntityClick}
-                    onEntityCenter={onEntityCenter}
-                    onLineageExpand={onLineageExpand}
-                    margin={margin}
-                    selectedEntity={selectedEntity}
-                    hoveredEntity={hoveredEntity}
-                    setHoveredEntity={setHoveredEntity}
-                    direction={Direction.Upstream}
-                    canvasHeight={height}
-                    setIsDraggingNode={setIsDraggingNode}
-                    draggedNodes={draggedNodes}
-                    setDraggedNodes={setDraggedNodes}
-                />
-                <LineageTree
-                    data={downstreamData}
-                    zoom={zoom}
-                    onEntityClick={onEntityClick}
-                    onEntityCenter={onEntityCenter}
-                    onLineageExpand={onLineageExpand}
-                    margin={margin}
-                    selectedEntity={selectedEntity}
-                    hoveredEntity={hoveredEntity}
-                    setHoveredEntity={setHoveredEntity}
-                    direction={Direction.Downstream}
-                    canvasHeight={height}
-                    setIsDraggingNode={setIsDraggingNode}
-                    draggedNodes={draggedNodes}
-                    setDraggedNodes={setDraggedNodes}
-                />
-            </RootSvg>
-        </ZoomContainer>
+        <LineageExplorerContext.Provider value={{ expandTitles: showExpandedTitles }}>
+            <ZoomContainer>
+                <ZoomControls>
+                    <ZoomButton onClick={() => zoom.scale({ scaleX: 1.2, scaleY: 1.2 })}>
+                        <PlusOutlined />
+                    </ZoomButton>
+                    <Button onClick={() => zoom.scale({ scaleX: 0.8, scaleY: 0.8 })}>
+                        <MinusOutlined />
+                    </Button>
+                </ZoomControls>
+                <DisplayControls>
+                    <ControlsTitle>Controls</ControlsTitle>
+                    <ControlsSwitch
+                        checked={showExpandedTitles}
+                        onChange={(checked) => setShowExpandedTitles(checked)}
+                    />{' '}
+                    Show Full Titles
+                </DisplayControls>
+                <RootSvg
+                    width={width}
+                    height={height}
+                    onMouseDown={zoom.dragStart}
+                    onMouseUp={zoom.dragEnd}
+                    onMouseMove={(e) => {
+                        if (!isDraggingNode) {
+                            zoom.dragMove(e);
+                        }
+                    }}
+                    onTouchStart={zoom.dragStart}
+                    onTouchMove={(e) => {
+                        if (!isDraggingNode) {
+                            zoom.dragMove(e);
+                        }
+                    }}
+                    onTouchEnd={zoom.dragEnd}
+                    isDragging={zoom.isDragging}
+                >
+                    <defs>
+                        <marker
+                            id="triangle-downstream"
+                            viewBox="0 0 10 10"
+                            refX="10"
+                            refY="5"
+                            markerUnits="strokeWidth"
+                            markerWidth="10"
+                            markerHeight="10"
+                            orient="auto"
+                        >
+                            <path d="M 0 0 L 10 5 L 0 10 z" fill="#BFBFBF" />
+                        </marker>
+                        <marker
+                            id="triangle-upstream"
+                            viewBox="0 0 10 10"
+                            refX="0"
+                            refY="5"
+                            markerUnits="strokeWidth"
+                            markerWidth="10"
+                            markerHeight="10"
+                            orient="auto"
+                        >
+                            <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#BFBFBF" />
+                        </marker>
+                        <marker
+                            id="triangle-downstream-highlighted"
+                            viewBox="0 0 10 10"
+                            refX="10"
+                            refY="5"
+                            markerUnits="strokeWidth"
+                            markerWidth="10"
+                            markerHeight="10"
+                            orient="auto"
+                        >
+                            <path d="M 0 0 L 10 5 L 0 10 z" fill="#1890FF" />
+                        </marker>
+                        <marker
+                            id="triangle-upstream-highlighted"
+                            viewBox="0 0 10 10"
+                            refX="0"
+                            refY="5"
+                            markerUnits="strokeWidth"
+                            markerWidth="10"
+                            markerHeight="10"
+                            orient="auto"
+                        >
+                            <path d="M 0 5 L 10 10 L 10 0 L 0 5 z" fill="#1890FF" />
+                        </marker>
+                        <linearGradient id="gradient-Downstream" x1="1" x2="0" y1="0" y2="0">
+                            <stop offset="0%" stopColor="#1890FF" />
+                            <stop offset="100%" stopColor="#1890FF" stopOpacity="0" />
+                        </linearGradient>
+                        <linearGradient id="gradient-Upstream" x1="0" x2="1" y1="0" y2="0">
+                            <stop offset="0%" stopColor="#1890FF" />
+                            <stop offset="100%" stopColor="#1890FF" stopOpacity="0" />
+                        </linearGradient>
+                        <filter id="shadow1">
+                            <feDropShadow
+                                dx="0"
+                                dy="0"
+                                stdDeviation="4"
+                                floodColor="rgba(72, 106, 108, 0.15)"
+                                floodOpacity="1"
+                            />
+                        </filter>
+                        <filter id="shadow1-selected">
+                            <feDropShadow
+                                dx="0"
+                                dy="0"
+                                stdDeviation="6"
+                                floodColor="rgba(24, 144, 255, .15)"
+                                floodOpacity="1"
+                            />
+                        </filter>
+                    </defs>
+                    <rect width={width} height={height} fill="#fafafa" />
+                    <LineageTree
+                        data={upstreamData}
+                        zoom={zoom}
+                        onEntityClick={onEntityClick}
+                        onEntityCenter={onEntityCenter}
+                        onLineageExpand={onLineageExpand}
+                        margin={margin}
+                        selectedEntity={selectedEntity}
+                        hoveredEntity={hoveredEntity}
+                        setHoveredEntity={setHoveredEntity}
+                        direction={Direction.Upstream}
+                        canvasHeight={height}
+                        setIsDraggingNode={setIsDraggingNode}
+                        draggedNodes={draggedNodes}
+                        setDraggedNodes={setDraggedNodes}
+                    />
+                    <LineageTree
+                        data={downstreamData}
+                        zoom={zoom}
+                        onEntityClick={onEntityClick}
+                        onEntityCenter={onEntityCenter}
+                        onLineageExpand={onLineageExpand}
+                        margin={margin}
+                        selectedEntity={selectedEntity}
+                        hoveredEntity={hoveredEntity}
+                        setHoveredEntity={setHoveredEntity}
+                        direction={Direction.Downstream}
+                        canvasHeight={height}
+                        setIsDraggingNode={setIsDraggingNode}
+                        draggedNodes={draggedNodes}
+                        setDraggedNodes={setDraggedNodes}
+                    />
+                </RootSvg>
+            </ZoomContainer>
+        </LineageExplorerContext.Provider>
     );
 }

--- a/datahub-web-react/src/app/lineage/constants.ts
+++ b/datahub-web-react/src/app/lineage/constants.ts
@@ -3,7 +3,7 @@ export const FORWARD_RELATIONSHIPS = ['DownstreamOf', 'Consumes', 'Contains', 'T
 // these relationships trigger a link where the source is to the left of the sink
 export const INVERSE_RELATIONSHIPS = ['Produces', 'MemberOf'];
 
-export const VERTICAL_SPACE_PER_NODE = 120;
 export const HORIZONTAL_SPACE_PER_LAYER = 400;
+export const VERTICAL_SPACE_BETWEEN_NODES = 40;
 
 export const CURVE_PADDING = 75;

--- a/datahub-web-react/src/app/lineage/utils/LineageExplorerContext.tsx
+++ b/datahub-web-react/src/app/lineage/utils/LineageExplorerContext.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export const LineageExplorerContext = React.createContext<LineageExplorerContextType>({
+    expandTitles: false,
+});
+
+type LineageExplorerContextType = {
+    expandTitles: boolean;
+};

--- a/datahub-web-react/src/app/lineage/utils/layoutTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/layoutTree.ts
@@ -1,4 +1,5 @@
 import { CURVE_PADDING, HORIZONTAL_SPACE_PER_LAYER, VERTICAL_SPACE_BETWEEN_NODES } from '../constants';
+import { width as nodeWidth } from '../LineageEntityNode';
 import { Direction, NodeData, VizEdge, VizNode } from '../types';
 import { nodeHeightFromTitleLength } from './nodeHeightFromTitleLength';
 
@@ -7,7 +8,6 @@ type ProcessArray = {
     node: NodeData;
 }[];
 
-const nodeWidth = 212;
 const INSIDE_NODE_SHIFT = nodeWidth / 2 - 19;
 
 const HEADER_HEIGHT = 125;
@@ -25,7 +25,6 @@ export default function layoutTree(
     height: number;
     layers: number;
 } {
-    console.log('expandTitles', expandTitles);
     const nodesToRender: VizNode[] = [];
     const edgesToRender: VizEdge[] = [];
     let maxHeight = 0;

--- a/datahub-web-react/src/app/lineage/utils/layoutTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/layoutTree.ts
@@ -43,7 +43,14 @@ export default function layoutTree(
             .filter((urn) => !nodesByUrn[urn || '']);
 
         const layerSize = nodesToAddInCurrentLayer.length;
-        const layerHeight = VERTICAL_SPACE_PER_NODE * (layerSize - 1);
+
+        const layerHeight = nodesInCurrentLayer
+            .filter(({ node }) => nodesToAddInCurrentLayer.indexOf(node.urn || '') > -1)
+            // TODO
+            .map(({ node }) => node.name.length)
+            .reduce((acc, len) => acc + len, 0);
+
+        // const layerHeight = VERTICAL_SPACE_PER_NODE * (layerSize - 1);
 
         maxHeight = Math.max(maxHeight, layerHeight);
 

--- a/datahub-web-react/src/app/lineage/utils/layoutTree.ts
+++ b/datahub-web-react/src/app/lineage/utils/layoutTree.ts
@@ -48,13 +48,12 @@ export default function layoutTree(
 
         const layerHeight = nodesInCurrentLayer
             .filter(({ node }) => nodesToAddInCurrentLayer.indexOf(node.urn || '') > -1)
-            // TODO
             .map(({ node }) => nodeHeightFromTitleLength(expandTitles ? node.name : undefined))
             .reduce((acc, height) => acc + height, 0);
 
         maxHeight = Math.max(maxHeight, layerHeight);
 
-        // approximate the starting position assuming each node has 1 line (its ok to be a bit off here)
+        // approximate the starting position assuming each node has a 1 line title (its ok to be a bit off here)
         let currentXPosition =
             -((nodeHeightFromTitleLength(undefined) + VERTICAL_SPACE_BETWEEN_NODES) * (layerSize - 1)) / 2 +
             canvasHeight / 2 +

--- a/datahub-web-react/src/app/lineage/utils/nodeHeightFromTitleLength.ts
+++ b/datahub-web-react/src/app/lineage/utils/nodeHeightFromTitleLength.ts
@@ -1,6 +1,4 @@
-import { VERTICAL_SPACE_PER_NODE } from '../constants';
-
-export interface OptionalOptions {
+interface OptionalOptions {
     font?: string;
     fontSize?: string;
     fontWeight?: string;
@@ -18,10 +16,13 @@ interface Options {
     wordBreak: string;
 }
 
-export interface Size {
+interface Size {
     width: number;
     height: number;
 }
+
+const HEIGHT_WITHOUT_TEXT_HEIGHT = 66;
+const DEFAULT_TEXT_TO_GET_NON_ZERO_HEIGHT = 'a';
 
 function createDummyElement(text: string, options: Options): HTMLElement {
     const element = document.createElement('div');
@@ -82,6 +83,6 @@ const calcualteSize = (text: string, options: OptionalOptions = {}): Size => {
     return size;
 };
 
-export function nodeHeightFromTitleLength(title: string) {
-    return Math.floor(calcualteSize(title).height) + VERTICAL_SPACE_PER_NODE - 14;
+export function nodeHeightFromTitleLength(title?: string) {
+    return Math.floor(calcualteSize(title || DEFAULT_TEXT_TO_GET_NON_ZERO_HEIGHT).height) + HEIGHT_WITHOUT_TEXT_HEIGHT;
 }

--- a/datahub-web-react/src/app/lineage/utils/nodeHeightFromTitleLength.ts
+++ b/datahub-web-react/src/app/lineage/utils/nodeHeightFromTitleLength.ts
@@ -1,0 +1,87 @@
+import { VERTICAL_SPACE_PER_NODE } from '../constants';
+
+export interface OptionalOptions {
+    font?: string;
+    fontSize?: string;
+    fontWeight?: string;
+    lineHeight?: string;
+    width?: string;
+    wordBreak?: string;
+}
+
+interface Options {
+    font: string;
+    fontSize: string;
+    fontWeight: string;
+    lineHeight: string;
+    width: string;
+    wordBreak: string;
+}
+
+export interface Size {
+    width: number;
+    height: number;
+}
+
+function createDummyElement(text: string, options: Options): HTMLElement {
+    const element = document.createElement('div');
+    const textNode = document.createTextNode(text);
+
+    element.appendChild(textNode);
+
+    element.style.fontFamily = options.font;
+    element.style.fontSize = options.fontSize;
+    element.style.fontWeight = options.fontWeight;
+    element.style.lineHeight = options.lineHeight;
+    element.style.position = 'absolute';
+    element.style.visibility = 'hidden';
+    element.style.left = '-999px';
+    element.style.top = '-999px';
+    element.style.width = options.width;
+    element.style.height = 'auto';
+    element.style.wordBreak = options.wordBreak;
+
+    document.body.appendChild(element);
+
+    return element;
+}
+
+function destroyElement(element: HTMLElement): void {
+    element?.parentNode?.removeChild(element);
+}
+
+const cache = {};
+
+const calcualteSize = (text: string, options: OptionalOptions = {}): Size => {
+    const cacheKey = JSON.stringify({ text, options });
+
+    if (cache[cacheKey]) {
+        return cache[cacheKey];
+    }
+
+    // prepare options
+    const finalOptions: OptionalOptions = {};
+    finalOptions.font = options.font || 'Manrope';
+    finalOptions.fontSize = options.fontSize || '14px';
+    finalOptions.fontWeight = options.fontWeight || 'normal';
+    finalOptions.lineHeight = options.lineHeight || 'normal';
+    finalOptions.width = options.width || '125px';
+    finalOptions.wordBreak = options.wordBreak || 'break-all';
+
+    const element = createDummyElement(text, finalOptions as Options);
+
+    const size = {
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+    };
+
+    destroyElement(element);
+
+    cache[cacheKey] = size;
+
+    return size;
+};
+
+export function nodeHeightFromTitleLength(title: string) {
+    return Math.floor(calcualteSize(title).height) + VERTICAL_SPACE_PER_NODE - 14;
+}


### PR DESCRIPTION
Adds a toggle in the bottom right corner to expand/contract entity titles. Also adds a fix for the lineage sidepanel to have long titles break onto the next line

![image](https://user-images.githubusercontent.com/2455694/148620940-8771f422-2578-44b8-8db7-2db3d65457be.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
