### PR TITLE
feat(ui): Host platform images on datahub-web-react

### DIFF
--- a/datahub-web-react/craco.config.js
+++ b/datahub-web-react/craco.config.js
@@ -17,6 +17,7 @@ module.exports = {
     webpack: {
         plugins: {
             add: [
+                // Self host images by copying them to the build directory
                 new CopyWebpackPlugin({
                     patterns: [{ from: 'src/images', to: 'platforms' }],
                 }),

--- a/datahub-web-react/craco.config.js
+++ b/datahub-web-react/craco.config.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const CracoAntDesignPlugin = require('craco-antd');
 const path = require('path');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const themeConfig = require(`./src/conf/theme/${process.env.REACT_APP_THEME_CONFIG}`);
 
@@ -13,6 +14,15 @@ function addLessPrefixToKeys(styles) {
 }
 
 module.exports = {
+    webpack: {
+        plugins: {
+            add: [
+                new CopyWebpackPlugin({
+                    patterns: [{ from: 'src/images', to: 'platforms' }],
+                }),
+            ],
+        },
+    },
     plugins: [
         {
             plugin: CracoAntDesignPlugin,

--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -134,6 +134,7 @@
         "@typescript-eslint/eslint-plugin": "^4.25.0",
         "@typescript-eslint/parser": "^4.25.0",
         "babel-loader": "8.2.2",
+        "copy-webpack-plugin": "6.4.1",
         "eslint": "^7.27.0",
         "eslint-config-airbnb-typescript": "^12.3.1",
         "eslint-config-prettier": "^8.3.0",

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -5900,6 +5900,23 @@ copy-to-clipboard@^3.2.0:
   dependencies:
     toggle-selection "^1.0.6"
 
+copy-webpack-plugin@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-6.4.1.tgz#138cd9b436dbca0a6d071720d5414848992ec47e"
+  integrity sha512-MXyPCjdPVx5iiWyl40Va3JGh27bKzOTNY3NjUTrosD2q7dR/cLD0013uqJ3BpFbUjyONINjb6qI7nDIJujrMbA==
+  dependencies:
+    cacache "^15.0.5"
+    fast-glob "^3.2.4"
+    find-cache-dir "^3.3.1"
+    glob-parent "^5.1.1"
+    globby "^11.0.1"
+    loader-utils "^2.0.0"
+    normalize-path "^3.0.0"
+    p-limit "^3.0.2"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    webpack-sources "^1.4.3"
+
 core-js-compat@^3.6.2, core-js-compat@^3.9.0, core-js-compat@^3.9.1:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.13.0.tgz#a88f5fa81d8e9b15d7f98abc4447a4dfca2a358f"
@@ -7775,6 +7792,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.4:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -8262,7 +8290,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
+glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -11303,7 +11331,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.2:
+micromatch@^4.0.2, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==

--- a/metadata-ingestion/examples/mce_files/data_platforms.json
+++ b/metadata-ingestion/examples/mce_files/data_platforms.json
@@ -11,7 +11,7 @@
               "name": "adlsGen1",
               "displayName": "Azure Data Lake (Gen 1)",
               "type": "FILE_SYSTEM",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/adlslogo.png"
+              "logoUrl": "/assets/platforms/adlslogo.png"
             }
           }
         ]
@@ -31,7 +31,7 @@
               "name": "adlsGen2",
               "displayName": "Azure Data Lake (Gen 2)",
               "type": "FILE_SYSTEM",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/adlslogo.png"
+              "logoUrl": "/assets/platforms/adlslogo.png"
             }
           }
         ]
@@ -70,7 +70,7 @@
               "name": "couchbase",
               "displayName": "Couchbase",
               "type": "KEY_VALUE_STORE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/couchbaselogo.png"
+              "logoUrl": "/assets/platforms/couchbaselogo.png"
             }
           }
         ]
@@ -109,7 +109,7 @@
               "name": "hdfs",
               "displayName": "HDFS",
               "type": "FILE_SYSTEM",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/hadooplogo.png"
+              "logoUrl": "/assets/platforms/hadooplogo.png"
             }
           }
         ]
@@ -129,7 +129,7 @@
               "name": "hive",
               "displayName": "Hive",
               "type": "FILE_SYSTEM",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/hivelogo.png"
+              "logoUrl": "/assets/platforms/hivelogo.png"
             }
           }
         ]
@@ -149,7 +149,7 @@
               "name": "s3",
               "displayName": "AWS S3",
               "type": "FILE_SYSTEM",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/s3.png"
+              "logoUrl": "/assets/platforms/s3.png"
             }
           }
         ]
@@ -169,7 +169,7 @@
               "name": "kafka",
               "displayName": "Kafka",
               "type": "MESSAGE_BROKER",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/kafkalogo.png"
+              "logoUrl": "/assets/platforms/kafkalogo.png"
             }
           }
         ]
@@ -189,7 +189,7 @@
               "name": "kusto",
               "displayName": "Kusto",
               "type": "OLAP_DATASTORE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/kustologo.png"
+              "logoUrl": "/assets/platforms/kustologo.png"
             }
           }
         ]
@@ -209,7 +209,7 @@
               "name": "mode",
               "displayName": "Mode",
               "type": "KEY_VALUE_STORE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/modelogo.png"
+              "logoUrl": "/assets/platforms/modelogo.png"
             }
           }
         ]
@@ -229,7 +229,7 @@
               "name": "mongodb",
               "displayName": "MongoDB",
               "type": "KEY_VALUE_STORE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mongodblogo.png"
+              "logoUrl": "/assets/platforms/mongodblogo.png"
             }
           }
         ]
@@ -249,7 +249,7 @@
               "name": "mysql",
               "displayName": "MySQL",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mysqllogo.png"
+              "logoUrl": "/assets/platforms/mysqllogo.png"
             }
           }
         ]
@@ -269,7 +269,7 @@
               "name": "oracle",
               "displayName": "Oracle",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/oraclelogo.png"
+              "logoUrl": "/assets/platforms/oraclelogo.png"
             }
           }
         ]
@@ -289,7 +289,7 @@
               "name": "pinot",
               "displayName": "Pinot",
               "type": "OLAP_DATASTORE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/pinotlogo.png"
+              "logoUrl": "/assets/platforms/pinotlogo.png"
             }
           }
         ]
@@ -309,7 +309,7 @@
               "name": "postgres",
               "displayName": "PostgreSQL",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/postgreslogo.png"
+              "logoUrl": "/assets/platforms/postgreslogo.png"
             }
           }
         ]
@@ -329,7 +329,7 @@
               "name": "presto",
               "displayName": "Presto",
               "type": "QUERY_ENGINE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/prestologo.png"
+              "logoUrl": "/assets/platforms/prestologo.png"
             }
           }
         ]
@@ -349,7 +349,7 @@
               "name": "teradata",
               "displayName": "Teradata",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/teradatalogo.png"
+              "logoUrl": "/assets/platforms/teradatalogo.png"
             }
           }
         ]
@@ -388,7 +388,7 @@
               "name": "snowflake",
               "displayName": "Snowflake",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/snowflakelogo.png"
+              "logoUrl": "/assets/platforms/snowflakelogo.png"
             }
           }
         ]
@@ -408,7 +408,7 @@
               "name": "redshift",
               "displayName": "Redshift",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/redshiftlogo.png"
+              "logoUrl": "/assets/platforms/redshiftlogo.png"
             }
           }
         ]
@@ -428,7 +428,7 @@
               "name": "mssql",
               "displayName": "SQL Server",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mssqllogo.png"
+              "logoUrl": "/assets/platforms/mssqllogo.png"
             }
           }
         ]
@@ -448,7 +448,7 @@
               "name": "bigquery",
               "displayName": "BigQuery",
               "type": "RELATIONAL_DB",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/bigquerylogo.png"
+              "logoUrl": "/assets/platforms/bigquerylogo.png"
             }
           }
         ]
@@ -468,7 +468,7 @@
               "name": "druid",
               "displayName": "Druid",
               "type": "OLAP_DATASTORE",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/druidlogo.png"
+              "logoUrl": "/assets/platforms/druidlogo.png"
             }
           }
         ]
@@ -488,7 +488,7 @@
               "name": "looker",
               "displayName": "Looker",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/lookerlogo.png"
+              "logoUrl": "/assets/platforms/lookerlogo.png"
             }
           }
         ]
@@ -508,7 +508,7 @@
               "name": "feast",
               "displayName": "Feast",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/feastlogo.png"
+              "logoUrl": "/assets/platforms/feastlogo.png"
             }
           }
         ]
@@ -528,7 +528,7 @@
               "name": "sagemaker",
               "displayName": "SageMaker",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/sagemakerlogo.png"
+              "logoUrl": "/assets/platforms/sagemakerlogo.png"
             }
           }
         ]
@@ -548,7 +548,7 @@
               "name": "glue",
               "displayName": "Glue",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/gluelogo.png"
+              "logoUrl": "/assets/platforms/gluelogo.png"
             }
           }
         ]
@@ -568,7 +568,7 @@
               "name": "redash",
               "displayName": "Redash",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/redashlogo.png"
+              "logoUrl": "/assets/platforms/redashlogo.png"
             }
           }
         ]
@@ -588,7 +588,7 @@
               "name": "tableau",
               "displayName": "Tableau",
               "type": "OTHERS",
-              "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/tableaulogo.png"
+              "logoUrl": "/assets/platforms/tableaulogo.png"
             }
           }
         ]

--- a/metadata-service/war/src/main/resources/boot/data_platforms.json
+++ b/metadata-service/war/src/main/resources/boot/data_platforms.json
@@ -6,7 +6,7 @@
       "name": "adlsGen1",
       "displayName": "Azure Data Lake (Gen 1)",
       "type": "FILE_SYSTEM",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/adlslogo.png"
+      "logoUrl": "/assets/platforms/adlslogo.png"
     }
   },
   {
@@ -16,7 +16,7 @@
       "name": "adlsGen2",
       "displayName": "Azure Data Lake (Gen 2)",
       "type": "FILE_SYSTEM",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/adlslogo.png"
+      "logoUrl": "/assets/platforms/adlslogo.png"
     }
   },
   {
@@ -26,7 +26,7 @@
       "name": "airflow",
       "displayName": "Airflow",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/airflowlogo.png"
+      "logoUrl": "/assets/platforms/airflowlogo.png"
     }
   },
   {
@@ -45,7 +45,7 @@
       "name": "couchbase",
       "displayName": "Couchbase",
       "type": "KEY_VALUE_STORE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/couchbaselogo.png"
+      "logoUrl": "/assets/platforms/couchbaselogo.png"
     }
   },
   {
@@ -64,7 +64,7 @@
       "name": "hdfs",
       "displayName": "HDFS",
       "type": "FILE_SYSTEM",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/hadooplogo.png"
+      "logoUrl": "/assets/platforms/hadooplogo.png"
     }
   },
   {
@@ -74,7 +74,7 @@
       "name": "hive",
       "displayName": "Hive",
       "type": "FILE_SYSTEM",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/hivelogo.png"
+      "logoUrl": "/assets/platforms/hivelogo.png"
     }
   },
   {
@@ -84,7 +84,7 @@
       "name": "s3",
       "displayName": "AWS S3",
       "type": "FILE_SYSTEM",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/s3.png"
+      "logoUrl": "/assets/platforms/s3.png"
     }
   },
   {
@@ -94,7 +94,7 @@
       "name": "kafka",
       "displayName": "Kafka",
       "type": "MESSAGE_BROKER",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/kafkalogo.png"
+      "logoUrl": "/assets/platforms/kafkalogo.png"
     }
   },
   {
@@ -104,7 +104,7 @@
       "name": "kafka-connect",
       "displayName": "Kafka Connect",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/kafkalogo.png"
+      "logoUrl": "/assets/platforms/kafkalogo.png"
     }
   },
   {
@@ -114,7 +114,7 @@
       "name": "kusto",
       "displayName": "Kusto",
       "type": "OLAP_DATASTORE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/kustologo.png"
+      "logoUrl": "/assets/platforms/kustologo.png"
     }
   },
   {
@@ -124,7 +124,7 @@
       "name": "mode",
       "displayName": "Mode",
       "type": "KEY_VALUE_STORE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/modelogo.png"
+      "logoUrl": "/assets/platforms/modelogo.png"
     }
   },
   {
@@ -134,7 +134,7 @@
       "name": "mongodb",
       "displayName": "MongoDB",
       "type": "KEY_VALUE_STORE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mongodblogo.png"
+      "logoUrl": "/assets/platforms/mongodblogo.png"
     }
   },
   {
@@ -144,7 +144,7 @@
       "name": "mysql",
       "displayName": "MySQL",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mysqllogo.png"
+      "logoUrl": "/assets/platforms/mysqllogo.png"
     }
   },
   {
@@ -154,7 +154,7 @@
       "name": "mariadb",
       "displayName": "MariaDB",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mariadblogo.png"
+      "logoUrl": "/assets/platforms/mariadblogo.png"
     }
   },
   {
@@ -164,7 +164,7 @@
       "name": "openapi",
       "displayName": "OpenAPI",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/openapilogo.png"
+      "logoUrl": "/assets/platforms/openapilogo.png"
     }
   },
   {
@@ -174,7 +174,7 @@
       "name": "oracle",
       "displayName": "Oracle",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/oraclelogo.png"
+      "logoUrl": "/assets/platforms/oraclelogo.png"
     }
   },
   {
@@ -184,7 +184,7 @@
       "name": "pinot",
       "displayName": "Pinot",
       "type": "OLAP_DATASTORE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/pinotlogo.png"
+      "logoUrl": "/assets/platforms/pinotlogo.png"
     }
   },
   {
@@ -194,7 +194,7 @@
       "name": "postgres",
       "displayName": "PostgreSQL",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/postgreslogo.png"
+      "logoUrl": "/assets/platforms/postgreslogo.png"
     }
   },
   {
@@ -204,7 +204,7 @@
       "name": "presto",
       "displayName": "Presto",
       "type": "QUERY_ENGINE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/prestologo.png"
+      "logoUrl": "/assets/platforms/prestologo.png"
     }
   },
   {
@@ -214,7 +214,7 @@
       "name": "tableau",
       "displayName": "Tableau",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/tableaulogo.png"
+      "logoUrl": "/assets/platforms/tableaulogo.png"
     }
   },
   {
@@ -224,7 +224,7 @@
       "name": "teradata",
       "displayName": "Teradata",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/teradatalogo.png"
+      "logoUrl": "/assets/platforms/teradatalogo.png"
     }
   },
   {
@@ -243,7 +243,7 @@
       "name": "snowflake",
       "displayName": "Snowflake",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/snowflakelogo.png"
+      "logoUrl": "/assets/platforms/snowflakelogo.png"
     }
   },
   {
@@ -253,7 +253,7 @@
       "name": "redshift",
       "displayName": "Redshift",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/redshiftlogo.png"
+      "logoUrl": "/assets/platforms/redshiftlogo.png"
     }
   },
   {
@@ -263,7 +263,7 @@
       "name": "mssql",
       "displayName": "SQL Server",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/mssqllogo.png"
+      "logoUrl": "/assets/platforms/mssqllogo.png"
     }
   },
   {
@@ -273,7 +273,7 @@
       "name": "bigquery",
       "displayName": "BigQuery",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/bigquerylogo.png"
+      "logoUrl": "/assets/platforms/bigquerylogo.png"
     }
   },
   {
@@ -283,7 +283,7 @@
       "name": "druid",
       "displayName": "Druid",
       "type": "OLAP_DATASTORE",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/druidlogo.png"
+      "logoUrl": "/assets/platforms/druidlogo.png"
     }
   },
   {
@@ -293,7 +293,7 @@
       "name": "looker",
       "displayName": "Looker",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/lookerlogo.png"
+      "logoUrl": "/assets/platforms/lookerlogo.png"
     }
   },
   {
@@ -303,7 +303,7 @@
       "name": "feast",
       "displayName": "Feast",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/feastlogo.png"
+      "logoUrl": "/assets/platforms/feastlogo.png"
     }
   },
   {
@@ -313,7 +313,7 @@
       "name": "sagemaker",
       "displayName": "SageMaker",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/sagemakerlogo.png"
+      "logoUrl": "/assets/platforms/sagemakerlogo.png"
     }
   },
   {
@@ -323,7 +323,7 @@
       "name": "glue",
       "displayName": "Glue",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/gluelogo.png"
+      "logoUrl": "/assets/platforms/gluelogo.png"
     }
   },
   {
@@ -333,7 +333,7 @@
       "name": "redash",
       "displayName": "Redash",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/redashlogo.png"
+      "logoUrl": "/assets/platforms/redashlogo.png"
     }
   },
   {
@@ -343,7 +343,7 @@
       "name": "athena",
       "displayName": "AWS Athena",
       "type": "RELATIONAL_DB",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/awsathenalogo.png"
+      "logoUrl": "/assets/platforms/awsathenalogo.png"
     }
   },
   {
@@ -353,7 +353,7 @@
       "name": "spark",
       "displayName": "Spark",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/sparklogo.png"
+      "logoUrl": "/assets/platforms/sparklogo.png"
     }
   },
   {
@@ -363,7 +363,7 @@
       "name": "dbt",
       "displayName": "dbt",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/dbtlogo.png"
+      "logoUrl": "/assets/platforms/dbtlogo.png"
     }
   },
   {
@@ -373,7 +373,7 @@
       "name": "elasticsearch",
       "displayName": "Elasticsearch",
       "type": "OTHERS",
-      "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/elasticsearchlogo.png"
+      "logoUrl": "/assets/platforms/elasticsearchlogo.png"
     }
   }
 ]


### PR DESCRIPTION
Adds capability for users to host their platform images (from `src/images`) on their react app instead.

Context: https://datahubspace.slack.com/archives/CV2UXSE9L/p1644477881072309

## Changes
- Installs [CopyWebpackPlugin](https://webpack.js.org/plugins/copy-webpack-plugin/) to copy `src/images` to `platforms`
- [Updated] `data_platforms.json` files are updated to use the new relative url

## Sample Usage:
```jsonc
// data_platforms.json
{
    "urn": "urn:li:dataPlatform:hive",
    "aspect": {
      "datasetNameDelimiter": ".",
      "name": "hive",
      "displayName": "Hive",
      "type": "FILE_SYSTEM",
      - "logoUrl": "https://raw.githubusercontent.com/linkedin/datahub/master/datahub-web-react/src/images/hivelogo.png"
      + "logoUrl": "/assets/platforms/hivelogo.png"
    }
  },
``` 

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
