### PR TITLE
fix(ui): Wrap homepage cards on long text

### DIFF
--- a/datahub-web-react/src/app/shared/LogoCountCard.tsx
+++ b/datahub-web-react/src/app/shared/LogoCountCard.tsx
@@ -20,6 +20,7 @@ const Container = styled(Button)`
     &&:hover {
         box-shadow: ${(props) => props.theme.styles['box-shadow-hover']};
     }
+    white-space: unset;
 `;
 
 const PlatformLogo = styled(Image)`
@@ -38,7 +39,9 @@ const LogoContainer = styled.div``;
 
 const TitleContainer = styled.div``;
 
-const Title = styled(Typography.Title)``;
+const Title = styled(Typography.Title)`
+    word-break: break-word;
+`;
 
 type Props = {
     logoUrl?: string;
@@ -55,7 +58,14 @@ export const LogoCountCard = ({ logoUrl, logoComponent, name, count, onClick }: 
                 {(logoUrl && <PlatformLogo preview={false} src={logoUrl} alt={name} />) || logoComponent}
             </LogoContainer>
             <TitleContainer>
-                <Title level={5}>{name}</Title>
+                <Title
+                    ellipsis={{
+                        rows: 4,
+                    }}
+                    level={5}
+                >
+                    {name}
+                </Title>
             </TitleContainer>
             {count && <CountText>{formatNumber(count)}</CountText>}
         </Container>


### PR DESCRIPTION
Platform or Domain names with long names will cause the text to appear unreadable on the homepage. This PR aims to address that! See screenshots below.

<img width="644" alt="Screen Shot 2022-02-22 at 8 01 56 PM" src="https://user-images.githubusercontent.com/17549204/155260113-d9ac22f1-a165-47ce-866d-326237083925.png">
<img width="663" alt="Screen Shot 2022-02-22 at 8 03 24 PM" src="https://user-images.githubusercontent.com/17549204/155260109-06ec8442-eff5-4a5b-bd09-b95716094eca.png">




## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
