### PR TITLE
refactor(ui): Allow DocumentationTab to optionally use updateDescription mutation

### DIFF
--- a/datahub-web-react/src/app/entity/shared/EntityContext.tsx
+++ b/datahub-web-react/src/app/entity/shared/EntityContext.tsx
@@ -20,9 +20,9 @@ export const useBaseEntity = <T,>(): T => {
     return baseEntity as T;
 };
 
-export const useEntityUpdate = <U,>(): UpdateEntityType<U> => {
+export const useEntityUpdate = <U,>(): UpdateEntityType<U> | null | undefined => {
     const { updateEntity } = useContext(EntityContext);
-    return updateEntity as UpdateEntityType<U>;
+    return updateEntity;
 };
 
 export const useEntityData = () => {


### PR DESCRIPTION

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
