### PR TITLE
docs(ingestion) azure: specify required permission type

### DIFF
--- a/metadata-ingestion/source_docs/azure-ad.md
+++ b/metadata-ingestion/source_docs/azure-ad.md
@@ -72,7 +72,7 @@ This is a known limitation in our data model that is being tracked by [this tick
 ## Quickstart recipe
 
 As a prerequisite, you should [create a DataHub Application](https://docs.microsoft.com/en-us/graph/toolkit/get-started/add-aad-app-registration) within the Azure AD Portal with the permissions
-to read your organization's Users and Groups. The required API permissions include the following:
+to read your organization's Users and Groups. The following permissions are required, with the `Application` permission type:
 
 - `Group.Read.All`
 - `GroupMember.Read.All`


### PR DESCRIPTION
In retrospect it's obvious that these should be application-type permissions, but it's easily glossed over when not too familiar with the Azure AD API permissions system.

slack thread: https://datahubspace.slack.com/archives/C029A3M079U/p1636471101266200
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
