### PR TITLE
refactor(ebean): Adding wrapped exception handle for Ebean server instantiation

### DIFF
--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -1,5 +1,5 @@
 DATASET_ENABLE_SCSI=false
-EBEAN_DATASOURCE_USERNAME=datahub
+EBEAN_DATASOURCE_USERNAME=myneed
 EBEAN_DATASOURCE_PASSWORD=datahub
 EBEAN_DATASOURCE_HOST=mysql:3306
 EBEAN_DATASOURCE_URL=jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2

--- a/docker/datahub-gms/env/docker.env
+++ b/docker/datahub-gms/env/docker.env
@@ -1,5 +1,5 @@
 DATASET_ENABLE_SCSI=false
-EBEAN_DATASOURCE_USERNAME=myneed
+EBEAN_DATASOURCE_USERNAME=datahub
 EBEAN_DATASOURCE_PASSWORD=datahub
 EBEAN_DATASOURCE_HOST=mysql:3306
 EBEAN_DATASOURCE_URL=jdbc:mysql://mysql:3306/datahub?verifyServerCertificate=false&useSSL=true&useUnicode=yes&characterEncoding=UTF-8&enabledTLSProtocols=TLSv1.2

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EbeanServerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EbeanServerFactory.java
@@ -4,6 +4,7 @@ import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import io.ebean.EbeanServer;
 import io.ebean.config.ServerConfig;
 import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -11,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 
 
+@Slf4j
 @Configuration
 public class EbeanServerFactory {
   public static final String EBEAN_MODEL_PACKAGE = EbeanAspectV2.class.getPackage().getName();
@@ -22,12 +24,24 @@ public class EbeanServerFactory {
   @DependsOn({"gmsEbeanServiceConfig"})
   @Nonnull
   protected EbeanServer createServer() {
-    ServerConfig serverConfig = applicationContext.getBean(ServerConfig.class);
-    // Make sure that the serverConfig includes the package that contains DAO's Ebean model.
-    if (!serverConfig.getPackages().contains(EBEAN_MODEL_PACKAGE)) {
-      serverConfig.getPackages().add(EBEAN_MODEL_PACKAGE);
+    try {
+      ServerConfig serverConfig = applicationContext.getBean(ServerConfig.class);
+
+      // Make sure that the serverConfig includes the package that contains DAO's Ebean model.
+      if (!serverConfig.getPackages().contains(EBEAN_MODEL_PACKAGE)) {
+        serverConfig.getPackages().add(EBEAN_MODEL_PACKAGE);
+      }
+
+      io.ebean.EbeanServer factory = io.ebean.EbeanServerFactory.create(serverConfig);
+
+      if (factory == null) {
+        throw new RuntimeException("Failed to create ebean server, EbeanServerFactory is null!");
+      }
+
+      // TODO: Consider supporting SCSI
+      return factory;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create ebean server!", e);
     }
-    // TODO: Consider supporting SCSI
-    return io.ebean.EbeanServerFactory.create(serverConfig);
   }
 }

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EbeanServerFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/entity/EbeanServerFactory.java
@@ -12,7 +12,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 
 
-@Slf4j
 @Configuration
 public class EbeanServerFactory {
   public static final String EBEAN_MODEL_PACKAGE = EbeanAspectV2.class.getPackage().getName();


### PR DESCRIPTION
Wrapping creation of ebean server in try catch with some nicer exception wrapping. This is because spring seems to do a less-than-ideal job of surfacing exceptions occurring within factory create methods. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
