### PR TITLE
fix(ui): Return empty search response on invalid characters in search

### DIFF
--- a/datahub-web-react/src/app/home/HomePageHeader.tsx
+++ b/datahub-web-react/src/app/home/HomePageHeader.tsx
@@ -242,7 +242,7 @@ export const HomePageHeader = () => {
                                         onClick={() =>
                                             navigateToSearchUrl({
                                                 type: undefined,
-                                                query: suggestion,
+                                                query: `"${suggestion}"`,
                                                 history,
                                             })
                                         }


### PR DESCRIPTION
When we use reserved characters to query elastic, the DataHub API will throw 500s. We want to catch and suppress such exceptions, abstracting them away from our callers.

Screenshot below showing exception has been handled on server: 
<img width="1067" alt="Screen Shot 2022-02-18 at 12 21 21 PM" src="https://user-images.githubusercontent.com/17549204/154756202-20a55c31-49ce-4df8-9732-53854eeb805f.png">


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
