### PR TITLE
fix(policies): fixing case where ownership is null in ownership client

### DIFF
--- a/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/OwnershipClient.java
+++ b/metadata-service/restli-client/src/main/java/com/linkedin/entity/client/OwnershipClient.java
@@ -38,7 +38,10 @@ public class OwnershipClient {
           OWNERSHIP_ASPECT_NAME,
           ASPECT_LATEST_VERSION,
           null);
-      return aspect.getAspect().getOwnership();
+      if (aspect != null && aspect.hasAspect()) {
+        return aspect.getAspect().getOwnership();
+      }
+      return null;
     } catch (RestLiServiceException e) {
       if (HttpStatus.S_404_NOT_FOUND.equals(e.getStatus())) {
         // No aspect exists.


### PR DESCRIPTION
This became an issue in the case where a policy applied to "owners" of dataset who does not have an ownership aspect. In that case, this line would throw a NPE.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
