### PR TITLE
feat(ui): Add display name & title to editable corp user properties.

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/CorpUserType.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/CorpUserType.java
@@ -138,6 +138,9 @@ public class CorpUserType implements SearchableEntityType<CorpUser>, MutableType
 
     private RecordTemplate mapCorpUserEditableInfo(CorpUserUpdateInput input, Optional<CorpUserEditableInfo> existing) {
         CorpUserEditableInfo result = existing.orElseGet(() -> new CorpUserEditableInfo());
+        if (input.getDisplayName() != null) {
+            result.setDisplayName(input.getDisplayName());
+        }
         if (input.getAboutMe() != null) {
             result.setAboutMe(input.getAboutMe());
         }
@@ -161,6 +164,9 @@ public class CorpUserType implements SearchableEntityType<CorpUser>, MutableType
         }
         if (input.getEmail() != null) {
             result.setEmail(input.getEmail());
+        }
+        if (input.getTitle() != null) {
+            result.setTitle(input.getTitle());
         }
 
         return result;

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserEditableInfoMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserEditableInfoMapper.java
@@ -21,6 +21,8 @@ public class CorpUserEditableInfoMapper implements ModelMapper<com.linkedin.iden
     @Override
     public CorpUserEditableProperties apply(@Nonnull final com.linkedin.identity.CorpUserEditableInfo info) {
         final CorpUserEditableProperties result = new CorpUserEditableProperties();
+        result.setDisplayName(info.getDisplayName());
+        result.setTitle(info.getTitle());
         result.setAboutMe(info.getAboutMe());
         result.setSkills(info.getSkills());
         result.setTeams(info.getTeams());

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserPropertiesMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/corpuser/mappers/CorpUserPropertiesMapper.java
@@ -21,6 +21,8 @@ public class CorpUserPropertiesMapper implements ModelMapper<com.linkedin.identi
   @Override
   public CorpUserProperties apply(@Nonnull final com.linkedin.identity.CorpUserInfo info) {
     final CorpUserProperties result = new CorpUserProperties();
+    result.setDisplayName(info.getDisplayName());
+    result.setTitle(info.getTitle());
     result.setActive(info.isActive());
     result.setCountryCode(info.getCountryCode());
     result.setDepartmentId(info.getDepartmentId());

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -2218,6 +2218,16 @@ Additional read write info about a user
 """
 type CorpUserEditableInfo {
     """
+    Display name to show on DataHub
+    """
+    displayName: String
+
+    """
+    Title to show on DataHub
+    """
+    title: String
+
+    """
     About me section of the user
     """
     aboutMe: String
@@ -2242,6 +2252,16 @@ type CorpUserEditableInfo {
 Additional read write properties about a user
 """
 type CorpUserEditableProperties {
+    """
+    Display name to show on DataHub
+    """
+    displayName: String
+
+    """
+    Title to show on DataHub
+    """
+    title: String
+
     """
     About me section of the user
     """
@@ -2283,6 +2303,16 @@ type CorpUserEditableProperties {
 Arguments provided to update a CorpUser Entity
 """
 input CorpUserUpdateInput {
+    """
+    Display name to show on DataHub
+    """
+    displayName: String
+
+    """
+    Title to show on DataHub
+    """
+    title: String
+
     """
     About me section of the user
     """

--- a/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserEditableInfo.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/identity/CorpUserEditableInfo.pdl
@@ -42,6 +42,16 @@ record CorpUserEditableInfo {
   pictureLink: Url = "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/default_avatar.png"
 
   /**
+   * DataHub-native display name
+   */
+  displayName: optional string
+
+  /**
+   * DataHub-native Title, e.g. 'Software Engineer'
+   */
+  title: optional string
+
+  /**
    * Slack handle for the user
    */
   slack: optional string

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1675,6 +1675,16 @@
       "doc" : "A URL which points to a picture which user wants to set as a profile photo",
       "default" : "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/default_avatar.png"
     }, {
+      "name" : "displayName",
+      "type" : "string",
+      "doc" : "DataHub-native display name",
+      "optional" : true
+    }, {
+      "name" : "title",
+      "type" : "string",
+      "doc" : "DataHub-native Title, e.g. 'Software Engineer'",
+      "optional" : true
+    }, {
       "name" : "slack",
       "type" : "string",
       "doc" : "Slack handle for the user",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -2099,6 +2099,16 @@
                     "doc" : "A URL which points to a picture which user wants to set as a profile photo",
                     "default" : "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/default_avatar.png"
                   }, {
+                    "name" : "displayName",
+                    "type" : "string",
+                    "doc" : "DataHub-native display name",
+                    "optional" : true
+                  }, {
+                    "name" : "title",
+                    "type" : "string",
+                    "doc" : "DataHub-native Title, e.g. 'Software Engineer'",
+                    "optional" : true
+                  }, {
                     "name" : "slack",
                     "type" : "string",
                     "doc" : "Slack handle for the user",

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -1432,6 +1432,16 @@
       "doc" : "A URL which points to a picture which user wants to set as a profile photo",
       "default" : "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/default_avatar.png"
     }, {
+      "name" : "displayName",
+      "type" : "string",
+      "doc" : "DataHub-native display name",
+      "optional" : true
+    }, {
+      "name" : "title",
+      "type" : "string",
+      "doc" : "DataHub-native Title, e.g. 'Software Engineer'",
+      "optional" : true
+    }, {
       "name" : "slack",
       "type" : "string",
       "doc" : "Slack handle for the user",


### PR DESCRIPTION
...For display name and title authored natively on datahub. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
