### PR TITLE
refactor(metadata-io/test): common ElasticsearchContainer and ability to override from environment.

### DIFF
--- a/metadata-io/src/test/java/com/linkedin/metadata/ElasticTestUtils.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/ElasticTestUtils.java
@@ -1,0 +1,48 @@
+package com.linkedin.metadata;
+
+import org.apache.http.HttpHost;
+import org.apache.http.impl.nio.reactor.IOReactorConfig;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.annotation.Nonnull;
+
+public class ElasticTestUtils {
+    private ElasticTestUtils() {
+    }
+
+    private static final String ELASTIC_VERSION = "7.9.3";
+    private static final String ELASTIC_IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch";
+    private static final String ENV_ELASTIC_IMAGE_FULL_NAME = System.getenv("ELASTIC_IMAGE_FULL_NAME");
+    private static final String ELASTIC_IMAGE_FULL_NAME = ENV_ELASTIC_IMAGE_FULL_NAME != null
+            ? ENV_ELASTIC_IMAGE_FULL_NAME : ELASTIC_IMAGE_NAME + ":" + ELASTIC_VERSION;
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse(ELASTIC_IMAGE_FULL_NAME)
+            .asCompatibleSubstituteFor(ELASTIC_IMAGE_NAME);
+
+    private static final int HTTP_PORT = 9200;
+
+    // A helper method to create an ElasticseachContainer defaulting to the current image and version, with the ability
+    // within firewalled environments to override with an environment variable to point to the offline repository.
+    @Nonnull
+    public static final ElasticsearchContainer getNewElasticsearchContainer() {
+        return new ElasticsearchContainer(DOCKER_IMAGE_NAME);
+    }
+
+    // A helper method to construct a standard rest client for Elastic search.
+    @Nonnull
+    public static RestHighLevelClient buildRestClient(ElasticsearchContainer elasticsearchContainer) {
+        final RestClientBuilder builder =
+                RestClient.builder(new HttpHost("localhost", elasticsearchContainer.getMappedPort(HTTP_PORT), "http"))
+                        .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setDefaultIOReactorConfig(
+                                IOReactorConfig.custom().setIoThreadCount(1).build()));
+
+        builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.
+                setConnectionRequestTimeout(3000));
+
+        return new RestHighLevelClient(builder);
+    }
+
+}

--- a/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/graph/ElasticSearchGraphServiceTest.java
@@ -2,6 +2,7 @@ package com.linkedin.metadata.graph;
 
 import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.ElasticSearchTestUtils;
+import com.linkedin.metadata.ElasticTestUtils;
 import com.linkedin.metadata.graph.elastic.ESGraphQueryDAO;
 import com.linkedin.metadata.graph.elastic.ESGraphWriteDAO;
 import com.linkedin.metadata.graph.elastic.ElasticSearchGraphService;
@@ -15,10 +16,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.SkipException;
@@ -40,15 +37,12 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   private final String _indexName = _indexConvention.getIndexName(INDEX_NAME);
   private ElasticSearchGraphService _client;
 
-  private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
-  private static final int HTTP_PORT = 9200;
-
   @BeforeTest
   public void setup() {
-    _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    _elasticsearchContainer = ElasticTestUtils.getNewElasticsearchContainer();
     checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
-    _searchClient = buildRestClient();
+    _searchClient = ElasticTestUtils.buildRestClient(_elasticsearchContainer);
     _client = buildService();
     _client.configure();
   }
@@ -57,19 +51,6 @@ public class ElasticSearchGraphServiceTest extends GraphServiceTestBase {
   public void wipe() throws Exception {
     _client.clear();
     syncAfterWrite();
-  }
-
-  @Nonnull
-  private RestHighLevelClient buildRestClient() {
-    final RestClientBuilder builder =
-        RestClient.builder(new HttpHost("localhost", _elasticsearchContainer.getMappedPort(HTTP_PORT), "http"))
-            .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setDefaultIOReactorConfig(
-                IOReactorConfig.custom().setIoThreadCount(1).build()));
-
-    builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.
-        setConnectionRequestTimeout(3000));
-
-    return new RestHighLevelClient(builder);
   }
 
   @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/ElasticSearchServiceTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.linkedin.common.urn.TestEntityUrn;
 import com.linkedin.common.urn.Urn;
+import com.linkedin.metadata.ElasticTestUtils;
 import com.linkedin.metadata.browse.BrowseResult;
 import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
@@ -20,13 +21,9 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import java.util.Collections;
 import javax.annotation.Nonnull;
-import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -50,19 +47,17 @@ public class ElasticSearchServiceTest {
   private SettingsBuilder _settingsBuilder;
   private ElasticSearchService _elasticSearchService;
 
-  private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
-  private static final int HTTP_PORT = 9200;
   private static final String ENTITY_NAME = "testEntity";
 
   @BeforeTest
   public void setup() {
     _entityRegistry = new SnapshotEntityRegistry(new Snapshot());
     _indexConvention = new IndexConventionImpl(null);
-    _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    _elasticsearchContainer = ElasticTestUtils.getNewElasticsearchContainer();
     _settingsBuilder = new SettingsBuilder(Collections.emptyList());
     checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
-    _searchClient = buildRestClient();
+    _searchClient = ElasticTestUtils.buildRestClient(_elasticsearchContainer);
     _elasticSearchService = buildService();
     _elasticSearchService.configure();
   }
@@ -71,19 +66,6 @@ public class ElasticSearchServiceTest {
   public void wipe() throws Exception {
     _elasticSearchService.clear();
     syncAfterWrite(_searchClient);
-  }
-
-  @Nonnull
-  private RestHighLevelClient buildRestClient() {
-    final RestClientBuilder builder =
-        RestClient.builder(new HttpHost("localhost", _elasticsearchContainer.getMappedPort(HTTP_PORT), "http"))
-            .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setDefaultIOReactorConfig(
-                IOReactorConfig.custom().setIoThreadCount(1).build()));
-
-    builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.
-        setConnectionRequestTimeout(3000));
-
-    return new RestHighLevelClient(builder);
   }
 
   public static BulkProcessor getBulkProcessor(RestHighLevelClient searchClient) {

--- a/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/systemmetadata/ElasticSearchSystemMetadataServiceTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.systemmetadata;
 
+import com.linkedin.metadata.ElasticTestUtils;
 import com.linkedin.metadata.run.AspectRowSummary;
 import com.linkedin.metadata.run.IngestionRunSummary;
 import com.linkedin.metadata.search.elasticsearch.ElasticSearchServiceTest;
@@ -8,10 +9,6 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConventionImpl;
 import com.linkedin.mxe.SystemMetadata;
 import java.util.List;
 import javax.annotation.Nonnull;
-import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.annotations.AfterTest;
@@ -33,15 +30,12 @@ public class ElasticSearchSystemMetadataServiceTest {
   private final String _indexName = _indexConvention.getIndexName(INDEX_NAME);
   private ElasticSearchSystemMetadataService _client;
 
-  private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
-  private static final int HTTP_PORT = 9200;
-
   @BeforeTest
   public void setup() {
-    _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    _elasticsearchContainer = ElasticTestUtils.getNewElasticsearchContainer();
     checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
-    _searchClient = buildRestClient();
+    _searchClient = ElasticTestUtils.buildRestClient(_elasticsearchContainer);
     _client = buildService();
     _client.configure();
   }
@@ -50,19 +44,6 @@ public class ElasticSearchSystemMetadataServiceTest {
   public void wipe() throws Exception {
     _client.clear();
     syncAfterWrite(_searchClient, _indexName);
-  }
-
-  @Nonnull
-  private RestHighLevelClient buildRestClient() {
-    final RestClientBuilder builder =
-        RestClient.builder(new HttpHost("localhost", _elasticsearchContainer.getMappedPort(HTTP_PORT), "http"))
-            .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setDefaultIOReactorConfig(
-                IOReactorConfig.custom().setIoThreadCount(1).build()));
-
-    builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.
-        setConnectionRequestTimeout(3000));
-
-    return new RestHighLevelClient(builder);
   }
 
   @Nonnull

--- a/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/timeseries/elastic/ElasticSearchTimeseriesAspectServiceTest.java
@@ -15,6 +15,7 @@ import com.linkedin.data.template.StringArray;
 import com.linkedin.data.template.StringArrayArray;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.data.template.StringMapArray;
+import com.linkedin.metadata.ElasticTestUtils;
 import com.linkedin.metadata.aspect.EnvelopedAspect;
 import com.linkedin.metadata.models.AspectSpec;
 import com.linkedin.metadata.models.DataSchemaFactory;
@@ -46,10 +47,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import org.apache.http.HttpHost;
-import org.apache.http.impl.nio.reactor.IOReactorConfig;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testng.annotations.AfterTest;
@@ -64,8 +61,6 @@ import static org.testng.Assert.*;
 public class ElasticSearchTimeseriesAspectServiceTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private static final String IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch:7.9.3";
-  private static final int HTTP_PORT = 9200;
   private static final String ENTITY_NAME = "testEntity";
   private static final String ASPECT_NAME = "testEntityProfile";
   private static final Urn TEST_URN = new TestEntityUrn("acryl", "testElasticSearchTimeseriesAspectService", "table1");
@@ -95,26 +90,14 @@ public class ElasticSearchTimeseriesAspectServiceTest {
     _entityRegistry = new ConfigEntityRegistry(new DataSchemaFactory("com.datahub.test"),
         TestEntityProfile.class.getClassLoader().getResourceAsStream("test-entity-registry.yml"));
     _indexConvention = new IndexConventionImpl(null);
-    _elasticsearchContainer = new ElasticsearchContainer(IMAGE_NAME);
+    _elasticsearchContainer = ElasticTestUtils.getNewElasticsearchContainer();
     checkContainerEngine(_elasticsearchContainer.getDockerClient());
     _elasticsearchContainer.start();
-    _searchClient = buildRestClient();
+    _searchClient = ElasticTestUtils.buildRestClient(_elasticsearchContainer);
     _elasticSearchTimeseriesAspectService = buildService();
     _elasticSearchTimeseriesAspectService.configure();
     EntitySpec entitySpec = _entityRegistry.getEntitySpec(ENTITY_NAME);
     _aspectSpec = entitySpec.getAspectSpec(ASPECT_NAME);
-  }
-
-  @Nonnull
-  private RestHighLevelClient buildRestClient() {
-    final RestClientBuilder builder =
-        RestClient.builder(new HttpHost("localhost", _elasticsearchContainer.getMappedPort(HTTP_PORT), "http"))
-            .setHttpClientConfigCallback(httpAsyncClientBuilder -> httpAsyncClientBuilder.setDefaultIOReactorConfig(
-                IOReactorConfig.custom().setIoThreadCount(1).build()));
-
-    builder.setRequestConfigCallback(requestConfigBuilder -> requestConfigBuilder.setConnectionRequestTimeout(3000));
-
-    return new RestHighLevelClient(builder);
   }
 
   @Nonnull


### PR DESCRIPTION
refactor(metadata-io/test): create common ElasticsearchContainer helper and ability to override from environment.

Add ElasticTestUtils to provide a common place to construct ElasticsearchContainer and create REST clients. This is to remove code duplication in tests, to ensure tests are against a consistent image of Elasticsearch. Also included is the ability to use an environment variable to override the container full name, this is to allow builds behind a firewall to specify internal source for the image.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
