### PR TITLE
Add AWS MSK Iam Auth Jar to GMS 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ project.ext.externalDependency = [
     'avro_1_7': 'org.apache.avro:avro:1.7.7',
     'avroCompiler_1_7': 'org.apache.avro:avro-compiler:1.7.7',
     'awsGlueSchemaRegistrySerde': 'software.amazon.glue:schema-registry-serde:1.1.1',
+    'awsMskIamAuth': 'software.amazon.msk:aws-msk-iam-auth:1.1.1',
     'cacheApi' : 'javax.cache:cache-api:1.1.0',
     'commonsIo': 'commons-io:commons-io:2.4',
     'commonsLang': 'commons-lang:commons-lang:2.6',

--- a/docs/how/kafka-config.md
+++ b/docs/how/kafka-config.md
@@ -16,6 +16,15 @@ export SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL=SASL_PLAINTEXT
 export SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG=com.sun.security.auth.module.Krb5LoginModule required principal='principal@REALM' useKeyTab=true storeKey=true keyTab='/keytab';
 ```
 
+Here is another example of how SASL_SSL can be configured for AWS_MSK_IAM when connecting to MSK using IAM via environment variables
+```bash
+SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL=SASL_SSL
+SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/tmp/kafka.client.truststore.jks
+SPRING_KAFKA_PROPERTIES_SASL_MECHANISM=AWS_MSK_IAM
+SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG=software.amazon.msk.auth.iam.IAMLoginModule required;
+SPRING_KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS=software.amazon.msk.auth.iam.IAMClientCallbackHandler
+```
+
 These properties can be specified via `application.properties` or `application.yml` files, or as command line switches, or as environment variables. See Spring's [Externalized Configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config) to see how this works.
 
 See [Kafka Connect Security](https://docs.confluent.io/current/connect/security.html) for more ways to connect.

--- a/metadata-jobs/mae-consumer/build.gradle
+++ b/metadata-jobs/mae-consumer/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     annotationProcessor externalDependency.lombok
 
     runtime externalDependency.logbackClassic
+
+    implementation externalDependency.awsMskIamAuth
 }
 
 task avroSchemaSources(type: Copy) {

--- a/metadata-jobs/mce-consumer/build.gradle
+++ b/metadata-jobs/mce-consumer/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     annotationProcessor externalDependency.lombok
 
+    implementation externalDependency.awsMskIamAuth
 }
 
 task avroSchemaSources(type: Copy) {

--- a/metadata-service/war/build.gradle
+++ b/metadata-service/war/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 
   runtime spec.product.pegasus.restliDocgen
   runtime spec.product.pegasus.restliSpringBridge
+
+  implementation externalDependency.awsMskIamAuth
 }
 
 configurations {


### PR DESCRIPTION
## Checklist
- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

In order to use the MSK with IAM and with SASL Mechanism as `AWS_MSK_IAM` and security protocol as `SASL_SSL` AWS MSK IAM Jar should be added to the Project Dependencies.

Here are the env variables that's used in the GMS Project

```
SPRING_KAFKA_PROPERTIES_SECURITY_PROTOCOL=SASL_SSL
SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/tmp/kafka.client.truststore.jks
SPRING_KAFKA_PROPERTIES_SASL_MECHANISM=AWS_MSK_IAM
SPRING_KAFKA_PROPERTIES_SASL_JAAS_CONFIG=software.amazon.msk.auth.iam.IAMLoginModule required awsDebugCreds=true;
SPRING_KAFKA_PROPERTIES_SASL_CLIENT_CALLBACK_HANDLER_CLASS=software.amazon.msk.auth.iam.IAMClientCallbackHandler
```

AWS MSK IAM Auth Project - https://github.com/aws/aws-msk-iam-auth
Related Issue on AWS MSK IAM Project  - https://github.com/aws/aws-msk-iam-auth/issues/50
