### PR TITLE
fix(ingestion): Restrict python to <=3.9.9

### DIFF
--- a/.github/workflows/metadata-ingestion-slow.yml
+++ b/.github/workflows/metadata-ingestion-slow.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9.9"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/metadata-ingestion.yml
+++ b/.github/workflows/metadata-ingestion.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.6", "3.9.9"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.6", "3.9.9"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -364,7 +364,8 @@ setuptools.setup(
     ],
     # Package info.
     zip_safe=False,
-    python_requires=">=3.6",
+    # restrict python to <=3.9.9 due to https://github.com/looker-open-source/sdk-codegen/issues/944
+    python_requires=">=3.6, <=3.9.9",
     package_dir={"": "src"},
     packages=setuptools.find_namespace_packages(where="./src"),
     package_data={


### PR DESCRIPTION
Restrict python to <=3.9.9 due to https://github.com/looker-open-source/sdk-codegen/issues/944 causes build failure

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
