### PR TITLE
fix(ingestion): Snowflake Usage should continue to emit usage workunits with include_operational_stats enabled.

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -135,7 +135,8 @@ plugins: Dict[str, Set[str]] = {
     | {"sqlalchemy-redshift", "psycopg2-binary", "GeoAlchemy2"},
     "sagemaker": aws_common,
     "snowflake": sql_common | {"snowflake-sqlalchemy<=1.2.4"},
-    "snowflake-usage": sql_common | {"snowflake-sqlalchemy<=1.2.4"},
+    "snowflake-usage": sql_common
+    | {"snowflake-sqlalchemy<=1.2.4", "more-itertools>=8.12.0"},
     "sqlalchemy": sql_common,
     "superset": {"requests"},
     "trino": sql_common


### PR DESCRIPTION
Fix the snowflake_usage source regression introduced in acryl-datahub 0.8.23.1. Currently, if include_operational_stats is enabled, all of the SnowflakeJoinedAccessEvents get consumed by operational stats emission alone, resulting in no usage events getting aggregated. This fix reorders the computation to produced both the usage aggregation and operational status workunits together during a single pass over the original SnowflakeJoinedAccessEvents.
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
