### PR TITLE
feat(ingestion) dbt: support spark sql types

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/dbt.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/dbt.py
@@ -20,6 +20,7 @@ from datahub.ingestion.source.sql.sql_types import (
     BIGQUERY_TYPES_MAP,
     POSTGRES_TYPES_MAP,
     SNOWFLAKE_TYPES_MAP,
+    SPARK_SQL_TYPES_MAP,
     resolve_postgres_modified_type,
 )
 from datahub.metadata.com.linkedin.pegasus2avro.common import (
@@ -482,6 +483,7 @@ _field_type_mapping = {
     **POSTGRES_TYPES_MAP,
     **SNOWFLAKE_TYPES_MAP,
     **BIGQUERY_TYPES_MAP,
+    **SPARK_SQL_TYPES_MAP,
 }
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/sql_types.py
@@ -282,3 +282,29 @@ BIGQUERY_TYPES_MAP: Dict[str, Any] = {
     "BIGNUMERIC": NumberType,
     "GEOGRAPHY": None,
 }
+
+# see https://spark.apache.org/docs/latest/sql-ref-datatypes.html
+SPARK_SQL_TYPES_MAP: Dict[str, Any] = {
+    "boolean": BooleanType,
+    "byte": NumberType,
+    "tinyint": NumberType,
+    "short": NumberType,
+    "smallint": NumberType,
+    "int": NumberType,
+    "integer": NumberType,
+    "long": NumberType,
+    "bigint": NumberType,
+    "float": NumberType,
+    "real": NumberType,
+    "double": NumberType,
+    "date": DateType,
+    "timestamp": TimeType,
+    "string": StringType,
+    "binary": BytesType,
+    "decimal": NumberType,
+    "dec": NumberType,
+    "numeric": NumberType,
+    "array": ArrayType,
+    "struct": RecordType,
+    "map": RecordType,
+}


### PR DESCRIPTION
Add spark sql types to the dbt type mappings, for use with the dbt-spark adapter.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
