### PR TITLE
fix(Ingestion): Elastic http/https host support

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -165,7 +165,7 @@ class ElasticsearchSourceReport(SourceReport):
 
 
 class ElasticsearchSourceConfig(DatasetSourceConfigBase):
-    host: str = "localhost:9092"
+    host: str = "localhost:9200"
     username: str = ""
     password: str = ""
     index_pattern: AllowDenyPattern = AllowDenyPattern(
@@ -185,7 +185,7 @@ class ElasticsearchSourceConfig(DatasetSourceConfigBase):
                 # This regex is quite loose. Many invalid hostnames or IPs will slip through,
                 # but it serves as a good first line of validation. We defer to Kafka for the
                 # remaining validation.
-                r"^[\w\-\.\:]+$",
+                r"^(http|https)[\w\-\.\://]+$",
                 host,
             ), f"host contains bad characters, found {host}"
             if port is not None:

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -183,9 +183,9 @@ class ElasticsearchSourceConfig(DatasetSourceConfigBase):
                 host = entry
             assert re.match(
                 # This regex is quite loose. Many invalid hostnames or IPs will slip through,
-                # but it serves as a good first line of validation. We defer to Kafka for the
+                # but it serves as a good first line of validation. We defer to Elastic for the
                 # remaining validation.
-                r"^(http|https)[\w\-\.\://]+$",
+                r"^[(http|https)://]*[\w\-\.\:]+[\/]*$",
                 host,
             ), f"host contains bad characters, found {host}"
             if port is not None:


### PR DESCRIPTION
allow users to specify url scheme. enable ingestion from both TLS enabled clusters.
currently specifying the url scheme resulted in assertion error.



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
