### PR TITLE
UI Fix: Modal close on Enter press, autofocus on modal, added split panel, alignment of button

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -73,6 +73,7 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.1.6",
         "react-scripts": "4.0.3",
+        "react-split-pane": "^0.1.92",
         "react-syntax-highlighter": "^15.4.4",
         "react-timezone-select": "^1.1.15",
         "react-visibility-sensor": "^5.1.1",

--- a/datahub-web-react/src/app/domain/CreateDomainModal.tsx
+++ b/datahub-web-react/src/app/domain/CreateDomainModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { message, Button, Input, Modal, Typography, Form, Collapse, Tag } from 'antd';
 import { useCreateDomainMutation } from '../../graphql/domain.generated';
+import { useEnterKeyListener } from '../shared/useEnterKeyListener';
 
 const SuggestedNamesGroup = styled.div`
     margin-top: 12px;
@@ -54,6 +55,11 @@ export default function CreateDomainModal({ visible, onClose, onCreate }: Props)
         onClose();
     };
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#createDomainButton',
+    });
+
     return (
         <Modal
             title="Create new Domain"
@@ -64,7 +70,7 @@ export default function CreateDomainModal({ visible, onClose, onCreate }: Props)
                     <Button onClick={onClose} type="text">
                         Cancel
                     </Button>
-                    <Button onClick={onCreateDomain} disabled={stagedName === ''}>
+                    <Button id="createDomainButton" onClick={onCreateDomain} disabled={stagedName === ''}>
                         Create
                     </Button>
                 </>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/EntityProfile.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import { Alert, Divider } from 'antd';
+import SplitPane from 'react-split-pane';
 import { MutationHookOptions, MutationTuple, QueryHookOptions, QueryResult } from '@apollo/client/react/types/types';
 import styled from 'styled-components';
 import { useHistory } from 'react-router';
@@ -68,7 +69,6 @@ const HeaderAndTabsFlex = styled.div`
 const Sidebar = styled.div`
     overflow: auto;
     flex-basis: 30%;
-    border-left: 1px solid ${ANTD_GRAY[4.5]};
     padding-left: 20px;
     padding-right: 20px;
 `;
@@ -83,6 +83,14 @@ const TabContent = styled.div`
     flex: 1;
     overflow: auto;
 `;
+
+const resizerStyles = {
+    background: '#E9E9E9',
+    width: '2px',
+    cursor: 'col-resize',
+    margin: '0 5px',
+    height: '100%',
+};
 
 const defaultTabDisplayConfig = {
     visible: (_, _1) => true,
@@ -229,7 +237,13 @@ export const EntityProfile = <T, U>({
                     {isLineageMode ? (
                         <LineageExplorer type={entityType} urn={urn} />
                     ) : (
-                        <>
+                        <SplitPane
+                            split="vertical"
+                            minSize={window.innerWidth - 550}
+                            maxSize={window.innerWidth - 300}
+                            defaultSize={window.innerWidth - 550}
+                            resizerStyle={resizerStyles}
+                        >
                             <HeaderAndTabs>
                                 <HeaderAndTabsFlex>
                                     <Header>
@@ -247,7 +261,7 @@ export const EntityProfile = <T, U>({
                             <Sidebar>
                                 <EntitySidebar sidebarSections={sideBarSectionsWithDefaults} />
                             </Sidebar>
-                        </>
+                        </SplitPane>
                     )}
                 </ContentContainer>
             </>

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SetDomainModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Domain/SetDomainModal.tsx
@@ -7,6 +7,7 @@ import { EntityType, SearchResult } from '../../../../../../../types.generated';
 import { useSetDomainMutation } from '../../../../../../../graphql/mutations.generated';
 import { useEntityRegistry } from '../../../../../../useEntityRegistry';
 import { useEntityData } from '../../../../EntityContext';
+import { useEnterKeyListener } from '../../../../../../shared/useEnterKeyListener';
 
 type Props = {
     visible: boolean;
@@ -101,6 +102,11 @@ export const SetDomainModal = ({ visible, onClose, refetch }: Props) => {
         }
     };
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#setDomainButton',
+    });
+
     const renderSearchResult = (result: SearchResult) => {
         const displayName = entityRegistry.getDisplayName(result.entity.type, result.entity);
         return (
@@ -133,7 +139,7 @@ export const SetDomainModal = ({ visible, onClose, refetch }: Props) => {
                     <Button onClick={onClose} type="text">
                         Cancel
                     </Button>
-                    <Button disabled={selectedDomain === undefined} onClick={onOk}>
+                    <Button id="setDomainButton" disabled={selectedDomain === undefined} onClick={onOk}>
                         Add
                     </Button>
                 </>
@@ -142,6 +148,7 @@ export const SetDomainModal = ({ visible, onClose, refetch }: Props) => {
             <Form component={false}>
                 <Form.Item>
                     <Select
+                        autoFocus
                         value={selectValue}
                         mode="multiple"
                         ref={inputEl}

--- a/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
+++ b/datahub-web-react/src/app/entity/shared/containers/profile/sidebar/Ownership/AddOwnerModal.tsx
@@ -9,6 +9,7 @@ import { useEntityRegistry } from '../../../../../../useEntityRegistry';
 import { useEntityData } from '../../../../EntityContext';
 import { CustomAvatar } from '../../../../../../shared/avatar';
 import analytics, { EventType, EntityActionType } from '../../../../../../analytics';
+import { useEnterKeyListener } from '../../../../../../shared/useEnterKeyListener';
 
 type Props = {
     visible: boolean;
@@ -172,6 +173,11 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
 
     const selectValue = (selectedActor && [selectedActor.displayName]) || [];
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#addOwnerButton',
+    });
+
     return (
         <Modal
             title="Add owner"
@@ -182,7 +188,7 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
                     <Button onClick={onClose} type="text">
                         Cancel
                     </Button>
-                    <Button disabled={selectedActor === undefined} onClick={onOk}>
+                    <Button id="addOwnerButton" disabled={selectedActor === undefined} onClick={onOk}>
                         Add
                     </Button>
                 </>
@@ -191,6 +197,7 @@ export const AddOwnerModal = ({ visible, onClose, refetch }: Props) => {
             <Form component={false}>
                 <Form.Item>
                     <Select
+                        autoFocus
                         value={selectValue}
                         mode="multiple"
                         ref={inputEl}

--- a/datahub-web-react/src/app/identity/group/CreateGroupModal.tsx
+++ b/datahub-web-react/src/app/identity/group/CreateGroupModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { message, Button, Input, Modal, Typography, Form, Collapse } from 'antd';
 import { useCreateGroupMutation } from '../../../graphql/group.generated';
+import { useEnterKeyListener } from '../../shared/useEnterKeyListener';
 
 type Props = {
     visible: boolean;
@@ -40,6 +41,11 @@ export default function CreateGroupModal({ visible, onClose, onCreate }: Props) 
         onClose();
     };
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#createGroupButton',
+    });
+
     return (
         <Modal
             title="Create new group"
@@ -50,7 +56,7 @@ export default function CreateGroupModal({ visible, onClose, onCreate }: Props) 
                     <Button onClick={onClose} type="text">
                         Cancel
                     </Button>
-                    <Button onClick={onCreateGroup} disabled={stagedName === ''}>
+                    <Button id="createGroupButton" onClick={onCreateGroup} disabled={stagedName === ''}>
                         Create
                     </Button>
                 </>

--- a/datahub-web-react/src/app/ingest/secret/SecretBuilderModal.tsx
+++ b/datahub-web-react/src/app/ingest/secret/SecretBuilderModal.tsx
@@ -1,5 +1,6 @@
 import { Button, Form, Input, Modal, Typography } from 'antd';
 import React, { useState } from 'react';
+import { useEnterKeyListener } from '../../shared/useEnterKeyListener';
 import { SecretBuilderState } from './types';
 
 type Props = {
@@ -33,6 +34,11 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
         });
     };
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#createSecretButton',
+    });
+
     return (
         <Modal
             width={540}
@@ -45,6 +51,7 @@ export const SecretBuilderModal = ({ initialState, visible, onSubmit, onCancel }
                         Cancel
                     </Button>
                     <Button
+                        id="createSecretButton"
                         onClick={() => onSubmit?.(secretBuilderState, () => setSecretBuilderState({}))}
                         disabled={
                             !secretBuilderState.name ||

--- a/datahub-web-react/src/app/policy/PolicyBuilderModal.tsx
+++ b/datahub-web-react/src/app/policy/PolicyBuilderModal.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
+import styled from 'styled-components';
 import { Button, Modal, Steps } from 'antd';
 import PolicyPrivilegeForm from './PolicyPrivilegeForm';
 import PolicyTypeForm from './PolicyTypeForm';
 import PolicyActorForm from './PolicyActorForm';
 import { ActorFilter, Policy, PolicyType, ResourceFilter } from '../../types.generated';
 import { EMPTY_POLICY } from './policyUtils';
+import { useEnterKeyListener } from '../shared/useEnterKeyListener';
 
 type Props = {
     policy: Omit<Policy, 'urn'>;
@@ -13,6 +15,24 @@ type Props = {
     onClose: () => void;
     onSave: (savePolicy: Omit<Policy, 'urn'>) => void;
 };
+
+const StepsContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    margin-top: 8px;
+`;
+
+const PrevButtonContainer = styled.div`
+    display: flex;
+    justify-content: start;
+    margin-left: 12px;
+`;
+
+const NextButtonContainer = styled.div`
+    display: flex;
+    justify-content: end;
+    margin-right: 12px;
+`;
 
 /**
  * Component used for constructing new policies. The purpose of this flow is to populate or edit a Policy
@@ -108,6 +128,14 @@ export default function PolicyBuilderModal({ policy, setPolicy, visible, onClose
     // Whether we're editing or creating a policy.
     const isEditing = policy !== undefined && policy !== null;
 
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#nextButton',
+    });
+
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#saveButton',
+    });
+
     return (
         <Modal
             title={isEditing ? 'Edit a Policy' : 'Create a new Policy'}
@@ -123,23 +151,23 @@ export default function PolicyBuilderModal({ policy, setPolicy, visible, onClose
                 ))}
             </Steps>
             <div className="steps-content">{activeStep.content}</div>
-            <div className="steps-action">
-                {activeStepIndex < policySteps.length - 1 && activeStep.complete && (
-                    <Button type="primary" onClick={() => next()}>
-                        Next
-                    </Button>
-                )}
-                {activeStepIndex === policySteps.length - 1 && activeStep.complete && (
-                    <Button type="primary" onClick={onSavePolicy}>
-                        Save
-                    </Button>
-                )}
-                {activeStepIndex > 0 && (
-                    <Button style={{ margin: '0 8px' }} onClick={() => prev()}>
-                        Previous
-                    </Button>
-                )}
-            </div>
+            <StepsContainer>
+                <PrevButtonContainer>
+                    {activeStepIndex > 0 && <Button onClick={() => prev()}>Previous</Button>}
+                </PrevButtonContainer>
+                <NextButtonContainer>
+                    {activeStepIndex < policySteps.length - 1 && activeStep.complete && (
+                        <Button id="nextButton" type="primary" onClick={() => next()}>
+                            Next
+                        </Button>
+                    )}
+                    {activeStepIndex === policySteps.length - 1 && activeStep.complete && (
+                        <Button id="saveButton" type="primary" onClick={onSavePolicy}>
+                            Save
+                        </Button>
+                    )}
+                </NextButtonContainer>
+            </StepsContainer>
         </Modal>
     );
 }

--- a/datahub-web-react/src/app/shared/tags/AddTagTermModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/AddTagTermModal.tsx
@@ -17,6 +17,7 @@ import { useEntityRegistry } from '../../useEntityRegistry';
 import { IconStyleType } from '../../entity/Entity';
 import { useAddTagMutation, useAddTermMutation } from '../../../graphql/mutations.generated';
 import analytics, { EventType, EntityActionType } from '../../analytics';
+import { useEnterKeyListener } from '../useEnterKeyListener';
 
 type AddTagModalProps = {
     globalTags?: GlobalTags | null;
@@ -223,6 +224,11 @@ export default function AddTagTermModal({
             });
     };
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#addTagButton',
+    });
+
     if (showCreateModal) {
         return (
             <CreateTagModal
@@ -249,6 +255,7 @@ export default function AddTagTermModal({
                         Cancel
                     </Button>
                     <Button
+                        id="addTagButton"
                         data-testid="add-tag-term-from-modal-btn"
                         onClick={onOk}
                         disabled={selectedValue.length === 0 || disableAdd}

--- a/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
+++ b/datahub-web-react/src/app/shared/tags/CreateTagModal.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useUpdateTagMutation } from '../../../graphql/tag.generated';
 import { useAddTagMutation } from '../../../graphql/mutations.generated';
 import { SubResourceType } from '../../../types.generated';
+import { useEnterKeyListener } from '../useEnterKeyListener';
 
 type CreateTagModalProps = {
     visible: boolean;
@@ -71,6 +72,11 @@ export default function CreateTagModal({
             });
     };
 
+    // Handle the Enter press
+    useEnterKeyListener({
+        querySelectorToExecuteClick: '#createTagButton',
+    });
+
     return (
         <Modal
             title={`Create ${tagName}`}
@@ -81,7 +87,7 @@ export default function CreateTagModal({
                     <Button onClick={onBack} type="text">
                         Back
                     </Button>
-                    <Button onClick={onOk} disabled={disableCreate}>
+                    <Button id="createTagButton" onClick={onOk} disabled={disableCreate}>
                         Create
                     </Button>
                 </>

--- a/datahub-web-react/src/app/shared/useEnterKeyListener.tsx
+++ b/datahub-web-react/src/app/shared/useEnterKeyListener.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+export const useEnterKeyListener = ({ querySelectorToExecuteClick }) => {
+    const element = document?.querySelector(querySelectorToExecuteClick);
+
+    useEffect(() => {
+        const handlePressEnter = () => {
+            const mouseClickEvents = ['mousedown', 'click', 'mouseup'];
+            function simulateMouseClick(event) {
+                mouseClickEvents?.forEach((mouseEventType) =>
+                    event?.dispatchEvent(
+                        new MouseEvent(mouseEventType, {
+                            view: window,
+                            bubbles: true,
+                            cancelable: true,
+                            buttons: 1,
+                        }),
+                    ),
+                );
+            }
+            simulateMouseClick(element);
+        };
+
+        const listener = (event) => {
+            if (event?.code === 'Enter' || event?.code === 'NumpadEnter') {
+                handlePressEnter();
+            }
+        };
+
+        document?.addEventListener('keydown', listener);
+
+        return () => {
+            document?.removeEventListener('keydown', listener);
+        };
+    });
+};

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -13278,6 +13278,15 @@ prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.6.0, prop-types@^15.6.1,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.5.4:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -13890,7 +13899,7 @@ react-icons@^4.2.0:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
   integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
 
-react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -13899,6 +13908,11 @@ react-is@^17.0.0, react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-lifecycles-compat@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
+  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-markdown@6.0.2:
   version "6.0.2"
@@ -14031,6 +14045,22 @@ react-select@^5.1.0:
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
+
+react-split-pane@^0.1.92:
+  version "0.1.92"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.92.tgz#68242f72138aed95dd5910eeb9d99822c4fc3a41"
+  integrity sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==
+  dependencies:
+    prop-types "^15.7.2"
+    react-lifecycles-compat "^3.0.4"
+    react-style-proptype "^3.2.2"
+
+react-style-proptype@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.2.tgz#d8e998e62ce79ec35b087252b90f19f1c33968a0"
+  integrity sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==
+  dependencies:
+    prop-types "^15.5.4"
 
 react-syntax-highlighter@^15.4.4:
   version "15.4.4"

--- a/smoke-test/tests/cypress/cypress/integration/mutations/mutations.js
+++ b/smoke-test/tests/cypress/cypress/integration/mutations/mutations.js
@@ -73,7 +73,7 @@ describe('mutations', () => {
   it('can add and remove terms from a dataset field', () => {
     cy.login();
     // make space for the glossary term column
-    cy.viewport(1300, 800)
+    cy.viewport(2000, 800)
     cy.visit('/dataset/urn:li:dataset:(urn:li:dataPlatform:hive,cypress_logging_events,PROD)');
     cy.get('[data-testid="schema-field-event_name-terms"]').trigger('mouseover', {force: true});
     cy.get('[data-testid="schema-field-event_name-terms"]').within(() => cy.contains('Add Term').click())


### PR DESCRIPTION
Completed: UI Fix and New Project

- Fixed alignment  previous and next button on policy builder modal
- Completed new project: Expand and collapse right section (tags, terms, domain)
- Close Modals (Add owner, tag, glossary term, domain) when user press Enter
- Auto Focus: When you click 'Add Owner' and 'Set Domain', the text box should be focused


https://user-images.githubusercontent.com/86347578/154199529-f2b98352-4e27-483e-a42b-a7ab24fe63ee.mp4

![policy_builder_button_1](https://user-images.githubusercontent.com/86347578/154199569-4fafdc31-4ff9-48c2-9f7b-b5b3234fa066.png)
![policy_builder_button_2](https://user-images.githubusercontent.com/86347578/154199571-3ee7baa3-69c6-48fe-b7b3-91b0215a19d8.png)

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
