### PR TITLE
fix(delete): Fixing NPE on delete urns path

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/entity/ebean/EbeanEntityService.java
@@ -468,6 +468,7 @@ public class EbeanEntityService extends EntityService {
     return true;
   }
 
+  @Nullable
   public RollbackResult deleteAspect(String urn, String aspectName, Map<String, String> conditions) {
     // Validate pre-conditions before running queries
     try {
@@ -541,15 +542,11 @@ public class EbeanEntityService extends EntityService {
         _entityDao.saveAspect(latest, false);
         _entityDao.deleteAspect(survivingAspect);
       } else {
-        // if this is the key aspect, we also want to delete the entity entirely
         if (isKeyAspect) {
-          if (_entityDao.getEarliestAspect(urn).get().getCreatedOn().equals(latest.getCreatedOn())) {
-            additionalRowsDeleted = _entityDao.deleteUrn(urn);
-            _entityDao.deleteAspect(latest);
-          } else {
-            return null;
-          }
+          // If this is the key aspect, delete the entity entirely.
+          additionalRowsDeleted = _entityDao.deleteUrn(urn);
         } else {
+          // Else, only delete the specific aspect.
           _entityDao.deleteAspect(latest);
         }
       }
@@ -614,21 +611,19 @@ public class EbeanEntityService extends EntityService {
     List<AspectRowSummary> removedAspects = new ArrayList<>();
     Integer rowsDeletedFromEntityDeletion = 0;
 
+    final EntitySpec spec = getEntityRegistry().getEntitySpec(urnToEntityName(urn));
+    final AspectSpec keySpec = spec.getKeyAspectSpec();
     String keyAspectName = getKeyAspectName(urn);
+
     EbeanAspectV2 latestKey = _entityDao.getLatestAspect(urn.toString(), keyAspectName);
     if (latestKey == null || latestKey.getSystemMetadata() == null) {
       return new RollbackRunResult(removedAspects, rowsDeletedFromEntityDeletion);
     }
 
     SystemMetadata latestKeySystemMetadata = parseSystemMetadata(latestKey.getSystemMetadata());
-
     RollbackResult result = deleteAspect(urn.toString(), keyAspectName, Collections.singletonMap("runId", latestKeySystemMetadata.getRunId()));
-    Optional<AspectSpec> aspectSpec = getAspectSpec(result.entityName, result.aspectName);
-    if (!aspectSpec.isPresent()) {
-      log.error("Issue while rolling back: unknown aspect {} for entity {}", result.entityName, result.aspectName);
-    }
 
-    if (result != null && aspectSpec.isPresent()) {
+    if (result != null) {
       AspectRowSummary summary = new AspectRowSummary();
       summary.setUrn(urn.toString());
       summary.setKeyAspect(true);
@@ -638,7 +633,7 @@ public class EbeanEntityService extends EntityService {
 
       rowsDeletedFromEntityDeletion = result.additionalRowsAffected;
       removedAspects.add(summary);
-      produceMetadataChangeLog(result.getUrn(), result.getEntityName(), result.getAspectName(), aspectSpec.get(),
+      produceMetadataChangeLog(result.getUrn(), result.getEntityName(), result.getAspectName(), keySpec,
           result.getOldValue(), result.getNewValue(), result.getOldSystemMetadata(), result.getNewSystemMetadata(),
           result.getChangeType());
     }


### PR DESCRIPTION
deleteAspect can return a null value, but the caller was not handling is appropriately. In addition a brittle legacy check is being removed that checks that the key aspect was written prior to the value aspect. Finally, an unnecessary call to deleteAspect was removed.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
