### PR TITLE
feat(authentication): propagate expired token exceptions to end user

### DIFF
--- a/metadata-service/auth-api/src/main/java/com/datahub/authentication/AuthenticationExpiredException.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authentication/AuthenticationExpiredException.java
@@ -11,6 +11,6 @@ public class AuthenticationExpiredException extends AuthenticationException {
   }
 
   public AuthenticationExpiredException(final String message, final Throwable cause) {
-    super(String.format("Failed to authenticate inbound request: %s", message), cause);
+    super(message, cause);
   }
 }

--- a/metadata-service/auth-api/src/main/java/com/datahub/authentication/AuthenticationExpiredException.java
+++ b/metadata-service/auth-api/src/main/java/com/datahub/authentication/AuthenticationExpiredException.java
@@ -1,0 +1,16 @@
+package com.datahub.authentication;
+
+/**
+ * An {@link Exception} thrown when an {@link Authenticator} is unable to be resolve an instance of
+ * {@link Authentication} for the current request.
+ */
+public class AuthenticationExpiredException extends AuthenticationException {
+
+  public AuthenticationExpiredException(final String message) {
+    this(message, null);
+  }
+
+  public AuthenticationExpiredException(final String message, final Throwable cause) {
+    super(String.format("Failed to authenticate inbound request: %s", message), cause);
+  }
+}

--- a/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
+++ b/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
@@ -1,10 +1,10 @@
 package com.datahub.authentication.filter;
 
 import com.datahub.authentication.Authentication;
+
 import com.datahub.authentication.AuthenticationConfiguration;
 import com.datahub.authentication.AuthenticationContext;
 import com.datahub.authentication.AuthenticationException;
-import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.AuthenticatorConfiguration;
 import com.datahub.authentication.authenticator.AuthenticatorChain;

--- a/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
+++ b/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
@@ -61,14 +61,11 @@ public class AuthenticationFilter implements Filter {
     Authentication authentication = null;
     try {
       authentication = this.authenticatorChain.authenticate(context);
-    } catch (AuthenticationExpiredException e) {
+    } catch (AuthenticationException e) {
       // For AuthenticationExpiredExceptions, terminate and provide that feedback to the user
       log.debug("Failed to authenticate request. Received an AuthenticationExpiredException from authenticator chain.", e);
       ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
       return;
-    } catch (AuthenticationException e) {
-      // For other AuthenticationExceptions, log & continue
-      log.debug("Failed to authenticate request. Received an AuthenticationExpiredException from authenticator chain.", e);
     }
 
     if (authentication != null) {

--- a/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
+++ b/metadata-service/auth-filter/src/main/java/com/datahub/authentication/filter/AuthenticationFilter.java
@@ -3,6 +3,8 @@ package com.datahub.authentication.filter;
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationConfiguration;
 import com.datahub.authentication.AuthenticationContext;
+import com.datahub.authentication.AuthenticationException;
+import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.AuthenticatorConfiguration;
 import com.datahub.authentication.authenticator.AuthenticatorChain;
@@ -56,7 +58,19 @@ public class AuthenticationFilter implements Filter {
       FilterChain chain)
       throws IOException, ServletException {
     AuthenticatorContext context = buildAuthContext((HttpServletRequest) request);
-    Authentication authentication = this.authenticatorChain.authenticate(context);
+    Authentication authentication = null;
+    try {
+      authentication = this.authenticatorChain.authenticate(context);
+    } catch (AuthenticationExpiredException e) {
+      // For AuthenticationExpiredExceptions, terminate and provide that feedback to the user
+      log.debug("Failed to authenticate request. Received an AuthenticationExpiredException from authenticator chain.", e);
+      ((HttpServletResponse) response).sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+      return;
+    } catch (AuthenticationException e) {
+      // For other AuthenticationExceptions, log & continue
+      log.debug("Failed to authenticate request. Received an AuthenticationExpiredException from authenticator chain.", e);
+    }
+
     if (authentication != null) {
       // Successfully authenticated.
       log.debug(String.format("Successfully authenticated request for Actor with type: %s, id: %s",

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/AuthenticatorChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/AuthenticatorChain.java
@@ -2,8 +2,10 @@ package com.datahub.authentication.authenticator;
 
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationException;
+import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.AuthenticatorContext;
+import com.datahub.authentication.token.TokenException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -39,7 +41,7 @@ public class AuthenticatorChain {
    * Returns null if {@link Authentication} cannot be resolved for the incoming request.
    */
   @Nullable
-  public Authentication authenticate(@Nonnull final AuthenticatorContext context) {
+  public Authentication authenticate(@Nonnull final AuthenticatorContext context) throws AuthenticationException {
     Objects.requireNonNull(context);
     for (final Authenticator authenticator : this.authenticators) {
       try {
@@ -49,9 +51,10 @@ public class AuthenticatorChain {
           // Authentication was successful - Short circuit
           return result;
         }
-      } catch (AuthenticationException e) {
-        // Simply log and continue if it's an AuthenticationException.
+      } catch (AuthenticationExpiredException e) {
+        // Throw if it's an AuthenticationException to propagate the error message to the end user
         log.debug(String.format("Unable to authenticate request using Authenticator %s", authenticator.getClass().getCanonicalName()), e);
+        throw e;
       } catch (Exception e) {
         // Log as a normal error otherwise.
         log.error(String.format(

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/AuthenticatorChain.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/AuthenticatorChain.java
@@ -1,11 +1,11 @@
 package com.datahub.authentication.authenticator;
 
 import com.datahub.authentication.Authentication;
+
 import com.datahub.authentication.AuthenticationException;
 import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.AuthenticatorContext;
-import com.datahub.authentication.token.TokenException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubTokenAuthenticator.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubTokenAuthenticator.java
@@ -2,10 +2,13 @@ package com.datahub.authentication.authenticator;
 
 import com.datahub.authentication.Actor;
 import com.datahub.authentication.Authentication;
+import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.AuthenticatorContext;
 import com.datahub.authentication.AuthenticationException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.token.TokenClaims;
+import com.datahub.authentication.token.TokenException;
+import com.datahub.authentication.token.TokenExpiredException;
 import com.datahub.authentication.token.TokenService;
 import javax.annotation.Nonnull;
 import java.util.Map;
@@ -66,6 +69,8 @@ public class DataHubTokenAuthenticator implements Authenticator {
           new Actor(claims.getActorType(), claims.getActorId()),
           credentials,
           claims.asMap());
+    } catch (TokenExpiredException e) {
+      throw new AuthenticationExpiredException(e.getMessage(), e);
     } catch (Exception e) {
       // Failed to validate the token
       throw new AuthenticationException("Unable to verify the provided token.", e);

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubTokenAuthenticator.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/authenticator/DataHubTokenAuthenticator.java
@@ -1,13 +1,13 @@
 package com.datahub.authentication.authenticator;
 
 import com.datahub.authentication.Actor;
+
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.AuthenticatorContext;
 import com.datahub.authentication.AuthenticationException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.token.TokenClaims;
-import com.datahub.authentication.token.TokenException;
 import com.datahub.authentication.token.TokenExpiredException;
 import com.datahub.authentication.token.TokenService;
 import javax.annotation.Nonnull;

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenExpiredException.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenExpiredException.java
@@ -1,0 +1,15 @@
+package com.datahub.authentication.token;
+
+/**
+ * A checked exception that is thrown when a DataHub-issued access token cannot be verified.
+ */
+public class TokenExpiredException extends TokenException {
+
+  public TokenExpiredException(final String message) {
+    super(message);
+  }
+
+  public TokenExpiredException(final String message, final Throwable e) {
+    super(message, e);
+  }
+}

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
@@ -29,7 +29,7 @@ import static com.datahub.authentication.token.TokenClaims.*;
  */
 public class TokenService {
 
-  private static final long DEFAULT_EXPIRES_IN_MS = 1L; // One day by default
+  private static final long DEFAULT_EXPIRES_IN_MS = 86400000L; // One day by default
   private static final List<String> SUPPORTED_ALGORITHMS = new ArrayList<>();
 
   static {
@@ -99,7 +99,7 @@ public class TokenService {
     Objects.requireNonNull(claims);
     final JwtBuilder builder = Jwts.builder()
       .addClaims(claims)
-      .setExpiration(new Date(System.currentTimeMillis() + 1))
+      .setExpiration(new Date(System.currentTimeMillis() + expiresInMs))
       .setId(UUID.randomUUID().toString())
       .setSubject(sub);
     if (this.iss != null) {

--- a/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
+++ b/metadata-service/auth-impl/src/main/java/com/datahub/authentication/token/TokenService.java
@@ -29,7 +29,7 @@ import static com.datahub.authentication.token.TokenClaims.*;
  */
 public class TokenService {
 
-  private static final long DEFAULT_EXPIRES_IN_MS = 86400000L; // One day by default
+  private static final long DEFAULT_EXPIRES_IN_MS = 1L; // One day by default
   private static final List<String> SUPPORTED_ALGORITHMS = new ArrayList<>();
 
   static {
@@ -99,7 +99,7 @@ public class TokenService {
     Objects.requireNonNull(claims);
     final JwtBuilder builder = Jwts.builder()
       .addClaims(claims)
-      .setExpiration(new Date(System.currentTimeMillis() + expiresInMs))
+      .setExpiration(new Date(System.currentTimeMillis() + 1))
       .setId(UUID.randomUUID().toString())
       .setSubject(sub);
     if (this.iss != null) {
@@ -138,6 +138,8 @@ public class TokenService {
               actorId,
               claims.getExpiration().getTime());
       }
+    } catch (io.jsonwebtoken.ExpiredJwtException e) {
+      throw new TokenExpiredException("Failed to validate DataHub token. Token has expired.", e);
     } catch (Exception e) {
       throw new TokenException("Failed to validate DataHub token", e);
     }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/authenticator/AuthenticatorChainTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/authenticator/AuthenticatorChainTest.java
@@ -1,11 +1,11 @@
 package com.datahub.authentication.authenticator;
 
 import com.datahub.authentication.Authentication;
+
 import com.datahub.authentication.AuthenticationException;
 import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.AuthenticatorContext;
-import com.datahub.authentication.token.TokenException;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/authenticator/AuthenticatorChainTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/authenticator/AuthenticatorChainTest.java
@@ -2,8 +2,10 @@ package com.datahub.authentication.authenticator;
 
 import com.datahub.authentication.Authentication;
 import com.datahub.authentication.AuthenticationException;
+import com.datahub.authentication.AuthenticationExpiredException;
 import com.datahub.authentication.Authenticator;
 import com.datahub.authentication.AuthenticatorContext;
+import com.datahub.authentication.token.TokenException;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -55,5 +57,20 @@ public class AuthenticatorChainTest {
 
     // If the authenticator throws, verify that null is returned to indicate failure to authenticate.
     assertNull(result);
+  }
+
+  @Test
+  public void testAuthenticateThrows() throws Exception {
+    final AuthenticatorChain authenticatorChain = new AuthenticatorChain();
+    final Authenticator mockAuthenticator = Mockito.mock(Authenticator.class);
+    final Authentication mockAuthentication = Mockito.mock(Authentication.class);
+    Mockito.when(mockAuthenticator.authenticate(Mockito.any())).thenThrow(new AuthenticationExpiredException("Failed to authenticate, token has expired"));
+
+    authenticatorChain.register(mockAuthenticator);
+
+    // Verify that the mock authentication is returned on Authenticate.
+    final AuthenticatorContext mockContext = Mockito.mock(AuthenticatorContext.class);
+
+    assertThrows(AuthenticationExpiredException.class, () -> authenticatorChain.authenticate(mockContext));
   }
 }

--- a/metadata-service/auth-impl/src/test/java/com/datahub/authentication/token/TokenServiceTest.java
+++ b/metadata-service/auth-impl/src/test/java/com/datahub/authentication/token/TokenServiceTest.java
@@ -79,7 +79,7 @@ public class TokenServiceTest {
     assertNotNull(token);
 
     // Validation should fail.
-    assertThrows(TokenException.class, () -> tokenService.validateAccessToken(token));
+    assertThrows(TokenExpiredException.class, () -> tokenService.validateAccessToken(token));
   }
 
   @Test


### PR DESCRIPTION
Previously, the error message for an expired token would be the same as an invalid token. This can cause confusion for an end user when a token that previously worked suddenly does not authenticate due to expiration. This pr propagates the expiration-specific warning back.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
