### PR TITLE
fix: docker-compose now persists kafka broker data

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,8 @@ services:
     ports:
       - "29092:29092"
       - "9092:9092"
+    volumes:
+      - broker://var/lib/kafka/data/
 
   # This "container" is a workaround to pre-create topics
   kafka-setup:
@@ -130,3 +132,4 @@ volumes:
   esdata:
   neo4jdata:
   zkdata:
+  broker:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "29092:29092"
       - "9092:9092"
     volumes:
-      - broker://var/lib/kafka/data/
+      - broker:/var/lib/kafka/data/
 
   # This "container" is a workaround to pre-create topics
   kafka-setup:

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -19,6 +19,8 @@ services:
     ports:
     - 29092:29092
     - 9092:9092
+    volumes:
+    - broker:/var/lib/kafka/data/
   datahub-actions:
     depends_on:
     - datahub-gms
@@ -190,6 +192,7 @@ services:
     - zkdata:/var/opt/zookeeper
 version: '2.3'
 volumes:
+  broker: null
   esdata: null
   mysqldata: null
   neo4jdata: null


### PR DESCRIPTION

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
