### PR TITLE
fix(ingestion): match default username for Azure OIDC and Azure ingestion source

### DIFF
--- a/metadata-ingestion/source_docs/azure-ad.md
+++ b/metadata-ingestion/source_docs/azure-ad.md
@@ -21,8 +21,8 @@ from your Azure AD instance.
 #### Usernames
 
 Usernames serve as unique identifiers for users on DataHub. This connector extracts usernames using the 
-"mail" field of an [Azure AD User Response](https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http#response-1). 
-By default, the 'mail' attribute, which contains an email, is parsed to extract the text before the "@" and map that to the DataHub username.
+"userPrincipalName" field of an [Azure AD User Response](https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http#response-1),
+which is the unique identifier for your Azure AD users.
 
 If this is not how you wish to map to DataHub usernames, you can provide a custom mapping using the configurations options detailed below. Namely, `azure_ad_response_to_username_attr` 
 and `azure_ad_response_to_username_regex`. 
@@ -124,8 +124,8 @@ Note that a `.` is used to denote nested fields in the YAML configuration block.
 | `ingest_users`                     | bool   |          | `True`      | Whether users should be ingested into DataHub.                                                                  |
 | `ingest_groups`                    | bool   |          | `True`      | Whether groups should be ingested into DataHub.                                                                 |
 | `ingest_group_membership`          | bool   |          | `True`      | Whether group membership should be ingested into DataHub. ingest_groups must be True if this is True.           |
-| `azure_ad_response_to_username_attr`    | string |          | `"mail"`   | Which Azure AD User Response attribute to use as input to DataHub username mapping.                                  |
-| `azure_ad_response_to_username_regex`   | string |          | `"([^@]+)"` | A regex used to parse the DataHub username from the attribute specified in `azure_ad_response_to_username_attr`.     |
+| `azure_ad_response_to_username_attr`    | string |          | `"userPrincipalName"`   | Which Azure AD User Response attribute to use as input to DataHub username mapping.                                  |
+| `azure_ad_response_to_username_regex`   | string |          | `"(.*)"` | A regex used to parse the DataHub username from the attribute specified in `azure_ad_response_to_username_attr`.     |
 | `users_pattern.allow`                 |  list of strings    |             |       | List of regex patterns for users to include in ingestion. The name against which compare the regexp is the DataHub user name, i.e. the one resulting from the action of `azure_ad_response_to_username_attr` and `azure_ad_response_to_username_regex`   |
 | `users_pattern.deny`                  | list of strings     |             |       | As above, but for excluding users from ingestion.                                                                                                                           |
 | `azure_ad_response_to_groupname_attr`  | string |          | `"name"`    | Which Azure AD Group Response attribute to use as input to DataHub group name mapping.                               |

--- a/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/identity/azure_ad.py
@@ -41,8 +41,8 @@ class AzureADConfig(ConfigModel):
 
     # Optional: Customize the mapping to DataHub Username from an attribute in the REST API response
     # Reference: https://docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http#response-1
-    azure_ad_response_to_username_attr: str = "mail"
-    azure_ad_response_to_username_regex: str = "([^@]+)"
+    azure_ad_response_to_username_attr: str = "userPrincipalName"
+    azure_ad_response_to_username_regex: str = "(.*)"
 
     # Optional: Customize the mapping to DataHub Groupname from an attribute in the REST API response
     # Reference: https://docs.microsoft.com/en-us/graph/api/group-list?view=graph-rest-1.0&tabs=http#response-1

--- a/metadata-ingestion/tests/integration/azure_ad/azure_ad_mces_golden_default_config.json
+++ b/metadata-ingestion/tests/integration/azure_ad/azure_ad_mces_golden_default_config.json
@@ -55,7 +55,7 @@
     "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot": {
-            "urn": "urn:li:corpuser:johngreen",
+            "urn": "urn:li:corpuser:johngreen@acryl.io",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {
@@ -94,7 +94,7 @@
     "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.CorpUserSnapshot": {
-            "urn": "urn:li:corpuser:adamhall",
+            "urn": "urn:li:corpuser:adamhall@acryl.io",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.identity.CorpUserInfo": {


### PR DESCRIPTION
Currently, when using Azure OIDC authentication together with the Azure AD ingestion source, the generated usernames won't match between logins and ingested users since both use a different attribute and regex to extract usernames (slack thread: https://datahubspace.slack.com/archives/CV2UVAPPG/p1642591442014900). I feel this is unexpected behavior.

I changed the ingestion source instead of the OIDC plugin because it seems more natural to me to use the azure principal name as the username in datahub, since it is guaranteed to uniquely identify a user. A change in the opposite direction would be fine as well, I think the important part is that they are consistent with each other.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
