### PR TITLE
Adding Snappy Lib and JKS File

### DIFF
--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -20,6 +20,7 @@ RUN apk --no-cache --update-cache --available upgrade \
     && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.20.v20190813/jetty-util-9.4.20.v20190813.jar --output jetty-util.jar \
     && wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.4.1/opentelemetry-javaagent-all.jar \
     && wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar -O jmx_prometheus_javaagent.jar \
+    && cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks \
     && curl -L https://github.com/treff7es/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-${DOCKERIZE_ARCH}-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
 FROM alpine:3.14.2 AS prod-build
@@ -41,9 +42,6 @@ RUN chmod +x /datahub/datahub-gms/scripts/start.sh
 
 # Snappy Lib update
 RUN apk update && apk add --no-cache gcompat
-
-## Setup TLS JKS
-RUN cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -39,6 +39,9 @@ COPY --from=prod-build /datahub-src/docker/datahub-gms/start.sh /datahub/datahub
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-gms/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-gms/scripts/start.sh
 
+# Snappy Lib update
+RUN apk update && apk add --no-cache gcompat
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -14,7 +14,7 @@ RUN apk --no-cache --update-cache --available upgrade \
     else \
       echo >&2 "Unsupported architecture $(arch)" ; exit 1; \
     fi \
-    && apk --no-cache add tar curl openjdk8-jre bash coreutils \
+    && apk --no-cache add tar curl openjdk8-jre bash coreutils gcompat \
     && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-runner/9.4.20.v20190813/jetty-runner-9.4.20.v20190813.jar --output jetty-runner.jar \
     && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-jmx/9.4.20.v20190813/jetty-jmx-9.4.20.v20190813.jar --output jetty-jmx.jar \
     && curl https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-util/9.4.20.v20190813/jetty-util-9.4.20.v20190813.jar --output jetty-util.jar \
@@ -39,9 +39,6 @@ COPY --from=prod-build /datahub-src/metadata-models/src/main/resources/entity-re
 COPY --from=prod-build /datahub-src/docker/datahub-gms/start.sh /datahub/datahub-gms/scripts/start.sh
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-gms/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-gms/scripts/start.sh
-
-# Snappy Lib update
-RUN apk update && apk add --no-cache gcompat
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -42,6 +42,10 @@ RUN chmod +x /datahub/datahub-gms/scripts/start.sh
 # Snappy Lib update
 RUN apk update && apk add --no-cache gcompat
 
+# Setup TLS JKS
+RUN apk add openjdk11
+RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -42,9 +42,8 @@ RUN chmod +x /datahub/datahub-gms/scripts/start.sh
 # Snappy Lib update
 RUN apk update && apk add --no-cache gcompat
 
-# Setup TLS JKS
-RUN apk add openjdk11
-RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+## Setup TLS JKS
+RUN cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -22,8 +22,7 @@ COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.y
 RUN chmod +x /datahub/datahub-mae-consumer/scripts/start.sh
 
 # Setup TLS JKS
-RUN apk add openjdk11
-RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+RUN cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -24,6 +24,10 @@ RUN chmod +x /datahub/datahub-mae-consumer/scripts/start.sh
 # Snappy Lib update
 RUN apk update && apk add --no-cache gcompat
 
+# Setup TLS JKS
+RUN apk add openjdk11
+RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -21,6 +21,9 @@ COPY --from=prod-build /datahub-src/docker/datahub-mae-consumer/start.sh /datahu
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mae-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mae-consumer/scripts/start.sh
 
+# Snappy Lib update
+RUN apk update && apk add --no-cache gcompat
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -21,9 +21,6 @@ COPY --from=prod-build /datahub-src/docker/datahub-mae-consumer/start.sh /datahu
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mae-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mae-consumer/scripts/start.sh
 
-# Snappy Lib update
-RUN apk update && apk add --no-cache gcompat
-
 # Setup TLS JKS
 RUN apk add openjdk11
 RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add curl tar wget bash coreutils \
     && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
 FROM adoptopenjdk/openjdk8:alpine-slim as prod-build
-RUN apk --no-cache add perl
+RUN apk --no-cache add openjdk8-jre perl
 COPY . datahub-src
 RUN cd datahub-src && ./gradlew :metadata-jobs:mae-consumer-job:build -x test
 RUN cd datahub-src && cp metadata-jobs/mae-consumer-job/build/libs/mae-consumer-job.jar ../mae-consumer-job.jar
@@ -22,7 +22,7 @@ COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.y
 RUN chmod +x /datahub/datahub-mae-consumer/scripts/start.sh
 
 # Setup TLS JKS
-RUN cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
+COPY --from=prod-build /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -19,6 +19,9 @@ COPY --from=prod-build /datahub-src/docker/datahub-mce-consumer/start.sh /datahu
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mce-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mce-consumer/scripts/start.sh
 
+# Snappy Lib update
+RUN apk update && apk add --no-cache gcompat
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -22,6 +22,10 @@ RUN chmod +x /datahub/datahub-mce-consumer/scripts/start.sh
 # Snappy Lib update
 RUN apk update && apk add --no-cache gcompat
 
+# Setup TLS JKS
+RUN apk add openjdk11
+RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -3,7 +3,7 @@ ARG APP_ENV=prod
 
 FROM adoptopenjdk/openjdk8:alpine-jre as base
 ENV DOCKERIZE_VERSION v0.6.1
-RUN apk --no-cache add curl tar wget bash \
+RUN apk --no-cache add curl tar wget openjdk8-jre bash \
     && wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.4.1/opentelemetry-javaagent-all.jar \
     && wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar -O jmx_prometheus_javaagent.jar \
     && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -20,8 +20,7 @@ COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.y
 RUN chmod +x /datahub/datahub-mce-consumer/scripts/start.sh
 
 # Setup TLS JKS
-RUN apk add openjdk11
-RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+RUN cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -6,6 +6,7 @@ ENV DOCKERIZE_VERSION v0.6.1
 RUN apk --no-cache add curl tar wget openjdk8-jre bash \
     && wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.4.1/opentelemetry-javaagent-all.jar \
     && wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.16.1/jmx_prometheus_javaagent-0.16.1.jar -O jmx_prometheus_javaagent.jar \
+    && cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks \
     && curl -L https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | tar -C /usr/local/bin -xzv
 
 FROM openjdk:8 as prod-build
@@ -18,9 +19,6 @@ COPY --from=prod-build /mce-consumer-job.jar /datahub/datahub-mce-consumer/bin/
 COPY --from=prod-build /datahub-src/docker/datahub-mce-consumer/start.sh /datahub/datahub-mce-consumer/scripts/
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mce-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mce-consumer/scripts/start.sh
-
-# Setup TLS JKS
-RUN cp /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/cacerts /tmp/kafka.client.truststore.jks
 
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -19,9 +19,6 @@ COPY --from=prod-build /datahub-src/docker/datahub-mce-consumer/start.sh /datahu
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mce-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mce-consumer/scripts/start.sh
 
-# Snappy Lib update
-RUN apk update && apk add --no-cache gcompat
-
 # Setup TLS JKS
 RUN apk add openjdk11
 RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks


### PR DESCRIPTION
## Checklist
- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

`Issue 1`: 
Running GMS on Kubernetes cluster causes MCL Consumer thread to stop because of Snappy lib loading issue.

Here is the Error Stack:
```
[generic-mae-consumer-job-client-0-C-1] ERROR o.s.k.l.KafkaMessageListenerContainer$ListenerConsumer - Stopping container due to an Error
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.7-ab3ffedb-1d79-4f1f-8fe3-aa9f8c65c08f-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-1.1.7-ab3ffedb-1d79-4f1f-8fe3-aa9f8c65c08f-libsnappyjava.so)
```

Looks like this issue is also common - https://stackoverflow.com/questions/50288034/unsatisfiedlinkerror-tmp-snappy-1-1-4-libsnappyjava-so-error-loading-shared-li

Added `gcompat` lib to solve the issue


`Issue 2`:

As part of this [PR](https://github.com/linkedin/datahub/pull/3872) IAM Auth Jar is added to the class path and the following config
SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/tmp/kafka.client.truststore.jks
expects a jks config file to be available in the above location.

In order to make this truststore file available copying it from openjdk11 cacerts.

Making this change available for all 3 consumers (GMS/MCE/MAE)

