### PR TITLE
Fix issue: Expand description width in UI by default

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -18,7 +18,7 @@ import { useEntityData, useRefetch, useRouteToTab } from '../../EntityContext';
 const DocumentationContainer = styled.div`
     margin: 0 auto;
     padding: 40px 0;
-    max-width: 550px;
+    max-width: calc(100% - 10px);
 `;
 
 export const DocumentationTab = () => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -19,6 +19,7 @@ const DocumentationContainer = styled.div`
     margin: 0 auto;
     padding: 40px 0;
     max-width: calc(100% - 10px);
+    margin: 20px;
 `;
 
 export const DocumentationTab = () => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -53,7 +53,9 @@ export const DocumentationTab = () => {
                         {description ? (
                             <MDEditor.Markdown style={{ fontWeight: 400 }} source={description} />
                         ) : (
-                            <Typography.Text type="secondary">No documentation added yet.</Typography.Text>
+                            <Typography.Text type="secondary" style={{ display: 'table', margin: '0 auto' }}>
+                                No documentation added yet.
+                            </Typography.Text>
                         )}
                         <Divider />
                         <LinkList refetch={refetch} />


### PR DESCRIPTION
UI FIX: Expanded the description width that was shown in non-edit mode.
![expand_description_default_width_1](https://user-images.githubusercontent.com/86347578/151778580-2ecb0e9b-8e3e-486a-8344-75bbf3d89d34.png)
![expand_description_default_width_2](https://user-images.githubusercontent.com/86347578/151778587-5708f341-828d-44df-92ea-7b30a11c1a66.png)

UI FIX: Aligned "No documentation added yet." text to the center.
![center_the_text](https://user-images.githubusercontent.com/86347578/151782093-7348ee32-867a-44d4-a509-3c3139d46368.png)

UI Fix: UI FIX: Added margin to the width of the description panel
![Added_Margin](https://user-images.githubusercontent.com/86347578/152082165-51684310-a9be-4ff8-82d9-6c310201bd8f.png)


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
