### PR TITLE
fix(ingestion): add constraint for urllib3

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -96,7 +96,7 @@ snowflake_common = {
 plugins: Dict[str, Set[str]] = {
     # Sink plugins.
     "datahub-kafka": kafka_common,
-    "datahub-rest": {"requests"},
+    "datahub-rest": {"requests", "urllib3>=1.26"},
     # Integrations.
     "airflow": {
         "apache-airflow >= 1.10.2",


### PR DESCRIPTION
Only urllib3 1.26+ has the allowed_methods kwarg, which we use for retry configuration.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
