### PR TITLE
Openapi new auth

### DIFF
--- a/metadata-ingestion/source_docs/openapi.md
+++ b/metadata-ingestion/source_docs/openapi.md
@@ -30,7 +30,9 @@ source:
     name: test_endpoint # this name will appear in DatHub
     url: https://test_endpoint.com/
     swagger_file: classicapi/doc/swagger.json  # where to search for the OpenApi definitions
-    get_token: True  # optional, if you need to get an authentication token beforehand 
+    get_token:  # optional, if you need to get an authentication token beforehand 
+        request_type: get
+        url: api/authentication/login?username={username}&password={password}
     username: your_username  # optional
     password: your_password  # optional
     forced_examples:  # optionals

--- a/metadata-ingestion/source_docs/openapi.md
+++ b/metadata-ingestion/source_docs/openapi.md
@@ -143,7 +143,7 @@ and this URL will be called to get back the needed metadata.
 
 If this tool needs to get an access token to interrogate the endpoints, this can be requested. Two methods are available at the moment:
 
-* 'get' : this requires username/password combination to be present in the url. Note that {username} and {password} are mandatory placeholders. They will be replaced with the true credentials at runtime.
+* 'get' : this requires username/password combination to be present in the url. Note that {username} and {password} are mandatory placeholders. They will be replaced with the true credentials at runtime. Note that username and password will be sent in the request address, so it's unsecure. If your provider allows for the other method, please go for it.
 * 'post' : username and password will be inserted in the body of the POST request
 
 In both cases, username and password are the ones defined in the configuration file.

--- a/metadata-ingestion/source_docs/openapi.md
+++ b/metadata-ingestion/source_docs/openapi.md
@@ -151,7 +151,11 @@ If this tool needs to get an access token to interrogate the endpoints, this can
         url: api/authentication/login?username={username}&password={password}
 ```
 
+Note that {username} and {password} are mandatory placeholders. They will be replaced with the true credentials at runtime.
+
 * 'post' : username and password will be inserted in the body of the POST request
+
+In both cases, username and password are the ones defined in the configuration file.
 
 ### Getting dataset metadata from `forced_example`
 

--- a/metadata-ingestion/source_docs/openapi.md
+++ b/metadata-ingestion/source_docs/openapi.md
@@ -143,16 +143,7 @@ and this URL will be called to get back the needed metadata.
 
 If this tool needs to get an access token to interrogate the endpoints, this can be requested. Two methods are available at the moment:
 
-* 'get' : this requires username/password combination to be present in the url:
-
-```yaml
-    get_token:  # optional, if you need to get an authentication token beforehand 
-        request_type: get
-        url: api/authentication/login?username={username}&password={password}
-```
-
-Note that {username} and {password} are mandatory placeholders. They will be replaced with the true credentials at runtime.
-
+* 'get' : this requires username/password combination to be present in the url. Note that {username} and {password} are mandatory placeholders. They will be replaced with the true credentials at runtime.
 * 'post' : username and password will be inserted in the body of the POST request
 
 In both cases, username and password are the ones defined in the configuration file.

--- a/metadata-ingestion/source_docs/openapi.md
+++ b/metadata-ingestion/source_docs/openapi.md
@@ -139,6 +139,20 @@ and this URL will be called to get back the needed metadata.
 
 ## Config details
 
+### Token authentication
+
+If this tool needs to get an access token to interrogate the endpoints, this can be requested. Two methods are available at the moment:
+
+* 'get' : this requires username/password combination to be present in the url:
+
+```yaml
+    get_token:  # optional, if you need to get an authentication token beforehand 
+        request_type: get
+        url: api/authentication/login?username={username}&password={password}
+```
+
+* 'post' : username and password will be inserted in the body of the POST request
+
 ### Getting dataset metadata from `forced_example`
 
 Suppose you have an endpoint defined in the swagger file, but without example given, and the tool is 

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -50,9 +50,13 @@ class OpenApiConfig(ConfigModel):
         if self.token is not None:  # token based authentication, to be expanded
             if self.token == "":
                 if self.get_token['request_type'] == 'get':
-                    assert 'url' in self.get_token.keys(), "When 'request_type' is set to 'get', a plain url with credentials is expected"
+                    assert 'url_complement' in self.get_token.keys(), "When 'request_type' is set to 'get', an url_complement is needed for the request."
+                    assert '{username}' in self.get_token['url_complement'], "we expect the keyword {username} to be present in the url"
+                    assert '{password}' in self.get_token['url_complement'], "we expect the keyword {password} to be present in the url"
+                    url4req = self.get_token['url_complement'].replace('{username}', self.username)
+                    url4req = url4req.replace('{password}', self.password)
                     self.token = get_tok(
-                        url=self.url, username=self.username, password=self.password, tok_url=self.get_token['url']
+                        url=self.url, username=self.username, password=self.password, tok_url=url4req
                     )
                 elif self.get_token['request_type'] == 'post':
                     self.token = get_tok(

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -2,7 +2,7 @@ import logging
 import time
 import warnings
 from abc import ABC
-from typing import Dict, Generator, Iterable, Tuple, Optional
+from typing import Dict, Generator, Iterable, Optional, Tuple
 
 from datahub.configuration.common import ConfigModel
 from datahub.emitter.mce_builder import make_tag_urn
@@ -49,21 +49,34 @@ class OpenApiConfig(ConfigModel):
     def get_swagger(self) -> Dict:
         if self.token is not None:  # token based authentication, to be expanded
             if self.token == "":
-                if self.get_token['request_type'] == 'get':
-                    assert 'url_complement' in self.get_token.keys(), "When 'request_type' is set to 'get', an url_complement is needed for the request."
-                    assert '{username}' in self.get_token['url_complement'], "we expect the keyword {username} to be present in the url"
-                    assert '{password}' in self.get_token['url_complement'], "we expect the keyword {password} to be present in the url"
-                    url4req = self.get_token['url_complement'].replace('{username}', self.username)
-                    url4req = url4req.replace('{password}', self.password)
-                    self.token = get_tok(
-                        url=self.url, username=self.username, password=self.password, tok_url=url4req
+                if self.get_token["request_type"] == "get":
+                    assert (
+                        "url_complement" in self.get_token.keys()
+                    ), "When 'request_type' is set to 'get', an url_complement is needed for the request."
+                    assert (
+                        "{username}" in self.get_token["url_complement"]
+                    ), "we expect the keyword {username} to be present in the url"
+                    assert (
+                        "{password}" in self.get_token["url_complement"]
+                    ), "we expect the keyword {password} to be present in the url"
+                    url4req = self.get_token["url_complement"].replace(
+                        "{username}", self.username
                     )
-                elif self.get_token['request_type'] == 'post':
+                    url4req = url4req.replace("{password}", self.password)
+                    self.token = get_tok(
+                        url=self.url,
+                        username=self.username,
+                        password=self.password,
+                        tok_url=url4req,
+                    )
+                elif self.get_token["request_type"] == "post":
                     self.token = get_tok(
                         url=self.url, username=self.username, password=self.password
                     )
                 else:
-                    raise KeyError("This tool accepts only 'get' and 'post' as method for getting tokens")
+                    raise KeyError(
+                        "This tool accepts only 'get' and 'post' as method for getting tokens"
+                    )
 
             sw_dict = get_swag_json(
                 self.url, token=self.token, swagger_file=self.swagger_file
@@ -114,7 +127,9 @@ class APISource(Source, ABC):
         elif status_code == 504:
             self.report.report_warning(key=key, reason="Timeout for reaching endpoint")
         else:
-            raise Exception(f"Unable to retrieve endpoint, response code {status_code}, key {key}")
+            raise Exception(
+                f"Unable to retrieve endpoint, response code {status_code}, key {key}"
+            )
 
     def init_dataset(
         self, endpoint_k: str, endpoint_dets: dict

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -44,10 +44,10 @@ class OpenApiConfig(ConfigModel):
     password: str = ""
     forced_examples: dict = {}
     token: Optional[str] = None
-    get_token: Optional[dict] = None
+    get_token: dict = {}
 
     def get_swagger(self) -> Dict:
-        if self.get_token is not None or self.token is not None:
+        if self.get_token or self.token is not None:
             if self.token is not None:
                 ...
             else:

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi.py
@@ -297,7 +297,7 @@ class APISource(Source, ABC):
 
 class OpenApiSource(APISource):
     def __init__(self, config: OpenApiConfig, ctx: PipelineContext):
-        super().__init__(config, ctx, "OpenApi")
+        super().__init__(config, ctx, "openapi")
 
     @classmethod
     def create(cls, config_dict, ctx):

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -212,10 +212,10 @@ def guessing_url_name(url: str, examples: dict) -> str:
         ex2use = root
     elif root[:-1] in examples.keys():
         ex2use = root[:-1]
-    elif root.replace('/', '.') in examples.keys():
-        ex2use = root.replace('/', '.')
-    elif root[:-1].replace('/', '.') in examples.keys():
-        ex2use = root[:-1].replace('/', '.')
+    elif root.replace("/", ".") in examples.keys():
+        ex2use = root.replace("/", ".")
+    elif root[:-1].replace("/", ".") in examples.keys():
+        ex2use = root[:-1].replace("/", ".")
     else:
         return url
 

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -172,7 +172,8 @@ def get_endpoints(sw_dict: dict) -> dict:  # noqa: C901
             if "parameters" in p_o["get"].keys():
                 url_details[p_k]["parameters"] = p_o["get"]["parameters"]
 
-    return url_details
+    ord_d = dict(sorted(url_details.items()))  # sorting for convenience
+    return ord_d
 
 
 def guessing_url_name(url: str, examples: dict) -> str:
@@ -211,6 +212,10 @@ def guessing_url_name(url: str, examples: dict) -> str:
         ex2use = root
     elif root[:-1] in examples.keys():
         ex2use = root[:-1]
+    elif root.replace('/', '.') in examples.keys():
+        ex2use = root.replace('/', '.')
+    elif root[:-1].replace('/', '.') in examples.keys():
+        ex2use = root[:-1].replace('/', '.')
     else:
         return url
 
@@ -332,19 +337,30 @@ def extract_fields(
             return [], {}
 
 
-def get_tok(url: str, username: str = "", password: str = "") -> str:
+def get_tok(url: str, username: str = "", password: str = "", tok_url: str = "") -> str:
     """
     Trying to post username/password to get auth.
-    Simplified version: it expect a POST at api/authenticate
     """
-    data = {"username": username, "password": password}
-    url2post = url + "api/authenticate/"
-    response = requests.post(url2post, data=data)
-    if response.status_code == 200:
-        cont = json.loads(response.content)
-        return cont["tokens"]["access"]
+    token = ""
+    if tok_url == "":
+        # this will make a POST call with username and password
+        data = {"username": username, "password": password}
+        url2post = url + "api/authenticate/"
+        response = requests.post(url2post, data=data)
+        if response.status_code == 200:
+            cont = json.loads(response.content)
+            token = cont["tokens"]["access"]
     else:
-        raise Exception("Unable to get a valid token")
+        # this will make a GET call with username and password
+        url2get = url + tok_url
+        response = requests.get(url2get)
+        if response.status_code == 200:
+            cont = json.loads(response.content)
+            token = cont["token"]
+    if token != "":
+        return token
+    else:
+        raise Exception(f"Unable to get a valid token: {response.text}")
 
 
 def set_metadata(

--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -337,26 +337,34 @@ def extract_fields(
             return [], {}
 
 
-def get_tok(url: str, username: str = "", password: str = "", tok_url: str = "") -> str:
+def get_tok(
+    url: str,
+    username: str = "",
+    password: str = "",
+    tok_url: str = "",
+    method: str = "post",
+) -> str:
     """
     Trying to post username/password to get auth.
     """
     token = ""
-    if tok_url == "":
+    url4req = url + tok_url
+    if method == "post":
         # this will make a POST call with username and password
         data = {"username": username, "password": password}
-        url2post = url + "api/authenticate/"
-        response = requests.post(url2post, data=data)
+        # url2post = url + "api/authenticate/"
+        response = requests.post(url4req, data=data)
         if response.status_code == 200:
             cont = json.loads(response.content)
             token = cont["tokens"]["access"]
-    else:
+    elif method == "get":
         # this will make a GET call with username and password
-        url2get = url + tok_url
-        response = requests.get(url2get)
+        response = requests.get(url4req)
         if response.status_code == 200:
             cont = json.loads(response.content)
             token = cont["token"]
+    else:
+        raise ValueError(f"Method unrecognised: {method}")
     if token != "":
         return token
     else:

--- a/metadata-ingestion/tests/integration/openapi/openapi_mces_golden.json
+++ b/metadata-ingestion/tests/integration/openapi/openapi_mces_golden.json
@@ -3,7 +3,7 @@
     "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:OpenApi,test_openapi.root,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:openapi,test_openapi.root,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {
@@ -95,7 +95,7 @@
     "auditHeader": null,
     "proposedSnapshot": {
         "com.linkedin.pegasus2avro.metadata.snapshot.DatasetSnapshot": {
-            "urn": "urn:li:dataset:(urn:li:dataPlatform:OpenApi,test_openapi.v2,PROD)",
+            "urn": "urn:li:dataset:(urn:li:dataPlatform:openapi,test_openapi.v2,PROD)",
             "aspects": [
                 {
                     "com.linkedin.pegasus2avro.dataset.DatasetProperties": {


### PR DESCRIPTION

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)

## Context
In order to interrogate the endpoints, an authentication via token is required.

Before this PR, only a POST request with username/password in the body was available. Now also a GET method, with username/password directly wrote in the url, is available.