### PR TITLE
fix(ui): update login title css to fit on one line

### DIFF
--- a/datahub-web-react/src/app/auth/login.module.css
+++ b/datahub-web-react/src/app/auth/login.module.css
@@ -34,4 +34,6 @@
 .title {
     color: white;
     margin: 20px 0px;
+    font-size: 14px;
+    text-align: center;
 }


### PR DESCRIPTION
## Description
fix(ui): update login title css to fit on one line

## Before
![image](https://user-images.githubusercontent.com/19418814/150241449-e8c3d02b-23b0-49b2-bd67-6dbe5503d065.png)

## After
![image](https://user-images.githubusercontent.com/19418814/150241524-9d0c5d0f-e140-4a55-9d20-fd661c35bb48.png)

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
- 
