### PR TITLE
Pinning down elasticsearch to less than 8.0.0

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -111,7 +111,7 @@ plugins: Dict[str, Set[str]] = {
     "data-lake": {*aws_common, "pydeequ==1.0.1", "pyspark==3.0.3", "parse==1.19.0"},
     "dbt": {"requests"},
     "druid": sql_common | {"pydruid>=0.6.2"},
-    "elasticsearch": {"elasticsearch"},
+    "elasticsearch": {"elasticsearch<=8.0.0"},
     "feast": {"docker"},
     "glue": aws_common,
     "hive": sql_common

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -111,7 +111,7 @@ plugins: Dict[str, Set[str]] = {
     "data-lake": {*aws_common, "pydeequ==1.0.1", "pyspark==3.0.3", "parse==1.19.0"},
     "dbt": {"requests"},
     "druid": sql_common | {"pydruid>=0.6.2"},
-    "elasticsearch": {"elasticsearch<=8.0.0"},
+    "elasticsearch": {"elasticsearch<8.0.0"},
     "feast": {"docker"},
     "glue": aws_common,
     "hive": sql_common

--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -111,7 +111,11 @@ plugins: Dict[str, Set[str]] = {
     "data-lake": {*aws_common, "pydeequ==1.0.1", "pyspark==3.0.3", "parse==1.19.0"},
     "dbt": {"requests"},
     "druid": sql_common | {"pydruid>=0.6.2"},
-    "elasticsearch": {"elasticsearch<8.0.0"},
+    # Starting with 7.14.0 python client is checking if it is connected to elasticsearch client. If its not it throws
+    # UnsupportedProductError
+    # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/release-notes.html#rn-7-14-0
+    # https://github.com/elastic/elasticsearch-py/issues/1639#issuecomment-883587433
+    "elasticsearch": {"elasticsearch==7.13.4"},
     "feast": {"docker"},
     "glue": aws_common,
     "hive": sql_common


### PR DESCRIPTION
The Elasticsearch client library is not pinned to a particular version of the client. It downloads the latest version of Elasticsearch which is > 8.0.0. In version 8.0.0 Elasticsearch python client introduced a check that checks if the response from Elasticsearch server has a header `'X-Elastic-Product: Elasticsearch'` If not it throws 
```UnsupportedProductError(
                    message=(
                        "The client noticed that the server is not Elasticsearch "
                        "and we do not support this unknown product"
                    )   
```
This breaks ingestion from OpenSearch as well as for those cases where we forked from open source Elasticsearch some time back. 

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
