### PR TITLE
Add support for url_prefix in elastisearch source

### DIFF
--- a/metadata-ingestion/source_docs/elastic_search.md
+++ b/metadata-ingestion/source_docs/elastic_search.md
@@ -34,6 +34,7 @@ source:
     username: ""
     password: ""
     # Options
+    url_prefix: "" # optional url_prefix
     env: "PROD"
     index_pattern:
         allow: [".*some_index_name_pattern*"]
@@ -53,6 +54,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | `host`                      |          | "localhost:9092" | The elastic search host URI.                                  |
 | `username`                  |          | ""               | The username credential.                                      |
 | `password`                  |          | ""               | The password credential.                                      |
+| `url_prefix`                |          | ""               | There are cases where an enterprise would have multiple elastic search clusters. One way for them to manage is to have a single endpoint for all the elastic search clusters and use url_prefix for routing requests to different clusters.                            |
 | `env`                       |          | `"PROD"`         | Environment to use in namespace when constructing URNs.       |
 | `platform_instance`         |          | None             | The Platform instance to use while constructing URNs.         |
 | `index_pattern.allow`       |          |                  | List of regex patterns for indexes to include in ingestion.   |

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -209,7 +209,7 @@ class ElasticsearchSource(Source):
         self.client = Elasticsearch(
             self.source_config.host,
             http_auth=(self.source_config.username, self.source_config.password),
-            url_prefix = self.source_config.url_prefix
+            url_prefix=self.source_config.url_prefix,
         )
         self.report = ElasticsearchSourceReport()
         self.data_stream_partition_count: Dict[str, int] = defaultdict(int)

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -223,7 +223,7 @@ class ElasticsearchSource(Source):
         return cls(config, ctx)
 
     def get_workunits(self) -> Iterable[MetadataWorkUnit]:
-        indices = self.client.indices.get_alias(index="*")
+        indices = self.client.indices.get_alias()
 
         for index in indices:
             self.report.report_index_scanned(index)

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -168,6 +168,7 @@ class ElasticsearchSourceConfig(DatasetSourceConfigBase):
     host: str = "localhost:9200"
     username: str = ""
     password: str = ""
+    url_prefix: str = ""
     index_pattern: AllowDenyPattern = AllowDenyPattern(
         allow=[".*"], deny=["^_.*", "^ilm-history.*"]
     )
@@ -208,6 +209,7 @@ class ElasticsearchSource(Source):
         self.client = Elasticsearch(
             self.source_config.host,
             http_auth=(self.source_config.username, self.source_config.password),
+            url_prefix = self.source_config.url_prefix
         )
         self.report = ElasticsearchSourceReport()
         self.data_stream_partition_count: Dict[str, int] = defaultdict(int)


### PR DESCRIPTION
There are cases where an enterprise would have multiple elastic search clusters. One way for them to manage is to have a single endpoint for all the elastic search clusters and use `url_prefix` for routing requests to different clusters. 

The current elasticsearch source does not support this use case. We can add the support by adding an optional config parameter called `url_prefix` and passing the value of `url_prefix` to the underlying `Elasticsearch` client constructor while creating it like 
```
source:
  type: "elasticsearch"
  config:
    env: "DEV"
    host: "localhost:9200"
    url_prefix: 'test_cluste1'
```


We need one more change to support this. Right now we use the following call for getting the list of indices from elastisearch `es.indices.get_alias(index="*")` which results into HTTP call like `http://localhost:29200 "GET /test_cluster1/*`
```
es.indices.get_alias(index="*")
DEBUG:urllib3.connectionpool:http://localhost:29200 "GET /test_cluster1/*/_alias HTTP/1.1" 403 93
WARNING:elasticsearch:GET http://localhost:29200/test_cluster1/*/_alias [status:403 request:0.003s]
DEBUG:elasticsearch:> None
DEBUG:elasticsearch:< <html><body><h1>403 Forbidden</h1>
Request forbidden by administrative rules.
</body></html>
```
In cases where you have multiple elasticsearch clusters along with ACL on them, the call would get blocked, rejected. 

Another way to get a list of indices would be `es.indices.get_alias()` 
```
es.indices.get_alias()
DEBUG:urllib3.connectionpool:http://localhost:29200 "GET /test_cluster1/_alias HTTP/1.1" 200 39430
INFO:elasticsearch:GET http://localhost:29200/test_cluster1/_alias [status:200 request:0.008s]
DEBUG:elasticsearch:> None
DEBUG:elasticsearch:< 
```
This should return the list in the same way


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
