### PR TITLE
fix(ingest) snowflake-usage: add logger warning to add an email_domain when email is missing

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/usage/snowflake_usage.py
@@ -393,10 +393,10 @@ class SnowflakeUsageSource(StatefulIngestionSourceBase):
                 event_dict["query_start_time"]
             ).astimezone(tz=timezone.utc)
 
-            if not event_dict["email"] and self.config.email_domain:
-                if not event_dict["user_name"]:
+            if not event_dict["email"]:
+                if not self.config.email_domain:
                     logging.warning(
-                        f"The user_name is missing from {event_dict}. Skipping ...."
+                        f"The email is missing from {event_dict}, so an email_domain must be supplied to generate users. Skipping ...."
                     )
                     continue
 


### PR DESCRIPTION
## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [X] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
