### PR TITLE
fix(cli) CA Cert option for CLI commands

### DIFF
--- a/metadata-ingestion/src/datahub/cli/cli_utils.py
+++ b/metadata-ingestion/src/datahub/cli/cli_utils.py
@@ -27,16 +27,20 @@ ENV_METADATA_HOST = "DATAHUB_GMS_HOST"
 ENV_METADATA_TOKEN = "DATAHUB_GMS_TOKEN"
 ENV_METADATA_CA_CERT = "DATAHUB_GMS_CA_CERT"
 
+
 class GmsConfig(BaseModel):
     server: str
     token: Optional[str]
     ca_cert: Optional[str]
 
+
 class DatahubConfig(BaseModel):
     gms: GmsConfig
 
 
-def write_datahub_config(host: str, token: Optional[str], ca_cert: Optional[str]) -> None:
+def write_datahub_config(
+    host: str, token: Optional[str], ca_cert: Optional[str]
+) -> None:
     config = {
         "gms": {
             "server": host,
@@ -59,7 +63,7 @@ def ensure_datahub_config() -> None:
             f"No {CONDENSED_DATAHUB_CONFIG_PATH} file found, generating one for you...",
             bold=True,
         )
-        write_datahub_config(DEFAULT_GMS_HOST, None)
+        write_datahub_config(DEFAULT_GMS_HOST, None, None)
 
 
 def get_details_from_config():
@@ -86,10 +90,12 @@ def get_details_from_config():
     return None, None, None
 
 
-def get_details_from_env() -> Tuple[Optional[str], Optional[str]]:
-    return os.environ.get(ENV_METADATA_HOST), \
-        os.environ.get(ENV_METADATA_TOKEN), \
-        os.environ.get(ENV_METADATA_CA_CERT)
+def get_details_from_env() -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    return (
+        os.environ.get(ENV_METADATA_HOST),
+        os.environ.get(ENV_METADATA_TOKEN),
+        os.environ.get(ENV_METADATA_CA_CERT),
+    )
 
 
 def first_non_null(ls: List[Optional[str]]) -> Optional[str]:
@@ -111,6 +117,7 @@ def get_token():
         gms_token = first_non_null([gms_token_env, gms_token_conf])
     return gms_token
 
+
 def get_ca_cert():
     _, _, gms_ca_cert_env = get_details_from_env()
     if should_skip_config():
@@ -120,6 +127,7 @@ def get_ca_cert():
         _, _, gms_ca_cert_conf = get_details_from_config()
         gms_ca_cert = first_non_null([gms_ca_cert_env, gms_ca_cert_conf])
     return gms_ca_cert
+
 
 def get_session_and_host():
     session = requests.Session()

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -82,7 +82,12 @@ def init() -> None:
         type=str,
         default="",
     )
-    write_datahub_config(host, token)
+    ca_cert = click.prompt(
+        "Enter CA cert path (Optional) (Supports env vars via `{VAR_NAME}` syntax)",
+        type=str,
+        default="",
+    )
+    write_datahub_config(host, token, ca_cert)
 
     click.echo(f"Written to {DATAHUB_CONFIG_PATH}")
 


### PR DESCRIPTION
When running CLI commands against a remote instance of datahub, there may be SSL related errors when connecting to the GMS.
While there is an option for ingestion (specify in the recipe), there should be an option for the user to define the CA cert when interacting with the remote instance for the other commands. Basically this PR adds ca_cert for requests.session().

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
