### PR TITLE
fix(ingestion): tighten conditions for restli json transformation

### DIFF
--- a/metadata-ingestion/src/datahub/emitter/serialization_helper.py
+++ b/metadata-ingestion/src/datahub/emitter/serialization_helper.py
@@ -5,10 +5,10 @@ from typing import Any
 def pre_json_transform(obj: Any) -> Any:
     if isinstance(obj, (dict, OrderedDict)):
         if len(obj.keys()) == 1:
-            key = list(obj.keys())[0]
+            key: str = list(obj.keys())[0]
             value = obj[key]
-            if key.find("com.linkedin.pegasus2avro.") >= 0:
-                new_key = key.replace("com.linkedin.pegasus2avro.", "com.linkedin.")
+            if key.startswith("com.linkedin.pegasus2avro.") >= 0:
+                new_key = key.replace("com.linkedin.pegasus2avro.", "com.linkedin.", 1)
                 return {new_key: pre_json_transform(value)}
 
         if "fieldDiscriminator" in obj:


### PR DESCRIPTION
Uses `startswith` instead of `find` and limits the replace to one modification.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
