### PR TITLE
Auto Save: Added documentation description in local storage

### DIFF
--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -19,7 +19,7 @@ const DocumentationContainer = styled.div`
     margin: 0 auto;
     padding: 40px 0;
     max-width: calc(100% - 10px);
-    margin: 20px;
+    margin: 32px;
 `;
 
 export const DocumentationTab = () => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -23,13 +23,21 @@ const DocumentationContainer = styled.div`
 `;
 
 export const DocumentationTab = () => {
-    const { entityData } = useEntityData();
+    const { urn, entityData } = useEntityData();
     const refetch = useRefetch();
     const description = entityData?.editableProperties?.description || entityData?.properties?.description || '';
     const links = entityData?.institutionalMemory?.elements || [];
+    const localStorageDictionary = localStorage.getItem('editedDescriptions');
 
     const routeToTab = useRouteToTab();
     const isEditing = queryString.parse(useLocation().search, { parseBooleans: true }).editing;
+
+    React.useEffect(() => {
+        const editedDescriptions = (localStorageDictionary && JSON.parse(localStorageDictionary)) || {};
+        if (editedDescriptions.hasOwnProperty(urn)) {
+            routeToTab({ tabName: 'Documentation', tabParams: { editing: true } });
+        }
+    }, [urn, routeToTab, localStorageDictionary]);
 
     return isEditing ? (
         <>

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -18,7 +18,7 @@ import { useEntityData, useRefetch, useRouteToTab } from '../../EntityContext';
 const DocumentationContainer = styled.div`
     margin: 0 auto;
     padding: 40px 0;
-    max-width: 550px;
+    max-width: calc(100% - 10px);
 `;
 
 export const DocumentationTab = () => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -19,6 +19,7 @@ const DocumentationContainer = styled.div`
     margin: 0 auto;
     padding: 40px 0;
     max-width: calc(100% - 10px);
+    margin: 20px;
 `;
 
 export const DocumentationTab = () => {

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/DocumentationTab.tsx
@@ -53,7 +53,9 @@ export const DocumentationTab = () => {
                         {description ? (
                             <MDEditor.Markdown style={{ fontWeight: 400 }} source={description} />
                         ) : (
-                            <Typography.Text type="secondary">No documentation added yet.</Typography.Text>
+                            <Typography.Text type="secondary" style={{ display: 'table', margin: '0 auto' }}>
+                                No documentation added yet.
+                            </Typography.Text>
                         )}
                         <Divider />
                         <LinkList refetch={refetch} />

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DescriptionEditor.tsx
@@ -10,6 +10,7 @@ import TabToolbar from '../../../components/styled/TabToolbar';
 import { GenericEntityUpdate } from '../../../types';
 import { useEntityData, useEntityUpdate, useRefetch } from '../../../EntityContext';
 import { useUpdateDescriptionMutation } from '../../../../../../graphql/mutations.generated';
+import { DiscardDescriptionModal } from './DiscardDescriptionModal';
 
 export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) => {
     const { urn, entityType, entityData } = useEntityData();
@@ -105,9 +106,11 @@ export const DescriptionEditor = ({ onComplete }: { onComplete?: () => void }) =
     return entityData ? (
         <>
             <TabToolbar>
-                <Button type="text" onClick={onComplete}>
-                    Back
-                </Button>
+                <DiscardDescriptionModal
+                    buttonProps={{ type: 'text' }}
+                    isDescriptionUpdated={isDescriptionUpdated}
+                    urn={urn}
+                />
                 <Button onClick={handleSaveDescription} disabled={!isDescriptionUpdated}>
                     <CheckOutlined /> Save
                 </Button>

--- a/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DiscardDescriptionModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/tabs/Documentation/components/DiscardDescriptionModal.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { Modal, Button } from 'antd';
+import { useRouteToTab } from '../../../EntityContext';
+
+type Props = {
+    buttonProps?: Record<string, unknown>;
+    isDescriptionUpdated?: boolean;
+    urn: string;
+};
+
+export const DiscardDescriptionModal = ({ buttonProps, isDescriptionUpdated, urn }: Props) => {
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const routeToTab = useRouteToTab();
+    const localStorageDictionary = localStorage.getItem('editedDescriptions');
+    const editedDescriptions = (localStorageDictionary && JSON.parse(localStorageDictionary)) || {};
+
+    const showModal = () => {
+        if (isDescriptionUpdated) {
+            setIsModalVisible(true);
+        } else {
+            routeToTab({ tabName: 'Documentation' });
+        }
+    };
+
+    const handleCancel = () => {
+        setIsModalVisible(false);
+    };
+
+    const handleDiscard = () => {
+        // Remove the urn_id from localStorage
+        // Updating the localStorage after save
+        delete editedDescriptions[urn];
+        if (Object.keys(editedDescriptions).length === 0) {
+            localStorage.removeItem('editedDescriptions');
+        } else {
+            localStorage.setItem('editedDescriptions', JSON.stringify(editedDescriptions));
+        }
+        routeToTab({ tabName: 'Documentation' });
+    };
+
+    return (
+        <>
+            <Button onClick={showModal} {...buttonProps}>
+                Back
+            </Button>
+            <Modal
+                title="Discard Changes"
+                visible={isModalVisible}
+                destroyOnClose
+                onCancel={handleCancel}
+                footer={[
+                    <Button type="text" onClick={handleCancel}>
+                        Cancel
+                    </Button>,
+                    <Button onClick={handleDiscard}>Discard</Button>,
+                ]}
+            >
+                <p>Changes will not be saved. Do you want to proceed?</p>
+            </Modal>
+        </>
+    );
+};


### PR DESCRIPTION
Added Feature:

1. When the user has paused typing for 5 seconds, updated the localStorage map for the urn to the current description.
2. Added a new button Back that returns the user to non-edit-mode.
3. The save button has been disabled if the change has not been made.
4. Reading the editor data from localStorage
5. If there is an urn in localStorage then the editor mode should be open by default
6. Updated the structure of localStorage.
7. Removed the **discard changes modal**. As the save the description is not mandatory so I removed the modal. Let me know the exact use-case for adding the discard modal 



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the change

https://user-images.githubusercontent.com/86347578/152213535-7ee137cb-1082-437a-9bc2-b7b63c338a0b.mp4

s have been added/updated (if applicable)
