### PR TITLE
fix(ui): Fixing domains double icon on profile

### DIFF
--- a/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/header/EntityHeader.tsx
@@ -123,12 +123,14 @@ export const EntityHeader = () => {
         <HeaderContainer>
             <MainHeaderContent>
                 <PlatformContent>
-                    <LogoContainer>
-                        {(!!platformLogoUrl && (
-                            <PreviewImage preview={false} src={platformLogoUrl} alt={platformName} />
-                        )) ||
-                            entityLogoComponent}
-                    </LogoContainer>
+                    {platformName && (
+                        <LogoContainer>
+                            {(!!platformLogoUrl && (
+                                <PreviewImage preview={false} src={platformLogoUrl} alt={platformName} />
+                            )) ||
+                                entityLogoComponent}
+                        </LogoContainer>
+                    )}
                     <PlatformText>{platformName}</PlatformText>
                     {(platformLogoUrl || platformName) && <PlatformDivider />}
                     {typeIcon && <TypeIcon>{typeIcon}</TypeIcon>}

--- a/metadata-ingestion/examples/recipes/file_to_datahub_rest.yml
+++ b/metadata-ingestion/examples/recipes/file_to_datahub_rest.yml
@@ -3,7 +3,7 @@
 source:
   type: "file"
   config:
-    filename: "../smoke-test/sample_bq_data.json"
+    filename: "./examples/mce_files/bootstrap_mce.json"
 
 # see https://datahubproject.io/docs/metadata-ingestion/sink_docs/datahub for complete documentation
 sink:


### PR DESCRIPTION
Domains icon appears twice in the top-left of the Domain profile. Addressing!

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
