### PR TITLE
Update querying-entities.md -> Documentation Error

### DIFF
--- a/docs/api/graphql/querying-entities.md
+++ b/docs/api/graphql/querying-entities.md
@@ -40,7 +40,7 @@ As GraphQL:
 
 ```graphql 
 {
-  search(input: { type: "DATASET", query: "my sql dataset", start: 0, count: 10 }) {
+  search(input: { type: DATASET, query: "my sql dataset", start: 0, count: 10 }) {
     start
     count
     total


### PR DESCRIPTION
There is a small error in the GraphQL code block. There are additional double quotes ("") in the type field in the "Searching for a Metadata Entitiy" section. This is wrong.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
