### PR TITLE
fix(ui): Fix add glossary term modal

### DIFF
--- a/datahub-web-react/src/app/shared/tags/AddTagTermModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagTermModal.tsx
@@ -75,15 +75,15 @@ export default function AddTagTermModal({
     const entityRegistry = useEntityRegistry();
     const [addTagMutation] = useAddTagMutation();
     const [addTermMutation] = useAddTermMutation();
-    const [tagSearch, { data: tagSearchData }] = useGetSearchResultsLazyQuery();
-    const tagSearchResults = tagSearchData?.search?.searchResults || [];
+    const [tagTermSearch, { data: tagTermSearchData }] = useGetSearchResultsLazyQuery();
+    const tagSearchResults = tagTermSearchData?.search?.searchResults || [];
 
     const handleSearch = (text: string) => {
         if (text.length > 0) {
-            tagSearch({
+            tagTermSearch({
                 variables: {
                     input: {
-                        type: EntityType.Tag,
+                        type,
                         query: text,
                         start: 0,
                         count: 10,


### PR DESCRIPTION
In a change yesterday, the search functionality for glossary terms + tags changed when adding via modal. This inadvertently broke adding glossary terms. Not yet released. 


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
