### PR TITLE
ci: update rename-namespace.sh to specify /bin/bash 

### DIFF
--- a/metadata-events/mxe-schemas/rename-namespace.sh
+++ b/metadata-events/mxe-schemas/rename-namespace.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 

--- a/metadata-events/mxe-schemas/rename-namespace.sh
+++ b/metadata-events/mxe-schemas/rename-namespace.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]:-$0}" )" >/dev/null && pwd )"
 
 # Rename all com.linkedin.* to com.linkedin.pegasus2avro.*, except for com.linkedin.avro2pegasus.*
 find $SCRIPT_ROOT/../mxe-schemas/src/renamed -type f -print0 | \


### PR DESCRIPTION
ci: update rename-namespace.sh to specify /bin/bash 

On some variants of linux /bin/sh isn't necessarily bash, this is to allow builds to succeed on these platforms.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
