### PR TITLE
fix(graphQL): Fixing set ordering in batchGet of entities

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/chart/ChartType.java
@@ -43,6 +43,7 @@ import com.linkedin.metadata.snapshot.Snapshot;
 import com.linkedin.r2.RemoteInvocationException;
 
 import graphql.execution.DataFetcherResult;
+import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -94,14 +95,15 @@ public class ChartType implements SearchableEntityType<Chart>, BrowsableEntityTy
 
     @Override
     public List<DataFetcherResult<Chart>> batchLoad(@Nonnull List<String> urnStrs, @Nonnull QueryContext context) throws Exception {
-        final Set<Urn> urns = urnStrs.stream()
+        final List<Urn> urns = urnStrs.stream()
             .map(UrnUtils::getUrn)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
         try {
             final Map<Urn, EntityResponse> chartMap =
                 _entityClient.batchGetV2(
                     Constants.CHART_ENTITY_NAME,
-                    urns, ASPECTS_TO_RESOLVE,
+                    new HashSet<>(urns),
+                    ASPECTS_TO_RESOLVE,
                     context.getAuthentication());
 
             final List<EntityResponse> gmsResults = new ArrayList<>();

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dashboard/DashboardType.java
@@ -44,6 +44,7 @@ import com.linkedin.metadata.snapshot.Snapshot;
 import com.linkedin.r2.RemoteInvocationException;
 
 import graphql.execution.DataFetcherResult;
+import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -94,14 +95,14 @@ public class DashboardType implements SearchableEntityType<Dashboard>, Browsable
 
     @Override
     public List<DataFetcherResult<Dashboard>> batchLoad(@Nonnull List<String> urnStrs, @Nonnull QueryContext context) throws Exception {
-        final Set<Urn> urns = urnStrs.stream()
+        final List<Urn> urns = urnStrs.stream()
             .map(UrnUtils::getUrn)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
         try {
             final Map<Urn, EntityResponse> dashboardMap =
                 _entityClient.batchGetV2(
                     Constants.DASHBOARD_ENTITY_NAME,
-                    urns,
+                    new HashSet<>(urns),
                     ASPECTS_TO_RESOLVE,
                     context.getAuthentication());
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/DataFlowType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataflow/DataFlowType.java
@@ -45,6 +45,7 @@ import com.linkedin.r2.RemoteInvocationException;
 import graphql.execution.DataFetcherResult;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,14 +93,14 @@ public class DataFlowType implements SearchableEntityType<DataFlow>, BrowsableEn
 
     @Override
     public List<DataFetcherResult<DataFlow>> batchLoad(final List<String> urnStrs, final QueryContext context) throws Exception {
-        final Set<Urn> urns = urnStrs.stream()
+        final List<Urn> urns = urnStrs.stream()
             .map(UrnUtils::getUrn)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
         try {
             final Map<Urn, EntityResponse> dataFlowMap =
                 _entityClient.batchGetV2(
                     Constants.DATA_FLOW_ENTITY_NAME,
-                    urns,
+                    new HashSet<>(urns),
                     ASPECTS_TO_RESOLVE,
                     context.getAuthentication());
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/DataJobType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/datajob/DataJobType.java
@@ -43,6 +43,7 @@ import com.linkedin.metadata.snapshot.DataJobSnapshot;
 import com.linkedin.metadata.snapshot.Snapshot;
 import graphql.execution.DataFetcherResult;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,13 +94,13 @@ public class DataJobType implements SearchableEntityType<DataJob>, BrowsableEnti
 
     @Override
     public List<DataFetcherResult<DataJob>> batchLoad(final List<String> urnStrs, final QueryContext context) throws Exception {
-        final Set<Urn> urns = urnStrs.stream()
+        final List<Urn> urns = urnStrs.stream()
             .map(UrnUtils::getUrn)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
         try {
             final Map<Urn, EntityResponse> dataJobMap = _entityClient.batchGetV2(
                 Constants.DATA_JOB_ENTITY_NAME,
-                urns,
+                new HashSet<>(urns),
                 ASPECTS_TO_RESOLVE,
                 context.getAuthentication());
 

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/DatasetType.java
@@ -43,6 +43,7 @@ import com.linkedin.metadata.snapshot.Snapshot;
 import com.linkedin.r2.RemoteInvocationException;
 
 import graphql.execution.DataFetcherResult;
+import java.util.HashSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -99,14 +100,15 @@ public class DatasetType implements SearchableEntityType<Dataset>, BrowsableEnti
 
     @Override
     public List<DataFetcherResult<Dataset>> batchLoad(final List<String> urnStrs, final QueryContext context) {
-        final Set<Urn> urns = urnStrs.stream()
+        final List<Urn> urns = urnStrs.stream()
             .map(UrnUtils::getUrn)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
         try {
             final Map<Urn, EntityResponse> datasetMap =
                 _entityClient.batchGetV2(
                     Constants.DATASET_ENTITY_NAME,
-                    urns, ASPECTS_TO_RESOLVE,
+                    new HashSet<>(urns),
+                    ASPECTS_TO_RESOLVE,
                     context.getAuthentication());
 
             final List<EntityResponse> gmsResults = new ArrayList<>();

--- a/metadata-ingestion/examples/recipes/file_to_datahub_rest.yml
+++ b/metadata-ingestion/examples/recipes/file_to_datahub_rest.yml
@@ -3,7 +3,7 @@
 source:
   type: "file"
   config:
-    filename: "./examples/mce_files/bootstrap_mce.json"
+    filename: "../smoke-test/sample_bq_data.json"
 
 # see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
 sink:

--- a/smoke-test/sample_bq_data.json
+++ b/smoke-test/sample_bq_data.json
@@ -380,5 +380,23 @@
             }
         },
         "proposedDelta": null
+    },
+    {
+        "auditHeader": null,
+        "proposedSnapshot": {
+            "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
+                "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,bigquery-public-data.covid19_geotab_mobility_impact.ca_border_wait_times,PROD)",
+                "aspects": [
+                    {
+                        "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
+                            "description": "This dataset shows hourly average border crossing duration for Canada-US border wait times",
+                            "uri": null,
+                            "tags": [],
+                            "customProperties": {}
+                        }
+                    }
+                ]
+            }
+        }
     }
 ]

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -162,6 +162,37 @@ def test_gms_get_dataset(platform, dataset_name, env):
     assert res_data["value"]["com.linkedin.metadata.snapshot.DatasetSnapshot"]
     assert res_data["value"]["com.linkedin.metadata.snapshot.DatasetSnapshot"]["urn"] == urn
 
+@pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
+def test_gms_batch_get():
+    platform = "urn:li:dataPlatform:bigquery"
+    env = "PROD"
+    name_1 = (
+        "bigquery-public-data.covid19_geotab_mobility_impact.us_border_wait_times"
+    )
+    name_2 = (
+        "bigquery-public-data.covid19_geotab_mobility_impact.ca_border_wait_times"
+    )
+    urn1 = f"urn:li:dataset:({platform},{name_1},{env})"
+    urn2 = f"urn:li:dataset:({platform},{name_2},{env})"
+
+    response = requests.get(
+        f"{GMS_ENDPOINT}/entitiesV2?ids=List({urllib.parse.quote(urn1)},{urllib.parse.quote(urn2)})?aspects=List(datasetProperties,ownership)",
+        headers={
+            **restli_default_headers,
+            "X-RestLi-Method": "batch_get",
+        },
+    )
+    response.raise_for_status()
+    res_data = response.json()
+
+    # Verify both urns exist and have correct aspects
+    assert res_data["results"]
+    assert res_data["results"][urn1]
+    assert res_data["results"][urn1]["aspects"]["datasetProperties"]
+    assert res_data["results"][urn1]["aspects"]["ownership"]
+    assert res_data["results"][urn2]
+    assert res_data["results"][urn2]["aspects"]["datasetProperties"]
+    assert res_data["results"][urn2]["aspects"]["ownership"] is None # Aspect does not exist.
 
 @pytest.mark.parametrize(
     "query,min_expected_results",

--- a/smoke-test/test_e2e.py
+++ b/smoke-test/test_e2e.py
@@ -163,7 +163,7 @@ def test_gms_get_dataset(platform, dataset_name, env):
     assert res_data["value"]["com.linkedin.metadata.snapshot.DatasetSnapshot"]["urn"] == urn
 
 @pytest.mark.dependency(depends=["test_healthchecks", "test_run_ingestion"])
-def test_gms_batch_get():
+def test_gms_batch_get_v2():
     platform = "urn:li:dataPlatform:bigquery"
     env = "PROD"
     name_1 = (
@@ -176,7 +176,7 @@ def test_gms_batch_get():
     urn2 = f"urn:li:dataset:({platform},{name_2},{env})"
 
     response = requests.get(
-        f"{GMS_ENDPOINT}/entitiesV2?ids=List({urllib.parse.quote(urn1)},{urllib.parse.quote(urn2)})?aspects=List(datasetProperties,ownership)",
+        f"{GMS_ENDPOINT}/entitiesV2?ids=List({urllib.parse.quote(urn1)},{urllib.parse.quote(urn2)})&aspects=List(datasetProperties,ownership)",
         headers={
             **restli_default_headers,
             "X-RestLi-Method": "batch_get",
@@ -192,7 +192,7 @@ def test_gms_batch_get():
     assert res_data["results"][urn1]["aspects"]["ownership"]
     assert res_data["results"][urn2]
     assert res_data["results"][urn2]["aspects"]["datasetProperties"]
-    assert res_data["results"][urn2]["aspects"]["ownership"] is None # Aspect does not exist.
+    assert "ownership" not in res_data["results"][urn2]["aspects"] # Aspect does not exist.
 
 @pytest.mark.parametrize(
     "query,min_expected_results",


### PR DESCRIPTION
In a recent change, we migrated from using the legacy snapshot-based batchGet method to a new batchGetV2. In the process, we introduced a bug that causes the ordering of results from batchGet to be non-deterministically changed. 

These changes have not yet been released. This PR fixes the issue. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
