### PR TITLE
fix(docs) Fix doc on modelDocUpload

### DIFF
--- a/docs/modeling/metadata-model.md
+++ b/docs/modeling/metadata-model.md
@@ -93,7 +93,7 @@ The metadata model documentation can be generated and uploaded into a running Da
 ./gradlew :metadata-ingestion:modelDocUpload
 ```
 
-**_NOTE_**: This will upload the model documentation to the DataHub instance running at the environment variable `$DATAHUB_HOST` (http://localhost:8080 by default)
+**_NOTE_**: This will upload the model documentation to the DataHub instance running at the environment variable `$DATAHUB_SERVER` (http://localhost:8080 by default)
 
 It will also generate a few files under `metadata-ingestion/generated/docs` such as a dot file called `metadata_graph.dot` that you can use to visualize the relationships among the entities.
 


### PR DESCRIPTION
Update the doc to use the same environment variable as the script
to configure which Datahub server to upload the model doc to.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
