### PR TITLE
fix(glossary): make schema tab no longer default for glossary term

### DIFF
--- a/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entity/glossaryTerm/GlossaryTermEntity.tsx
@@ -61,6 +61,10 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                 useEntityQuery={useGetGlossaryTermQuery as any}
                 tabs={[
                     {
+                        name: 'Related Entities',
+                        component: GlossaryRelatedEntity,
+                    },
+                    {
                         name: 'Schema',
                         component: SchemaTab,
                         properties: {
@@ -72,10 +76,6 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                             enabled: (_, glossaryTerm: GetGlossaryTermQuery) =>
                                 glossaryTerm?.glossaryTerm?.schemaMetadata !== null,
                         },
-                    },
-                    {
-                        name: 'Related Entities',
-                        component: GlossaryRelatedEntity,
                     },
                     {
                         name: 'Related Terms',


### PR DESCRIPTION
Schema tab is not always present. Having it be the default tab creates a strange scenario where landing on a glossary term page does not provide a consistent experience. Updating that. cc @saxo-lalrishav 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
