### PR TITLE
feat(ingestion): Support Kafka confluent external schema resolution by name or subject

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from dataclasses import dataclass, field
 from hashlib import md5
@@ -91,15 +92,20 @@ class KafkaSource(Source):
             else:
                 self.report.report_dropped(t)
 
+    @staticmethod
+    def _compact_schema(schema_str: str) -> str:
+        # Eliminate all white-spaces for a compact representation.
+        return json.dumps(json.loads(schema_str), separators=(",", ":"))
+
     def get_schema_str_replace_confluent_ref_avro(
         self, schema: Schema, schema_seen: Optional[set] = None
     ) -> str:
         if not schema.references:
-            return schema.schema_str
+            return self._compact_schema(schema.schema_str)
 
         if schema_seen is None:
             schema_seen = set()
-        schema_str = schema.schema_str
+        schema_str = self._compact_schema(schema.schema_str)
         for schema_ref in schema.references:
             ref_subject = schema_ref["subject"]
             if ref_subject in schema_seen:
@@ -111,12 +117,28 @@ class KafkaSource(Source):
             logger.debug(
                 f"ref for {ref_subject} is {reference_schema.schema.schema_str}"
             )
+            # Replace only external type references with the reference schema recursively.
+            # NOTE: The type pattern is dependent on _compact_schema.
+            avro_type_kwd = '"type"'
             ref_name = schema_ref["name"]
+            # Try by name first
+            pattern_to_replace = f'{avro_type_kwd}:"{ref_name}"'
+            if pattern_to_replace not in schema_str:
+                # Try by subject
+                pattern_to_replace = f'{avro_type_kwd}:"{ref_subject}"'
+                if pattern_to_replace not in schema_str:
+                    logger.warning(
+                        f"Not match for external schema type: {{name:{ref_name}, subject:{ref_subject}}} in schema:{schema_str}"
+                    )
+                else:
+                    logger.debug(
+                        f"External schema matches by subject, {pattern_to_replace}"
+                    )
+            else:
+                logger.debug(f"External schema matches by name, {pattern_to_replace}")
             schema_str = schema_str.replace(
-                f'"{ref_name}"',
-                self.get_schema_str_replace_confluent_ref_avro(
-                    reference_schema.schema, schema_seen
-                ),
+                pattern_to_replace,
+                f"{avro_type_kwd}:{self.get_schema_str_replace_confluent_ref_avro(reference_schema.schema, schema_seen)}",
             )
         return schema_str
 

--- a/metadata-ingestion/tests/unit/test_kafka_source.py
+++ b/metadata-ingestion/tests/unit/test_kafka_source.py
@@ -14,27 +14,13 @@ from datahub.metadata.com.linkedin.pegasus2avro.mxe import MetadataChangeEvent
 class KafkaSourceTest(unittest.TestCase):
     def test_get_schema_str_replace_confluent_ref_avro(self):
 
-        # References external schema by name 'TestTopic1' in the definition of 'my_field1'.
-        schema_str_orig_external_schema_ref_by_name = """
+        # References external schema 'TestTopic1' in the definition of 'my_field1' field.
+        schema_str_orig = """
 {
   "fields": [
     {
       "name": "my_field1",
       "type": "TestTopic1"
-    }
-  ],
-  "name": "TestTopic1Val",
-  "namespace": "io.acryl",
-  "type": "record"
-}
-"""
-        # References external schema by subject 'schema_subject1' in the definition of 'my_field1'.
-        schema_str_orig_external_schema_ref_by_subject = """
-{
-  "fields": [
-    {
-      "name": "my_field1",
-      "type": "schema_subject_1"
     }
   ],
   "name": "TestTopic1Val",
@@ -98,8 +84,9 @@ class KafkaSourceTest(unittest.TestCase):
             new_get_latest_version,
         ):
             schema_str = kafka_source.get_schema_str_replace_confluent_ref_avro(
+                # The external reference would match by name.
                 schema=Schema(
-                    schema_str=schema_str_orig_external_schema_ref_by_name,
+                    schema_str=schema_str_orig,
                     schema_type="AVRO",
                     references=[
                         dict(name="TestTopic1", subject="schema_subject_1", version=1)
@@ -114,11 +101,12 @@ class KafkaSourceTest(unittest.TestCase):
             new_get_latest_version,
         ):
             schema_str = kafka_source.get_schema_str_replace_confluent_ref_avro(
+                # The external reference would match by subject.
                 schema=Schema(
-                    schema_str=schema_str_orig_external_schema_ref_by_subject,
+                    schema_str=schema_str_orig,
                     schema_type="AVRO",
                     references=[
-                        dict(name="TestTopic1", subject="schema_subject_1", version=1)
+                        dict(name="schema_subject_1", subject="TestTopic1", version=1)
                     ],
                 )
             )


### PR DESCRIPTION
Adds support for Kafka confluent external schema resolution by name or subject.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
