### PR TITLE
refactor(gql/ui): Misc refactorings

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/BrowsePathsResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/browse/BrowsePathsResolver.java
@@ -7,6 +7,7 @@ import com.linkedin.datahub.graphql.generated.EntityType;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 
+import java.util.Collections;
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,11 @@ public class BrowsePathsResolver implements DataFetcher<CompletableFuture<List<B
                     String.format("Fetch browse paths. entity type: %s, urn: %s",
                         input.getType(),
                         input.getUrn()));
-                return _typeToEntity.get(input.getType()).browsePaths(input.getUrn(), environment.getContext());
+                if (_typeToEntity.containsKey(input.getType())) {
+                    return _typeToEntity.get(input.getType()).browsePaths(input.getUrn(), environment.getContext());
+                }
+                // Browse path is impl detail.
+                return Collections.emptyList();
             } catch (Exception e) {
                 _logger.error("Failed to retrieve browse paths: "
                     + String.format("entity type %s, urn %s",

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/DescriptionUtils.java
@@ -42,7 +42,7 @@ public class DescriptionUtils {
 
       editableFieldInfo.setDescription(newDescription);
 
-      persistAspect(resourceUrn, editableSchemaMetadata, actor, entityService);
+      persistAspect(resourceUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
   }
 
   public static Boolean validateFieldDescriptionInput(

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
@@ -5,6 +5,7 @@ import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.datahub.graphql.generated.SubResourceType;
 import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.entity.EntityService;
 import com.linkedin.metadata.utils.GenericAspectUtils;
 import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.schema.EditableSchemaFieldInfo;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/MutationUtils.java
@@ -1,15 +1,12 @@
 package com.linkedin.datahub.graphql.resolvers.mutate;
 
-import com.google.common.collect.ImmutableList;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.urn.Urn;
 import com.linkedin.data.template.RecordTemplate;
-import com.linkedin.datahub.graphql.authorization.ConjunctivePrivilegeGroup;
 import com.linkedin.datahub.graphql.generated.SubResourceType;
-import com.linkedin.entity.Entity;
-import com.linkedin.metadata.authorization.PoliciesConfig;
-import com.linkedin.metadata.entity.EntityService;
-import com.linkedin.metadata.snapshot.Snapshot;
+import com.linkedin.events.metadata.ChangeType;
+import com.linkedin.metadata.utils.GenericAspectUtils;
+import com.linkedin.mxe.MetadataChangeProposal;
 import com.linkedin.schema.EditableSchemaFieldInfo;
 import com.linkedin.schema.EditableSchemaFieldInfoArray;
 import com.linkedin.schema.EditableSchemaMetadata;
@@ -22,17 +19,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MutationUtils {
   public static final String SCHEMA_ASPECT_NAME = "schemaMetadata";
-  private static final ConjunctivePrivilegeGroup ALL_PRIVILEGES_GROUP = new ConjunctivePrivilegeGroup(ImmutableList.of(
-      PoliciesConfig.EDIT_ENTITY_PRIVILEGE.getType()
-  ));
 
   private MutationUtils() { }
 
-  public static void persistAspect(Urn urn, RecordTemplate aspect, Urn actor, EntityService entityService) {
-    Snapshot updatedSnapshot = entityService.buildSnapshot(urn, aspect);
-    Entity entityToPersist = new Entity();
-    entityToPersist.setValue(updatedSnapshot);
-    entityService.ingestEntity(entityToPersist, getAuditStamp(actor));
+  public static void persistAspect(Urn urn, String aspectName, RecordTemplate aspect, Urn actor, EntityService entityService) {
+    final MetadataChangeProposal proposal = new MetadataChangeProposal();
+    proposal.setEntityUrn(urn);
+    proposal.setEntityType(urn.getEntityType());
+    proposal.setAspectName(aspectName);
+    proposal.setAspect(GenericAspectUtils.serializeAspect(aspect));
+    proposal.setChangeType(ChangeType.UPSERT);
+    entityService.ingestProposal(proposal, getAuditStamp(actor));
   }
 
   public static RecordTemplate getAspectFromEntity(String entityUrn, String aspectName, EntityService entityService, RecordTemplate defaultValue) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LabelUtils.java
@@ -55,7 +55,7 @@ public class LabelUtils {
       terms.setAuditStamp(getAuditStamp(actor));
 
       removeTermIfExists(terms, labelUrn);
-      persistAspect(targetUrn, terms, actor, entityService);
+      persistAspect(targetUrn, GLOSSARY_TERM_ASPECT_NAME, terms, actor, entityService);
     } else {
       com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
           (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
@@ -66,7 +66,7 @@ public class LabelUtils {
       }
 
       removeTermIfExists(editableFieldInfo.getGlossaryTerms(), labelUrn);
-      persistAspect(targetUrn, editableSchemaMetadata, actor, entityService);
+      persistAspect(targetUrn, GLOSSARY_TERM_ASPECT_NAME, editableSchemaMetadata, actor, entityService);
     }
   }
 
@@ -85,7 +85,7 @@ public class LabelUtils {
         tags.setTags(new TagAssociationArray());
       }
       removeTagIfExists(tags, labelUrn);
-      persistAspect(targetUrn, tags, actor, entityService);
+      persistAspect(targetUrn, TAGS_ASPECT_NAME, tags, actor, entityService);
     } else {
       com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
           (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
@@ -96,7 +96,7 @@ public class LabelUtils {
         editableFieldInfo.setGlobalTags(new GlobalTags());
       }
       removeTagIfExists(editableFieldInfo.getGlobalTags(), labelUrn);
-      persistAspect(targetUrn, editableSchemaMetadata, actor, entityService);
+      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
     }
   }
 
@@ -115,7 +115,7 @@ public class LabelUtils {
         tags.setTags(new TagAssociationArray());
       }
       addTagIfNotExists(tags, labelUrn);
-      persistAspect(targetUrn, tags, actor, entityService);
+      persistAspect(targetUrn, TAGS_ASPECT_NAME, tags, actor, entityService);
     } else {
       com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
           (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
@@ -127,7 +127,7 @@ public class LabelUtils {
       }
 
       addTagIfNotExists(editableFieldInfo.getGlobalTags(), labelUrn);
-      persistAspect(targetUrn, editableSchemaMetadata, actor, entityService);
+      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
     }
   }
 
@@ -148,7 +148,7 @@ public class LabelUtils {
       }
 
       addTermIfNotExistsToEntity(terms, labelUrn);
-      persistAspect(targetUrn, terms, actor, entityService);
+      persistAspect(targetUrn, GLOSSARY_TERM_ASPECT_NAME, terms, actor, entityService);
     } else {
       com.linkedin.schema.EditableSchemaMetadata editableSchemaMetadata =
           (com.linkedin.schema.EditableSchemaMetadata) getAspectFromEntity(
@@ -162,7 +162,7 @@ public class LabelUtils {
       editableFieldInfo.getGlossaryTerms().setAuditStamp(getAuditStamp(actor));
 
       addTermIfNotExistsToEntity(editableFieldInfo.getGlossaryTerms(), labelUrn);
-      persistAspect(targetUrn, editableSchemaMetadata, actor, entityService);
+      persistAspect(targetUrn, EDITABLE_SCHEMA_METADATA, editableSchemaMetadata, actor, entityService);
     }
   }
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/LinkUtils.java
@@ -42,7 +42,7 @@ public class LinkUtils {
         entityService,
         new InstitutionalMemory());
     addLink(institutionalMemoryAspect, linkUrl, linkLabel, actor);
-    persistAspect(resourceUrn, institutionalMemoryAspect, actor, entityService);
+    persistAspect(resourceUrn, Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME, institutionalMemoryAspect, actor, entityService);
   }
 
   public static void removeLink(
@@ -57,7 +57,7 @@ public class LinkUtils {
         entityService,
         new InstitutionalMemory());
     removeLink(institutionalMemoryAspect, linkUrl);
-    persistAspect(resourceUrn, institutionalMemoryAspect, actor, entityService);
+    persistAspect(resourceUrn, Constants.INSTITUTIONAL_MEMORY_ASPECT_NAME, institutionalMemoryAspect, actor, entityService);
   }
 
   private static void addLink(InstitutionalMemory institutionalMemoryAspect, String linkUrl, String linkLabel, Urn actor) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/mutate/util/OwnerUtils.java
@@ -44,7 +44,7 @@ public class OwnerUtils {
         entityService,
         new Ownership());
     addOwner(ownershipAspect, ownerUrn);
-    persistAspect(resourceUrn, ownershipAspect, actor, entityService);
+    persistAspect(resourceUrn, Constants.OWNERSHIP_ASPECT_NAME, ownershipAspect, actor, entityService);
   }
 
   public static void removeOwner(
@@ -60,7 +60,7 @@ public class OwnerUtils {
         new Ownership());
     ownershipAspect.setLastModified(getAuditStamp(actor));
     removeOwner(ownershipAspect, ownerUrn);
-    persistAspect(resourceUrn, ownershipAspect, actor, entityService);
+    persistAspect(resourceUrn, Constants.OWNERSHIP_ASPECT_NAME, ownershipAspect, actor, entityService);
   }
 
   private static void addOwner(Ownership ownershipAspect, Urn ownerUrn) {

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearch.tsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react';
+import * as QueryString from 'query-string';
+import { useHistory, useLocation, useParams } from 'react-router';
+import { message } from 'antd';
+import { useEntityRegistry } from '../../../../../useEntityRegistry';
+import { EntityType, FacetFilterInput } from '../../../../../../types.generated';
+import useFilters from '../../../../../search/utils/useFilters';
+import { ENTITY_FILTER_NAME } from '../../../../../search/utils/constants';
+import { useGetSearchResultsForMultipleQuery } from '../../../../../../graphql/search.generated';
+import { SearchCfg } from '../../../../../../conf';
+import { navigateToEntitySearchUrl } from './navigateToEntitySearchUrl';
+import { EmbeddedListSearchResults } from './EmbeddedListSearchResults';
+import EmbeddedListSearchHeader from './EmbeddedListSearchHeader';
+
+type SearchPageParams = {
+    type?: string;
+};
+
+type Props = {
+    emptySearchQuery?: string | null;
+    fixedFilter?: FacetFilterInput | null;
+    placeholderText?: string | null;
+};
+
+export const EmbeddedListSearch = ({ emptySearchQuery, fixedFilter, placeholderText }: Props) => {
+    const history = useHistory();
+    const location = useLocation();
+    const entityRegistry = useEntityRegistry();
+
+    const params = QueryString.parse(location.search, { arrayFormat: 'comma' });
+    const query: string = params.query ? (params.query as string) : '';
+    const activeType = entityRegistry.getTypeOrDefaultFromPathName(useParams<SearchPageParams>().type || '', undefined);
+    const page: number = params.page && Number(params.page as string) > 0 ? Number(params.page as string) : 1;
+    const filters: Array<FacetFilterInput> = useFilters(params);
+    const filtersWithoutEntities: Array<FacetFilterInput> = filters.filter(
+        (filter) => filter.field !== ENTITY_FILTER_NAME,
+    );
+    const finalFilters = (fixedFilter && [...filtersWithoutEntities, fixedFilter]) || filtersWithoutEntities;
+    const entityFilters: Array<EntityType> = filters
+        .filter((filter) => filter.field === ENTITY_FILTER_NAME)
+        .map((filter) => filter.value.toUpperCase() as EntityType);
+
+    const [showFilters, setShowFilters] = useState(false);
+
+    const { data, loading, error } = useGetSearchResultsForMultipleQuery({
+        variables: {
+            input: {
+                types: entityFilters,
+                query,
+                start: (page - 1) * SearchCfg.RESULTS_PER_PAGE,
+                count: SearchCfg.RESULTS_PER_PAGE,
+                filters: finalFilters,
+            },
+        },
+    });
+
+    const onSearch = (q: string) => {
+        let finalQuery = q;
+        if (q.trim().length === 0) {
+            if (emptySearchQuery) {
+                finalQuery = emptySearchQuery;
+            } else {
+                return;
+            }
+        }
+        navigateToEntitySearchUrl({
+            baseUrl: location.pathname,
+            type: activeType,
+            query: finalQuery,
+            page: 1,
+            history,
+        });
+    };
+
+    const onChangeFilters = (newFilters: Array<FacetFilterInput>) => {
+        navigateToEntitySearchUrl({
+            baseUrl: location.pathname,
+            type: activeType,
+            query,
+            page: 1,
+            filters: newFilters,
+            history,
+        });
+    };
+
+    const onChangePage = (newPage: number) => {
+        navigateToEntitySearchUrl({
+            baseUrl: location.pathname,
+            type: activeType,
+            query,
+            page: newPage,
+            filters,
+            history,
+        });
+    };
+
+    const toggleFilters = () => {
+        setShowFilters(!showFilters);
+    };
+
+    // Filter out the persistent filter values
+    const filteredFilters =
+        data?.searchAcrossEntities?.facets?.filter((facet) => facet.field !== fixedFilter?.field) || [];
+
+    return (
+        <>
+            {error && message.error(`Failed to complete search: ${error && error.message}`)}
+            <EmbeddedListSearchHeader
+                onSearch={onSearch}
+                placeholderText={placeholderText}
+                onToggleFilters={toggleFilters}
+            />
+            <EmbeddedListSearchResults
+                loading={loading}
+                searchResponse={data?.searchAcrossEntities}
+                filters={filteredFilters}
+                selectedFilters={filters}
+                onChangeFilters={onChangeFilters}
+                onChangePage={onChangePage}
+                page={page}
+                showFilters={showFilters}
+            />
+        </>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchHeader.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Button, Typography } from 'antd';
+import { FilterOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+import TabToolbar from '../TabToolbar';
+import { SearchBar } from '../../../../../search/SearchBar';
+import { useEntityRegistry } from '../../../../../useEntityRegistry';
+
+const HeaderContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 16px;
+    width: 100%;
+`;
+
+type Props = {
+    onSearch: (q: string) => void;
+    onToggleFilters: () => void;
+    placeholderText?: string | null;
+};
+
+export default function EmbeddedListSearchHeader({ onSearch, onToggleFilters, placeholderText }: Props) {
+    const entityRegistry = useEntityRegistry();
+
+    const onQueryChange = (query: string) => {
+        onSearch(query);
+    };
+
+    return (
+        <TabToolbar>
+            <HeaderContainer>
+                <Button type="text" onClick={onToggleFilters}>
+                    <FilterOutlined />
+                    <Typography.Text>Filters</Typography.Text>
+                </Button>
+                <SearchBar
+                    initialQuery=""
+                    placeholderText={placeholderText || 'Search entities...'}
+                    suggestions={[]}
+                    style={{
+                        maxWidth: 220,
+                        padding: 0,
+                    }}
+                    inputStyle={{
+                        height: 32,
+                        fontSize: 12,
+                    }}
+                    onSearch={onSearch}
+                    onQueryChange={onQueryChange}
+                    entityRegistry={entityRegistry}
+                />
+            </HeaderContainer>
+        </TabToolbar>
+    );
+}

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/EmbeddedListSearchResults.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Pagination, Typography } from 'antd';
+import styled from 'styled-components';
+import { FacetFilterInput, FacetMetadata, SearchResults as SearchResultType } from '../../../../../../types.generated';
+import { SearchFilters } from '../../../../../search/SearchFilters';
+import { SearchCfg } from '../../../../../../conf';
+import { EntityNameList } from '../../../../../recommendations/renderer/component/EntityNameList';
+
+const SearchBody = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+const PaginationInfo = styled(Typography.Text)`
+    padding: 0px;
+`;
+
+const FiltersContainer = styled.div`
+    display: block;
+    max-width: 260px;
+    min-width: 260px;
+    border-right: 1px solid;
+    border-color: ${(props) => props.theme.styles['border-color-base']};
+`;
+
+const ResultContainer = styled.div`
+    flex: 1;
+    margin-bottom: 20px;
+`;
+
+const PaginationInfoContainer = styled.div`
+    padding: 8px;
+    padding-left: 16px;
+    border-bottom: 1px solid;
+    border-color: ${(props) => props.theme.styles['border-color-base']};
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const FiltersHeader = styled.div`
+    font-size: 14px;
+    font-weight: 600;
+
+    padding-left: 20px;
+    padding-right: 20px;
+    padding-bottom: 8px;
+
+    width: 100%;
+    height: 46px;
+    line-height: 46px;
+    border-bottom: 1px solid;
+    border-color: ${(props) => props.theme.styles['border-color-base']};
+`;
+
+const StyledPagination = styled(Pagination)`
+    margin: 0px;
+    padding: 0px;
+`;
+
+const SearchFilterContainer = styled.div`
+    padding-top: 10px;
+`;
+
+interface Props {
+    page: number;
+    searchResponse?: SearchResultType | null;
+    filters?: Array<FacetMetadata> | null;
+    selectedFilters: Array<FacetFilterInput>;
+    loading: boolean;
+    showFilters?: boolean;
+    onChangeFilters: (filters: Array<FacetFilterInput>) => void;
+    onChangePage: (page: number) => void;
+}
+
+export const EmbeddedListSearchResults = ({
+    page,
+    searchResponse,
+    filters,
+    selectedFilters,
+    loading,
+    showFilters,
+    onChangeFilters,
+    onChangePage,
+}: Props) => {
+    const pageStart = searchResponse?.start || 0;
+    const pageSize = searchResponse?.count || 0;
+    const totalResults = searchResponse?.total || 0;
+    const lastResultIndex = pageStart + pageSize > totalResults ? totalResults : pageStart + pageSize;
+
+    const onFilterSelect = (newFilters) => {
+        onChangeFilters(newFilters);
+    };
+
+    return (
+        <>
+            <SearchBody>
+                {!!showFilters && (
+                    <FiltersContainer>
+                        <FiltersHeader>Filter</FiltersHeader>
+                        <SearchFilterContainer>
+                            <SearchFilters
+                                loading={loading}
+                                facets={filters || []}
+                                selectedFilters={selectedFilters}
+                                onFilterSelect={onFilterSelect}
+                            />
+                        </SearchFilterContainer>
+                    </FiltersContainer>
+                )}
+                <ResultContainer>
+                    {!loading && (
+                        <>
+                            <EntityNameList
+                                entities={
+                                    searchResponse?.searchResults?.map((searchResult) => searchResult.entity) || []
+                                }
+                            />
+                        </>
+                    )}
+                    <PaginationInfoContainer>
+                        <PaginationInfo>
+                            <b>
+                                {lastResultIndex > 0 ? (page - 1) * pageSize + 1 : 0} - {lastResultIndex}
+                            </b>{' '}
+                            of <b>{totalResults}</b>
+                        </PaginationInfo>
+                        <StyledPagination
+                            current={page}
+                            pageSize={SearchCfg.RESULTS_PER_PAGE}
+                            total={totalResults}
+                            showLessItems
+                            onChange={onChangePage}
+                            showSizeChanger={false}
+                        />
+                        <span />
+                    </PaginationInfoContainer>
+                </ResultContainer>
+            </SearchBody>
+        </>
+    );
+};

--- a/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
+++ b/datahub-web-react/src/app/entity/shared/components/styled/search/navigateToEntitySearchUrl.ts
@@ -1,0 +1,39 @@
+import { RouteComponentProps } from 'react-router';
+import * as QueryString from 'query-string';
+import { EntityType, FacetFilterInput } from '../../../../../../types.generated';
+import filtersToQueryStringParams from '../../../../../search/utils/filtersToQueryStringParams';
+
+export const navigateToEntitySearchUrl = ({
+    baseUrl,
+    type: newType,
+    query: newQuery,
+    page: newPage = 1,
+    filters: newFilters,
+    history,
+}: {
+    baseUrl: string;
+    type?: EntityType;
+    query?: string;
+    page?: number;
+    filters?: Array<FacetFilterInput>;
+    history: RouteComponentProps['history'];
+}) => {
+    const constructedFilters = newFilters || [];
+    if (newType) {
+        constructedFilters.push({ field: 'entity', value: newType });
+    }
+
+    const search = QueryString.stringify(
+        {
+            ...filtersToQueryStringParams(constructedFilters),
+            query: newQuery,
+            page: newPage,
+        },
+        { arrayFormat: 'comma' },
+    );
+
+    history.push({
+        pathname: `${baseUrl}`,
+        search,
+    });
+};

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -35,7 +35,7 @@ type Props<T, U> = {
             urn: string;
         }>
     >;
-    useUpdateQuery: (
+    useUpdateQuery?: (
         baseOptions?: MutationHookOptions<U, { urn: string; input: GenericEntityUpdate }> | undefined,
     ) => MutationTuple<U, { urn: string; input: GenericEntityUpdate }>;
     getOverrideProperties: (T) => GenericEntityProperties;
@@ -135,9 +135,13 @@ export const EntityProfile = <T, U>({
         variables: { urn },
     });
 
-    const [updateEntity] = useUpdateQuery({
+    const maybeUpdateEntity = useUpdateQuery?.({
         onCompleted: () => refetch(),
     });
+    let updateEntity;
+    if (maybeUpdateEntity) {
+        [updateEntity] = maybeUpdateEntity;
+    }
 
     const entityData =
         (data && getDataForEntityType({ data: data[Object.keys(data)[0]], entityType, getOverrideProperties })) || null;
@@ -193,6 +197,10 @@ export const EntityProfile = <T, U>({
         );
     }
 
+    const isBrowsable = entityRegistry.getBrowseEntityTypes().includes(entityType);
+    const isLineageEnabled = entityRegistry.getLineageEntityTypes().includes(entityType);
+    const showBrowseBar = isBrowsable || isLineageEnabled;
+
     return (
         <EntityContext.Provider
             value={{
@@ -207,7 +215,7 @@ export const EntityProfile = <T, U>({
             }}
         >
             <>
-                <EntityProfileNavBar urn={urn} entityType={entityType} />
+                {showBrowseBar && <EntityProfileNavBar urn={urn} entityType={entityType} />}
                 {loading && <Message type="loading" content="Loading..." style={{ marginTop: '10%' }} />}
                 {!loading && error && (
                     <Alert type="error" message={error?.message || `Entity failed to load for urn ${urn}`} />

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -77,7 +77,6 @@ const Header = styled.div`
     border-bottom: 1px solid ${ANTD_GRAY[4.5]};
     padding: 20px 20px 0 20px;
     flex-shrink: 0;
-    min-height: 137px;
 `;
 
 const TabContent = styled.div`

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -5,15 +5,19 @@ import styled from 'styled-components';
 
 import { capitalizeFirstLetter } from '../../../../../shared/capitalizeFirstLetter';
 import { useEntityRegistry } from '../../../../../useEntityRegistry';
+import { IconStyleType } from '../../../../Entity';
 import { ANTD_GRAY } from '../../../constants';
 import { useEntityData } from '../../../EntityContext';
 import { useEntityPath } from '../utils';
+
+const LogoContainer = styled.span`
+    margin-right: 10px;
+`;
 
 const PreviewImage = styled(Image)`
     max-height: 17px;
     width: auto;
     object-fit: contain;
-    margin-right: 10px;
     background-color: transparent;
 `;
 
@@ -63,6 +67,7 @@ export const EntityHeader = () => {
 
     const platformName = capitalizeFirstLetter(entityData?.platform?.name);
     const platformLogoUrl = entityData?.platform?.info?.logoUrl;
+    const entityLogoComponent = entityRegistry.getIcon(entityType, 12, IconStyleType.ACCENT);
     const entityTypeCased = entityRegistry.getEntityName(entityType);
     const entityPath = useEntityPath(entityType, urn);
     const externalUrl = entityData?.externalUrl || undefined;
@@ -71,11 +76,14 @@ export const EntityHeader = () => {
         <HeaderContainer>
             <MainHeaderContent>
                 <PlatformContent>
-                    <span>
-                        {!!platformLogoUrl && <PreviewImage preview={false} src={platformLogoUrl} alt={platformName} />}
-                    </span>
+                    <LogoContainer>
+                        {(!!platformLogoUrl && (
+                            <PreviewImage preview={false} src={platformLogoUrl} alt={platformName} />
+                        )) ||
+                            entityLogoComponent}
+                    </LogoContainer>
                     <PlatformText>{platformName}</PlatformText>
-                    {platformLogoUrl || (platformName && <PlatformDivider />)}
+                    {(platformLogoUrl || platformName) && <PlatformDivider />}
                     <PlatformText>{entityData?.entityTypeOverride || entityTypeCased}</PlatformText>
                 </PlatformContent>
                 <Link to={entityPath}>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -75,7 +75,7 @@ export const EntityHeader = () => {
                         {!!platformLogoUrl && <PreviewImage preview={false} src={platformLogoUrl} alt={platformName} />}
                     </span>
                     <PlatformText>{platformName}</PlatformText>
-                    <PlatformDivider />
+                    {platformLogoUrl || (platformName && <PlatformDivider />)}
                     <PlatformText>{entityData?.entityTypeOverride || entityTypeCased}</PlatformText>
                 </PlatformContent>
                 <Link to={entityPath}>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -1,4 +1,4 @@
-import { CheckOutlined, LinkOutlined } from '@ant-design/icons';
+import { CheckOutlined, CopyOutlined } from '@ant-design/icons';
 import { Typography, Image, Button, Tooltip } from 'antd';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -92,16 +92,14 @@ export const EntityHeader = () => {
                 </Link>
             </MainHeaderContent>
             {hasExternalUrl && <Button href={externalUrl}>View in {platformName}</Button>}
-            <Tooltip title="An URN uniquely identifies an entity on DataHub.">
+            <Tooltip title="Copy URN. An URN uniquely identifies an entity on DataHub.">
                 <Button
-                    icon={copiedUrn ? <CheckOutlined /> : <LinkOutlined />}
+                    icon={copiedUrn ? <CheckOutlined /> : <CopyOutlined />}
                     onClick={() => {
                         navigator.clipboard.writeText(urn);
                         setCopiedUrn(true);
                     }}
-                >
-                    {copiedUrn ? 'Copied!' : 'Copy URN'}
-                </Button>
+                />
             </Tooltip>
         </HeaderContainer>
     );

--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -1,5 +1,6 @@
-import { Typography, Image, Button } from 'antd';
-import React from 'react';
+import { CheckOutlined, LinkOutlined } from '@ant-design/icons';
+import { Typography, Image, Button, Tooltip } from 'antd';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -64,7 +65,7 @@ const MainHeaderContent = styled.div`
 export const EntityHeader = () => {
     const { urn, entityType, entityData } = useEntityData();
     const entityRegistry = useEntityRegistry();
-
+    const [copiedUrn, setCopiedUrn] = useState(false);
     const platformName = capitalizeFirstLetter(entityData?.platform?.name);
     const platformLogoUrl = entityData?.platform?.info?.logoUrl;
     const entityLogoComponent = entityRegistry.getIcon(entityType, 12, IconStyleType.ACCENT);
@@ -91,6 +92,17 @@ export const EntityHeader = () => {
                 </Link>
             </MainHeaderContent>
             {hasExternalUrl && <Button href={externalUrl}>View in {platformName}</Button>}
+            <Tooltip title="An URN uniquely identifies an entity on DataHub.">
+                <Button
+                    icon={copiedUrn ? <CheckOutlined /> : <LinkOutlined />}
+                    onClick={() => {
+                        navigator.clipboard.writeText(urn);
+                        setCopiedUrn(true);
+                    }}
+                >
+                    {copiedUrn ? 'Copied!' : 'Copy URN'}
+                </Button>
+            </Tooltip>
         </HeaderContainer>
     );
 };

--- a/datahub-web-react/src/app/entity/shared/types.ts
+++ b/datahub-web-react/src/app/entity/shared/types.ts
@@ -86,7 +86,7 @@ export type EntityContextType = {
     entityType: EntityType;
     entityData: GenericEntityProperties | null;
     baseEntity: any;
-    updateEntity: UpdateEntityType<any>;
+    updateEntity?: UpdateEntityType<any> | null;
     routeToTab: (params: { tabName: string; tabParams?: Record<string, any>; method?: 'push' | 'replace' }) => void;
     refetch: () => Promise<any>;
     lineage: FetchedEntity | undefined;

--- a/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/preview/DefaultPreviewCard.tsx
@@ -151,7 +151,7 @@ export default function DefaultPreviewCard({
                             {(logoUrl && <PreviewImage preview={false} src={logoUrl} alt={platform || ''} />) ||
                                 logoComponent}
                             {platform && <PlatformText>{platform}</PlatformText>}
-                            <PlatformDivider />
+                            {(logoUrl || logoComponent || platform) && <PlatformDivider />}
                             <PlatformText>{type}</PlatformText>
                         </PlatformInfo>
                         <EntityTitle onClick={onClick} $titleSizePx={titleSizePx}>

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -71,7 +71,6 @@ export const EntityNameList = ({ entities, onClick }: Props) => {
                                 titleSizePx={14}
                                 tags={genericProps?.globalTags || undefined}
                                 glossaryTerms={genericProps?.glossaryTerms || undefined}
-                                domain={genericProps?.domain}
                                 onClick={() => onClick?.(index)}
                             />
                         </ListItem>

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityNameList.tsx
@@ -5,6 +5,7 @@ import { Entity } from '../../../../types.generated';
 import { useEntityRegistry } from '../../../useEntityRegistry';
 import DefaultPreviewCard from '../../../preview/DefaultPreviewCard';
 import { IconStyleType } from '../../../entity/Entity';
+import { capitalizeFirstLetter } from '../../../shared/capitalizeFirstLetter';
 
 const StyledList = styled(List)`
     margin-top: -1px;
@@ -51,7 +52,8 @@ export const EntityNameList = ({ entities, onClick }: Props) => {
             renderItem={(entity, index) => {
                 const genericProps = entityRegistry.getGenericEntityProperties(entity.type, entity);
                 const platformLogoUrl = genericProps?.platform?.info?.logoUrl;
-                const platformName = genericProps?.platform?.info?.displayName;
+                const platformName =
+                    genericProps?.platform?.info?.displayName || capitalizeFirstLetter(genericProps?.platform?.name);
                 const entityTypeName = entityRegistry.getEntityName(entity.type);
                 const displayName = entityRegistry.getDisplayName(entity.type, entity);
                 const url = entityRegistry.getEntityUrl(entity.type, entity.urn);
@@ -67,6 +69,9 @@ export const EntityNameList = ({ entities, onClick }: Props) => {
                                 platform={platformName || undefined}
                                 type={entityTypeName}
                                 titleSizePx={14}
+                                tags={genericProps?.globalTags || undefined}
+                                glossaryTerms={genericProps?.glossaryTerms || undefined}
+                                domain={genericProps?.domain}
                                 onClick={() => onClick?.(index)}
                             />
                         </ListItem>

--- a/datahub-web-react/src/app/search/SearchBar.tsx
+++ b/datahub-web-react/src/app/search/SearchBar.tsx
@@ -66,6 +66,7 @@ interface Props {
     onSearch: (query: string, type?: EntityType) => void;
     onQueryChange: (query: string) => void;
     style?: React.CSSProperties;
+    inputStyle?: React.CSSProperties;
     autoCompleteStyle?: React.CSSProperties;
     entityRegistry: EntityRegistry;
 }
@@ -85,6 +86,7 @@ export const SearchBar = ({
     onQueryChange,
     entityRegistry,
     style,
+    inputStyle,
     autoCompleteStyle,
 }: Props) => {
     const [searchQuery, setSearchQuery] = useState<string>();
@@ -139,6 +141,7 @@ export const SearchBar = ({
                         e.stopPropagation();
                         onSearch(filterSearchQuery(searchQuery || ''));
                     }}
+                    style={inputStyle}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     data-testid="search-input"


### PR DESCRIPTION
# Changes

- Ensure browsePaths resolver returns empty list when an Entity has no browse path (threw before). 
- Migrate persistAspect in mutationUtils to use ingestProposal instead of ingestEntity. 
- Adding common EmbeddedListSearch components to bundle entity search into a set of reusable, common components. 
- remove minHeight CSS in EntityHeader to avoid ui bug where tabs were floating above cutline. 
- Only show EntityProfile browse / lineage bar when lineage or browse is enabled for the entity
- make updateEntity an optional parameter to EntityProfile (in some cases not necessary) 
- Only show divider when there is a platform on entity profile 
- [Finally] Adding "Copy Urn" button to all entity profiles 
- Support "inputStyle" on search bar component
- Add Glossary Terms & Tags to the Recommendation list views (currently just shows name) 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
