### PR TITLE
feat(git-version): Add version to the UI and config endpoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,10 @@ out
 **/*.class
 # Have to copy gradle/wrapper/gradle-wrapper.jar, can't exclude ALL jars
 **/build/**/*.jar
-.git
+# Content in .git is used to get the git version
+# Just ignore the heavy parts that are not used
+#.git/objects
+.git/logs
+.git/COMMIT_*
+.git/index
 .gradle

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@ out
 **/build/**/*.jar
 # Content in .git is used to get the git version
 # Just ignore the heavy parts that are not used
-#.git/objects
 .git/logs
 .git/COMMIT_*
 .git/index

--- a/.github/workflows/docker-datahub-upgrade.yml
+++ b/.github/workflows/docker-datahub-upgrade.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/datahub-upgrade/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-datahub-upgrade.yml
+++ b/.github/workflows/docker-datahub-upgrade.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/elasticsearch-setup/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-elasticsearch-setup.yml
+++ b/.github/workflows/docker-elasticsearch-setup.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-feast-source.yml
+++ b/.github/workflows/docker-feast-source.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/datahub-frontend/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-frontend-react.yml
+++ b/.github/workflows/docker-frontend-react.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/datahub-gms/Dockerfile
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/docker-gms.yml
+++ b/.github/workflows/docker-gms.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-ingestion.yml
+++ b/.github/workflows/docker-ingestion.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/datahub-ingestion/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-ingestion.yml
+++ b/.github/workflows/docker-ingestion.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-kafka-setup.yml
+++ b/.github/workflows/docker-kafka-setup.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-kafka-setup.yml
+++ b/.github/workflows/docker-kafka-setup.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/kafka-setup/Dockerfile
           platforms: linux/amd64,linux/arm64
           context: ./docker/kafka-setup

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/datahub-mae-consumer/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-mae-consumer.yml
+++ b/.github/workflows/docker-mae-consumer.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-mce-consumer.yml
+++ b/.github/workflows/docker-mce-consumer.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/datahub-mce-consumer/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-mysql-setup.yml
+++ b/.github/workflows/docker-mysql-setup.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-mysql-setup.yml
+++ b/.github/workflows/docker-mysql-setup.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/mysql-setup/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/.github/workflows/docker-postgres-setup.yml
+++ b/.github/workflows/docker-postgres-setup.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1

--- a/.github/workflows/docker-postgres-setup.yml
+++ b/.github/workflows/docker-postgres-setup.yml
@@ -68,6 +68,7 @@ jobs:
       - name: Build and Push image
         uses: docker/build-push-action@v2
         with:
+          context: .
           file: ./docker/postgres-setup/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           push: ${{ needs.setup.outputs.publish == 'true' }}

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
   }
 }
 
+plugins {
+  id 'com.gorylenko.gradle-git-properties' version '2.4.0-rc2'
+}
+
 project.ext.spec = [
     'product' : [
         'pegasus' : [
@@ -137,10 +141,19 @@ allprojects {
 
 subprojects {
   apply plugin: 'maven'
+  apply plugin: 'com.gorylenko.gradle-git-properties'
 
   configurations.all {
     exclude group: "io.netty", module: "netty"
     exclude group: "log4j", module: "log4j"
+  }
+
+  gitProperties {
+    keys = ['git.commit.id','git.commit.id.describe','git.commit.time']
+    // using any tags (not limited to annotated tags) for "git.commit.id.describe" property
+    // see http://ajoberstar.org/grgit/grgit-describe.html for more info about the describe method and available parameters
+    // 'it' is an instance of org.ajoberstar.grgit.Grgit
+    customProperty 'git.commit.id.describe', { it.describe(tags: true) }
   }
 
   plugins.withType(JavaPlugin) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -114,6 +114,7 @@ import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationsService;
 import com.linkedin.metadata.graph.GraphClient;
+import com.linkedin.metadata.version.GitVersion;
 import com.linkedin.usage.UsageClient;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.idl.RuntimeWiring;
@@ -153,6 +154,7 @@ public class GmsGraphQLEngine {
     private final RecommendationsService recommendationsService;
     private final EntityRegistry entityRegistry;
     private final TokenService tokenService;
+    private final GitVersion gitVersion;
 
     private final DatasetType datasetType;
     private final CorpUserType corpUserType;
@@ -207,6 +209,7 @@ public class GmsGraphQLEngine {
             null,
             null,
             null,
+            null,
             null);
     }
 
@@ -218,7 +221,8 @@ public class GmsGraphQLEngine {
         final EntityService entityService,
         final RecommendationsService recommendationsService,
         final TokenService tokenService,
-        final EntityRegistry entityRegistry
+        final EntityRegistry entityRegistry,
+        final GitVersion gitVersion
         ) {
 
         this.entityClient = entityClient;
@@ -230,6 +234,7 @@ public class GmsGraphQLEngine {
         this.recommendationsService = recommendationsService;
         this.tokenService = tokenService;
         this.entityRegistry = entityRegistry;
+        this.gitVersion = gitVersion;
 
         this.datasetType = new DatasetType(entityClient);
         this.corpUserType = new CorpUserType(entityClient);
@@ -398,7 +403,7 @@ public class GmsGraphQLEngine {
     private void configureQueryResolvers(final RuntimeWiring.Builder builder) {
         builder.type("Query", typeWiring -> typeWiring
             .dataFetcher("appConfig",
-                new AppConfigResolver(analyticsService != null))
+                new AppConfigResolver(gitVersion, analyticsService != null))
             .dataFetcher("me", new AuthenticatedResolver<>(
                     new MeResolver(this.entityClient)))
             .dataFetcher("search", new AuthenticatedResolver<>(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -9,6 +9,7 @@ import com.linkedin.datahub.graphql.generated.IdentityManagementConfig;
 import com.linkedin.datahub.graphql.generated.PoliciesConfig;
 import com.linkedin.datahub.graphql.generated.Privilege;
 import com.linkedin.datahub.graphql.generated.ResourcePrivileges;
+import com.linkedin.metadata.version.GitVersion;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import java.util.concurrent.CompletableFuture;
@@ -20,9 +21,11 @@ import java.util.stream.Collectors;
  */
 public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfig>> {
 
-  private final Boolean _isAnalyticsEnabled;
+  private final GitVersion _gitVersion;
+  private final boolean _isAnalyticsEnabled;
 
-  public AppConfigResolver(final Boolean isAnalyticsEnabled) {
+  public AppConfigResolver(final GitVersion gitVersion, final boolean isAnalyticsEnabled) {
+    _gitVersion = gitVersion;
     _isAnalyticsEnabled = isAnalyticsEnabled;
   }
 
@@ -32,6 +35,8 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
     final QueryContext context = environment.getContext();
 
     final AppConfig appConfig = new AppConfig();
+
+    appConfig.setAppVersion(_gitVersion.getVersion());
 
     final AnalyticsConfig analyticsConfig = new AnalyticsConfig();
     analyticsConfig.setEnabled(_isAnalyticsEnabled);

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -59,6 +59,11 @@ This configuration dictates the behavior of the UI, such as which features are e
 """
 type AppConfig {
   """
+  App version
+  """
+  appVersion: String
+
+  """
   Configurations related to the Analytics Feature
   """
   analyticsConfig: AnalyticsConfig!

--- a/datahub-web-react/src/app/shared/ManageAccount.tsx
+++ b/datahub-web-react/src/app/shared/ManageAccount.tsx
@@ -11,6 +11,7 @@ import { isLoggedInVar } from '../auth/checkAuthStatus';
 import CustomAvatar from './avatar/CustomAvatar';
 import analytics, { EventType } from '../analytics';
 import { ANTD_GRAY } from '../entity/shared/constants';
+import { useAppConfig } from '../useAppConfig';
 
 const MenuItem = styled(Menu.Item)`
     && {
@@ -44,14 +45,16 @@ const defaultProps = {
 export const ManageAccount = ({ urn: _urn, pictureLink: _pictureLink, name }: Props) => {
     const entityRegistry = useEntityRegistry();
     const themeConfig = useTheme();
+    const { config } = useAppConfig();
     const handleLogout = () => {
         analytics.event({ type: EventType.LogOutEvent });
         isLoggedInVar(false);
         Cookies.remove(GlobalCfg.CLIENT_AUTH_COOKIE);
     };
-
+    const version = config?.appVersion;
     const menu = (
         <Menu>
+            {version && <MenuItem key="version">{version}</MenuItem>}
             {themeConfig.content.menu.items.map((value) => {
                 return (
                     <MenuItem key={value.label}>

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -1,5 +1,6 @@
 query appConfig {
     appConfig {
+        appVersion
         policiesConfig {
             enabled
             platformPrivileges {

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -29,9 +29,6 @@ RUN apk --no-cache --update-cache --available upgrade \
     && apk --no-cache add openjdk8 perl
 
 COPY . /datahub-src
-RUN ls -l /datahub-src
-RUN cat /datahub-src/.dockerignore
-RUN ls -l /datahub-src/.git
 RUN cd /datahub-src && ./gradlew :metadata-service:war:build -x test
 RUN cp /datahub-src/metadata-service/war/build/libs/war.war /war.war
 

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -29,6 +29,8 @@ RUN apk --no-cache --update-cache --available upgrade \
     && apk --no-cache add openjdk8 perl
 
 COPY . /datahub-src
+RUN ls -l
+RUN ls -l .git
 RUN cd /datahub-src && ./gradlew :metadata-service:war:build -x test
 RUN cp /datahub-src/metadata-service/war/build/libs/war.war /war.war
 

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -29,8 +29,9 @@ RUN apk --no-cache --update-cache --available upgrade \
     && apk --no-cache add openjdk8 perl
 
 COPY . /datahub-src
-RUN ls -l
-RUN ls -l .git
+RUN ls -l /datahub-src
+RUN cat /datahub-src/.dockerignore
+RUN ls -l /datahub-src/.git
 RUN cd /datahub-src && ./gradlew :metadata-service:war:build -x test
 RUN cp /datahub-src/metadata-service/war/build/libs/war.war /war.war
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/version/GitVersion.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/version/GitVersion.java
@@ -1,0 +1,18 @@
+package com.linkedin.metadata.version;
+
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.Value;
+
+
+@Value
+public class GitVersion {
+  String version;
+  String commitId;
+  Optional<String> flag;
+
+  public static GitVersion getVersion(@Nonnull String commitId, @Nonnull String commitDescribe) {
+    String version = commitDescribe.split("-")[0];
+    return new GitVersion(version, commitId, Optional.empty());
+  }
+}

--- a/metadata-io/src/main/java/com/linkedin/metadata/version/GitVersion.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/version/GitVersion.java
@@ -1,5 +1,7 @@
 package com.linkedin.metadata.version;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import lombok.Value;
@@ -14,5 +16,9 @@ public class GitVersion {
   public static GitVersion getVersion(@Nonnull String commitId, @Nonnull String commitDescribe) {
     String version = commitDescribe.split("-")[0];
     return new GitVersion(version, commitId, Optional.empty());
+  }
+
+  public Map<String, Object> toConfig() {
+    return ImmutableMap.of("version", version, "commit", commitId);
   }
 }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MclConsumerConfig.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MclConsumerConfig.java
@@ -1,20 +1,31 @@
 package com.linkedin.metadata.kafka;
 
+import com.linkedin.gms.factory.common.GitVersionFactory;
+import com.linkedin.metadata.version.GitVersion;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-@Controller
-public class MclConsumerConfig {
-    Map<String, String> config = new HashMap<String, String>() {{
-        put("noCode", "true");
-    }};
 
-    @GetMapping("/config")
-    @ResponseBody
-    public Map<String, String> sayHello() {
-      return config;
-    }
+@Controller
+@Import(GitVersionFactory.class)
+public class MclConsumerConfig {
+  private final Map<String, String> config;
+
+  public MclConsumerConfig(GitVersion gitVersion) {
+    config = new HashMap<>();
+    config.put("noCode", "true");
+
+    config.put("version", gitVersion.getVersion());
+    config.put("commit", gitVersion.getCommitId());
+  }
+
+  @GetMapping("/config")
+  @ResponseBody
+  public Map<String, String> getConfig() {
+    return config;
+  }
 }

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MclConsumerConfig.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MclConsumerConfig.java
@@ -19,7 +19,7 @@ public class MclConsumerConfig {
   private final Map<String, Object> config;
   private final String configJson;
 
-  private static ObjectMapper OBJECT_MAPPER =
+  private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
   public MclConsumerConfig(GitVersion gitVersion) throws JsonProcessingException {

--- a/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MclConsumerConfig.java
+++ b/metadata-jobs/mae-consumer/src/main/java/com/linkedin/metadata/kafka/MclConsumerConfig.java
@@ -1,5 +1,8 @@
 package com.linkedin.metadata.kafka;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.gms.factory.common.GitVersionFactory;
 import com.linkedin.metadata.version.GitVersion;
 import java.util.HashMap;
@@ -13,19 +16,25 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 @Import(GitVersionFactory.class)
 public class MclConsumerConfig {
-  private final Map<String, String> config;
+  private final Map<String, Object> config;
+  private final String configJson;
 
-  public MclConsumerConfig(GitVersion gitVersion) {
+  private static ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+  public MclConsumerConfig(GitVersion gitVersion) throws JsonProcessingException {
     config = new HashMap<>();
     config.put("noCode", "true");
 
-    config.put("version", gitVersion.getVersion());
-    config.put("commit", gitVersion.getCommitId());
+    Map<String, Object> versionConfig = new HashMap<>();
+    versionConfig.put("linkedin/datahub", gitVersion.toConfig());
+    config.put("versions", versionConfig);
+    configJson = OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(config);
   }
 
   @GetMapping("/config")
   @ResponseBody
-  public Map<String, String> getConfig() {
-    return config;
+  public String getConfig() {
+    return configJson;
   }
 }

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MceConsumerConfig.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/MceConsumerConfig.java
@@ -1,0 +1,31 @@
+package com.linkedin.metadata.kafka;
+
+import com.linkedin.gms.factory.common.GitVersionFactory;
+import com.linkedin.metadata.version.GitVersion;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+
+@Controller
+@Import(GitVersionFactory.class)
+public class MceConsumerConfig {
+  private final Map<String, String> config;
+
+  public MceConsumerConfig(GitVersion gitVersion) {
+    config = new HashMap<>();
+    config.put("noCode", "true");
+
+    config.put("version", gitVersion.getVersion());
+    config.put("commit", gitVersion.getCommitId());
+  }
+
+  @GetMapping("/config")
+  @ResponseBody
+  public Map<String, String> getConfig() {
+    return config;
+  }
+}

--- a/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/McpConsumerConfig.java
+++ b/metadata-jobs/mce-consumer/src/main/java/com/linkedin/metadata/kafka/McpConsumerConfig.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
 @Import(GitVersionFactory.class)
-public class MceConsumerConfig {
+public class McpConsumerConfig {
   private final Map<String, Object> config;
   private final String configJson;
 
-  private static ObjectMapper OBJECT_MAPPER =
+  private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-  public MceConsumerConfig(GitVersion gitVersion) throws JsonProcessingException {
+  public McpConsumerConfig(GitVersion gitVersion) throws JsonProcessingException {
     config = new HashMap<>();
     config.put("noCode", "true");
 

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/GitVersionFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/common/GitVersionFactory.java
@@ -1,0 +1,25 @@
+package com.linkedin.gms.factory.common;
+
+import com.linkedin.metadata.version.GitVersion;
+import javax.annotation.Nonnull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+
+@Configuration
+@PropertySource("classpath:git.properties")
+public class GitVersionFactory {
+  @Value("${git.commit.id}")
+  private String commitId;
+
+  @Value("${git.commit.id.describe}")
+  private String commitDescribe;
+
+  @Nonnull
+  @Bean(name = "gitVersion")
+  protected GitVersion getInstance() {
+    return GitVersion.getVersion(commitId, commitDescribe);
+  }
+}

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -1,22 +1,23 @@
 package com.linkedin.gms.factory.graphql;
 
 import com.datahub.authentication.token.TokenService;
-
 import com.linkedin.datahub.graphql.GmsGraphQLEngine;
 import com.linkedin.datahub.graphql.GraphQLEngine;
 import com.linkedin.datahub.graphql.analytics.service.AnalyticsService;
 import com.linkedin.entity.client.JavaEntityClient;
 import com.linkedin.gms.factory.auth.DataHubTokenServiceFactory;
+import com.linkedin.gms.factory.common.GitVersionFactory;
 import com.linkedin.gms.factory.common.IndexConventionFactory;
 import com.linkedin.gms.factory.common.RestHighLevelClientFactory;
-import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.gms.factory.entity.RestliEntityClientFactory;
+import com.linkedin.gms.factory.entityregistry.EntityRegistryFactory;
 import com.linkedin.gms.factory.recommendation.RecommendationServiceFactory;
 import com.linkedin.metadata.entity.EntityService;
+import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.recommendation.RecommendationsService;
-import com.linkedin.metadata.graph.GraphClient;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
+import com.linkedin.metadata.version.GitVersion;
 import com.linkedin.usage.UsageClient;
 import javax.annotation.Nonnull;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -29,14 +30,9 @@ import org.springframework.context.annotation.Import;
 
 
 @Configuration
-@Import({
-    RestHighLevelClientFactory.class,
-    IndexConventionFactory.class,
-    RestliEntityClientFactory.class,
-    RecommendationServiceFactory.class,
-    EntityRegistryFactory.class,
-    DataHubTokenServiceFactory.class
-})
+@Import({RestHighLevelClientFactory.class, IndexConventionFactory.class, RestliEntityClientFactory.class,
+    RecommendationServiceFactory.class, EntityRegistryFactory.class, DataHubTokenServiceFactory.class,
+    GitVersionFactory.class})
 public class GraphQLEngineFactory {
   @Autowired
   @Qualifier("elasticSearchRestHighLevelClient")
@@ -73,6 +69,10 @@ public class GraphQLEngineFactory {
   @Qualifier("entityRegistry")
   private EntityRegistry _entityRegistry;
 
+  @Autowired
+  @Qualifier("gitVersion")
+  private GitVersion _gitVersion;
+
   @Value("${platformAnalytics.enabled}") // TODO: Migrate to DATAHUB_ANALYTICS_ENABLED
   private Boolean isAnalyticsEnabled;
 
@@ -80,24 +80,11 @@ public class GraphQLEngineFactory {
   @Nonnull
   protected GraphQLEngine getInstance() {
     if (isAnalyticsEnabled) {
-      return new GmsGraphQLEngine(
-          _entityClient,
-          _graphClient,
-          _usageClient,
-          new AnalyticsService(elasticClient, indexConvention.getPrefix()),
-          _entityService,
-          _recommendationsService,
-          _tokenService,
-          _entityRegistry).builder().build();
+      return new GmsGraphQLEngine(_entityClient, _graphClient, _usageClient,
+          new AnalyticsService(elasticClient, indexConvention.getPrefix()), _entityService, _recommendationsService,
+          _tokenService, _entityRegistry, _gitVersion).builder().build();
     }
-    return new GmsGraphQLEngine(
-        _entityClient,
-        _graphClient,
-        _usageClient,
-        null,
-        _entityService,
-        _recommendationsService,
-        _tokenService,
-        _entityRegistry).builder().build();
+    return new GmsGraphQLEngine(_entityClient, _graphClient, _usageClient, null, _entityService,
+        _recommendationsService, _tokenService, _entityRegistry, _gitVersion).builder().build();
   }
 }

--- a/metadata-service/servlet/build.gradle
+++ b/metadata-service/servlet/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'java'
 
 dependencies {
+  compile project(':metadata-io')
   compile externalDependency.httpClient
   compile externalDependency.servletApi
   compile externalDependency.gson

--- a/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
+++ b/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
@@ -59,8 +59,9 @@ public class Config extends HttpServlet {
     config.put("noCode", "true");
 
     GitVersion version = getGitVersion(req.getServletContext());
-    config.put("version", version.getVersion());
-    config.put("commit", version.getCommitId());
+    Map<String, Object> versionConfig = new HashMap<>();
+    versionConfig.put("linkedin/datahub", version.toConfig());
+    config.put("versions", versionConfig);
 
     resp.setContentType("application/json");
     PrintWriter out = resp.getWriter();

--- a/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
+++ b/metadata-service/servlet/src/main/java/com/datahub/gms/servlet/Config.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.models.registry.PluginEntityRegistryLoader;
 import com.linkedin.metadata.models.registry.config.EntityRegistryLoadResult;
+import com.linkedin.metadata.version.GitVersion;
 import com.linkedin.util.Pair;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -22,6 +23,7 @@ import org.springframework.web.context.support.WebApplicationContextUtils;
 // Return a 200 for health checks
 
 public class Config extends HttpServlet {
+
   Map<String, Object> config = new HashMap<String, Object>() {{
     put("noCode", "true");
     put("retention", "true");
@@ -47,8 +49,19 @@ public class Config extends HttpServlet {
     return patchDiagnostics;
   }
 
+  private GitVersion getGitVersion(ServletContext servletContext) {
+    WebApplicationContext ctx = WebApplicationContextUtils.getRequiredWebApplicationContext(servletContext);
+    return (GitVersion) ctx.getBean("gitVersion");
+  }
+
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+    config.put("noCode", "true");
+
+    GitVersion version = getGitVersion(req.getServletContext());
+    config.put("version", version.getVersion());
+    config.put("commit", version.getCommitId());
+
     resp.setContentType("application/json");
     PrintWriter out = resp.getWriter();
 


### PR DESCRIPTION
Add version to the UI and config endpoint by
1: Add git properties plugin to all java based gradle tasks that generates a git.properties file with the commit hash and other necessary information (latest tag for the given commit)
2: Add GitVersionFactory that fetches the commit hash and version from the git.properties
3: Add the version info to the config endpoint

Also modified all github actions that checkout code to build image to fetch all history (otherwise git describe does not work)
```
curl http://localhost:8080/config

{
  "models" : { },
  "versions" : {
    "linkedin/datahub" : {
      "version" : "v0.8.22",
      "commit" : "22acafafa4b86c1ee9623bc6023851a50829949d"
    }
  },
  "statefulIngestionCapable" : true,
  "retention" : "true",
  "noCode" : "true"
}
```
4: Add the version info in the UI
<img width="540" alt="Screen Shot 2022-01-10 at 9 35 14 PM" src="https://user-images.githubusercontent.com/896177/148887282-13b08cea-bfa8-40aa-bbb7-9b7884e18dd7.png">

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
