### PR TITLE
Add pagination to group ownerships

### DIFF
--- a/datahub-web-react/src/app/entity/group/GroupOwnerships.tsx
+++ b/datahub-web-react/src/app/entity/group/GroupOwnerships.tsx
@@ -1,0 +1,79 @@
+import { Pagination, Row, Space } from 'antd';
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { EntityType, SearchResult } from '../../../types.generated';
+import { useGetAllEntitySearchResults } from '../../../utils/customGraphQL/useGetAllEntitySearchResults';
+import RelatedEntityResults from '../../shared/entitySearch/RelatedEntityResults';
+import { useEntityRegistry } from '../../useEntityRegistry';
+import { GetGroupQuery } from '../../../graphql/group.generated';
+
+type Props = {
+    data?: GetGroupQuery;
+    pageSize: number;
+};
+
+const OwnershipView = styled(Space)`
+    width: 100%;
+    margin-bottom: 32px;
+    padding-top: 28px;
+`;
+
+export default function GroupOwnerships({ data, pageSize }: Props) {
+    const [page, setPage] = useState(1);
+    const [currentMenuKey, setCurrentMenuKey] = useState('');
+    const entityRegistry = useEntityRegistry();
+
+    const ownershipResult = useGetAllEntitySearchResults({
+        query: `owners:${data?.corpGroup?.name}`,
+        start: (page - 1) * pageSize,
+        count: pageSize,
+    });
+
+    const onChangePage = (newPage: number) => {
+        setPage(newPage);
+    };
+
+    const setCurrentMenuKeyHook = (menuKey: string) => {
+        setPage(1);
+        setCurrentMenuKey(menuKey);
+    };
+
+    const [ownershipForDetails, totalResultsLength] = useMemo(() => {
+        let total = 0;
+        const filteredOwnershipResult: {
+            [key in EntityType]?: Array<SearchResult>;
+        } = {};
+
+        Object.keys(ownershipResult).forEach((type) => {
+            const search = ownershipResult[type].data?.search;
+            if (search && search.total > 0) {
+                filteredOwnershipResult[type] = [];
+            }
+            if (currentMenuKey === entityRegistry.getPathName(type as EntityType)) {
+                total = ownershipResult[type].data?.search?.total;
+
+                const selectedTabPaginatedResults = ownershipResult[type].data?.search?.searchResults;
+                if (selectedTabPaginatedResults && selectedTabPaginatedResults.length > 0) {
+                    filteredOwnershipResult[type] = selectedTabPaginatedResults;
+                }
+            }
+        });
+        return [filteredOwnershipResult, total];
+    }, [ownershipResult, entityRegistry, currentMenuKey]);
+
+    return (
+        <OwnershipView direction="vertical" size="middle">
+            <Row justify="center">
+                <RelatedEntityResults searchResult={ownershipForDetails} menuItemChangeHook={setCurrentMenuKeyHook} />
+                <Pagination
+                    current={page}
+                    pageSize={pageSize}
+                    total={totalResultsLength}
+                    showLessItems
+                    onChange={onChangePage}
+                    showSizeChanger={false}
+                />
+            </Row>
+        </OwnershipView>
+    );
+}

--- a/datahub-web-react/src/app/shared/entitySearch/RelatedEntityResults.tsx
+++ b/datahub-web-react/src/app/shared/entitySearch/RelatedEntityResults.tsx
@@ -25,9 +25,10 @@ type Props = {
         [key in EntityType]?: Array<SearchResult>;
     };
     emptyMessage?: string;
+    menuItemChangeHook?: (string) => void;
 };
 
-export default function RelatedEntityResults({ searchResult, emptyMessage }: Props) {
+export default function RelatedEntityResults({ searchResult, emptyMessage, menuItemChangeHook }: Props) {
     const entityRegistry = useEntityRegistry();
     const menuOptions: Array<EntityType> = Object.keys(searchResult) as Array<EntityType>;
     const [selectedKey, setSelectedKey] = useState('');
@@ -35,11 +36,13 @@ export default function RelatedEntityResults({ searchResult, emptyMessage }: Pro
         if (menuOptions && menuOptions.length > 0 && selectedKey.length === 0) {
             const firstEntityType = entityRegistry.getPathName(menuOptions[0] as EntityType);
             setSelectedKey(firstEntityType);
+            menuItemChangeHook?.(firstEntityType);
         }
-    }, [menuOptions, entityRegistry, selectedKey]);
+    }, [menuOptions, entityRegistry, selectedKey, menuItemChangeHook]);
 
     const onMenuClick = ({ key }) => {
         setSelectedKey(key);
+        menuItemChangeHook?.(key);
     };
 
     return (


### PR DESCRIPTION
## What:

There was no pagination support on the ownerships of the groups. For each type of entity, if the group owns more than 10 entities, the rest of these become unreachable through UI. 

In this pr, I have tried to implement pagination per entity type to allow discovering all of the entities owned by the group.


![dh_group_ownership](https://user-images.githubusercontent.com/9121316/154779302-a21cdb67-9347-4ddb-a925-9349d58cc9e3.gif)
_(I have changed the page size for ownership to 10, while it's 20 in the recording)_

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
