### PR TITLE
fix(ingestion): enforce correct behaviour for commit policy

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/api/committable.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/committable.py
@@ -5,9 +5,9 @@ from typing import Generic, List, Optional, TypeVar
 
 
 class CommitPolicy(Enum):
-    ALWAYS = auto
-    ON_NO_ERRORS = auto
-    ON_NO_ERRORS_AND_NO_WARNINGS = auto
+    ALWAYS = auto()
+    ON_NO_ERRORS = auto()
+    ON_NO_ERRORS_AND_NO_WARNINGS = auto()
 
 
 @dataclass

--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -90,22 +90,59 @@ class TestPipeline(object):
     @pytest.mark.parametrize(
         "commit_policy,source,should_commit",
         [
-            (CommitPolicy.ALWAYS, "FakeSource", True),
-            (CommitPolicy.ON_NO_ERRORS, "FakeSource", True),
-            (CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS, "FakeSource", True),
-            (CommitPolicy.ALWAYS, "FakeSourceWithWarnings", True),
-            (CommitPolicy.ON_NO_ERRORS, "FakeSourceWithWarnings", True),
-            (
+            pytest.param(
+                CommitPolicy.ALWAYS,
+                "FakeSource",
+                True,
+                id="ALWAYS-no-warnings-no-errors",
+            ),
+            pytest.param(
+                CommitPolicy.ON_NO_ERRORS,
+                "FakeSource",
+                True,
+                id="ON_NO_ERRORS-no-warnings-no-errors",
+            ),
+            pytest.param(
+                CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS,
+                "FakeSource",
+                True,
+                id="ON_NO_ERRORS_AND_NO_WARNINGS-no-warnings-no-errors",
+            ),
+            pytest.param(
+                CommitPolicy.ALWAYS,
+                "FakeSourceWithWarnings",
+                True,
+                id="ALWAYS-with-warnings",
+            ),
+            pytest.param(
+                CommitPolicy.ON_NO_ERRORS,
+                "FakeSourceWithWarnings",
+                True,
+                id="ON_NO_ERRORS-with-warnings",
+            ),
+            pytest.param(
                 CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS,
                 "FakeSourceWithWarnings",
                 False,
+                id="ON_NO_ERRORS_AND_NO_WARNINGS-with-warnings",
             ),
-            (CommitPolicy.ALWAYS, "FakeSourceWithFailures", True),
-            (CommitPolicy.ON_NO_ERRORS, "FakeSourceWithFailures", False),
-            (
+            pytest.param(
+                CommitPolicy.ALWAYS,
+                "FakeSourceWithFailures",
+                True,
+                id="ALWAYS-with-errors",
+            ),
+            pytest.param(
+                CommitPolicy.ON_NO_ERRORS,
+                "FakeSourceWithFailures",
+                False,
+                id="ON_NO_ERRORS-with-errors",
+            ),
+            pytest.param(
                 CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS,
                 "FakeSourceWithFailures",
                 False,
+                id="ON_NO_ERRORS_AND_NO_WARNINGS-with-errors",
             ),
         ],
     )
@@ -120,14 +157,14 @@ class TestPipeline(object):
         )
 
         class FakeCommittable(Committable):
-            def __init__(self, commit_policy):
+            def __init__(self, commit_policy: CommitPolicy):
                 self.name = "test_checkpointer"
                 self.commit_policy = commit_policy
 
-            def commit(self):
+            def commit(self) -> None:
                 pass
 
-        fake_committable = FakeCommittable(commit_policy)
+        fake_committable: Committable = FakeCommittable(commit_policy)
 
         with patch.object(
             FakeCommittable, "commit", wraps=fake_committable.commit

--- a/metadata-ingestion/tests/unit/test_pipeline.py
+++ b/metadata-ingestion/tests/unit/test_pipeline.py
@@ -1,9 +1,10 @@
-import unittest
 from typing import Iterable, List, cast
 from unittest.mock import patch
 
+import pytest
 from freezegun import freeze_time
 
+from datahub.ingestion.api.committable import CommitPolicy, Committable
 from datahub.ingestion.api.common import RecordEnvelope, WorkUnit
 from datahub.ingestion.api.source import Source, SourceReport
 from datahub.ingestion.api.transform import Transformer
@@ -21,7 +22,7 @@ from tests.test_helpers.sink_helpers import RecordingSinkReport
 FROZEN_TIME = "2020-04-14 07:00:00"
 
 
-class PipelineTest(unittest.TestCase):
+class TestPipeline(object):
     @patch("datahub.ingestion.source.kafka.KafkaSource.get_workunits", autospec=True)
     @patch("datahub.ingestion.sink.console.ConsoleSink.close", autospec=True)
     @freeze_time(FROZEN_TIME)
@@ -65,8 +66,8 @@ class PipelineTest(unittest.TestCase):
             RecordingSinkReport, pipeline.sink.get_report()
         )
 
-        self.assertEqual(len(sink_report.received_records), 1)
-        self.assertEqual(expected_mce, sink_report.received_records[0].record)
+        assert len(sink_report.received_records) == 1
+        assert expected_mce == sink_report.received_records[0].record
 
     @freeze_time(FROZEN_TIME)
     def test_run_including_registered_transformation(self):
@@ -85,6 +86,60 @@ class PipelineTest(unittest.TestCase):
             }
         )
         assert pipeline
+
+    @pytest.mark.parametrize(
+        "commit_policy,source,should_commit",
+        [
+            (CommitPolicy.ALWAYS, "FakeSource", True),
+            (CommitPolicy.ON_NO_ERRORS, "FakeSource", True),
+            (CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS, "FakeSource", True),
+            (CommitPolicy.ALWAYS, "FakeSourceWithWarnings", True),
+            (CommitPolicy.ON_NO_ERRORS, "FakeSourceWithWarnings", True),
+            (
+                CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS,
+                "FakeSourceWithWarnings",
+                False,
+            ),
+            (CommitPolicy.ALWAYS, "FakeSourceWithFailures", True),
+            (CommitPolicy.ON_NO_ERRORS, "FakeSourceWithFailures", False),
+            (
+                CommitPolicy.ON_NO_ERRORS_AND_NO_WARNINGS,
+                "FakeSourceWithFailures",
+                False,
+            ),
+        ],
+    )
+    @freeze_time(FROZEN_TIME)
+    def test_pipeline_process_commits(self, commit_policy, source, should_commit):
+        pipeline = Pipeline.create(
+            {
+                "source": {"type": f"tests.unit.test_pipeline.{source}"},
+                "sink": {"type": "console"},
+                "run_id": "pipeline_test",
+            }
+        )
+
+        class FakeCommittable(Committable):
+            def __init__(self, commit_policy):
+                self.name = "test_checkpointer"
+                self.commit_policy = commit_policy
+
+            def commit(self):
+                pass
+
+        fake_committable = FakeCommittable(commit_policy)
+
+        with patch.object(
+            FakeCommittable, "commit", wraps=fake_committable.commit
+        ) as mock_commit:
+            pipeline.ctx.register_reporter(fake_committable)
+
+            pipeline.run()
+            # check that we called the commit method once only if should_commit is True
+            if should_commit:
+                mock_commit.assert_called_once()
+            else:
+                mock_commit.assert_not_called()
 
 
 class AddStatusRemovedTransformer(Transformer):
@@ -112,7 +167,7 @@ class FakeSource(Source):
     @classmethod
     def create(cls, config_dict: dict, ctx: PipelineContext) -> "Source":
         assert not config_dict
-        return FakeSource()
+        return cls()
 
     def get_workunits(self) -> Iterable[WorkUnit]:
         return self.work_units
@@ -122,6 +177,24 @@ class FakeSource(Source):
 
     def close(self):
         pass
+
+
+class FakeSourceWithWarnings(FakeSource):
+    def __init__(self):
+        super().__init__()
+        self.source_report.report_warning("test_warning", "warning_text")
+
+    def get_report(self) -> SourceReport:
+        return self.source_report
+
+
+class FakeSourceWithFailures(FakeSource):
+    def __init__(self):
+        super().__init__()
+        self.source_report.report_failure("test_failure", "failure_text")
+
+    def get_report(self) -> SourceReport:
+        return self.source_report
 
 
 def get_initial_mce() -> MetadataChangeEventClass:


### PR DESCRIPTION
fixes a bug in the CommitPolicy enum that was causing an incorrect behaviour during the pipeline `process_commits` stage.

```
class CommitPolicy(Enum):
    ALWAYS = auto
    ON_NO_ERRORS = auto
    ON_NO_ERRORS_AND_NO_WARNINGS = auto
```
meant that ```ALWAYS == ON_NO_ERRORS == ON_NO_ERRORS_AND_NO_WARNINGS``` that would cause an incorrect
behaviour when calling the `process_commits()` method in the pipeline


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
