### PR TITLE
Adding jks

### DIFF
--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -39,6 +39,10 @@ COPY --from=prod-build /datahub-src/docker/datahub-gms/start.sh /datahub/datahub
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-gms/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-gms/scripts/start.sh
 
+# Setup TLS JKS
+RUN apk add openjdk11
+RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+
 # Snappy Lib update
 RUN apk update && apk add --no-cache gcompat
 

--- a/docker/datahub-gms/Dockerfile
+++ b/docker/datahub-gms/Dockerfile
@@ -39,6 +39,9 @@ COPY --from=prod-build /datahub-src/docker/datahub-gms/start.sh /datahub/datahub
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-gms/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-gms/scripts/start.sh
 
+# Snappy Lib update
+RUN apk update && apk add --no-cache gcompat
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-mae-consumer/Dockerfile
+++ b/docker/datahub-mae-consumer/Dockerfile
@@ -21,6 +21,10 @@ COPY --from=prod-build /datahub-src/docker/datahub-mae-consumer/start.sh /datahu
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mae-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mae-consumer/scripts/start.sh
 
+# Setup TLS JKS
+RUN apk add openjdk11
+RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134

--- a/docker/datahub-mce-consumer/Dockerfile
+++ b/docker/datahub-mce-consumer/Dockerfile
@@ -19,6 +19,10 @@ COPY --from=prod-build /datahub-src/docker/datahub-mce-consumer/start.sh /datahu
 COPY --from=prod-build /datahub-src/docker/monitoring/client-prometheus-config.yaml /datahub/datahub-mce-consumer/scripts/prometheus-config.yaml
 RUN chmod +x /datahub/datahub-mce-consumer/scripts/start.sh
 
+# Setup TLS JKS
+RUN apk add openjdk11
+RUN cp /usr/lib/jvm/java-11-openjdk/lib/security/cacerts /tmp/kafka.client.truststore.jks
+
 FROM base as dev-install
 # Dummy stage for development. Assumes code is built on your machine and mounted to this image.
 # See this excellent thread https://github.com/docker/cli/issues/1134


### PR DESCRIPTION

## Checklist
- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X ] Links to related issues (if applicable)

As part of this [PR](https://github.com/linkedin/datahub/pull/3872) IAM Auth Jar is added to the class path and the following config 
`SPRING_KAFKA_PROPERTIES_SSL_TRUSTSTORE_LOCATION=/tmp/kafka.client.truststore.jks` 
expects a jks config file to be available in the above location.

In order to make this truststore file available copying it from openjdk11 cacerts.

Making this change available for all 3 consumers (GMS/MCE/MAE)
