### PR TITLE
fix(ingest): fix tableau sheets external url ingestion

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -646,10 +646,13 @@ class TableauSource(Source):
 
             if sheet.get("path", ""):
                 sheet_external_url = f"{self.config.connect_uri}#/site/{self.config.site}/views/{sheet.get('path', '')}"
-            else:
+            elif sheet.get("containedInDashboards"):
                 # sheet contained in dashboard
                 dashboard_path = sheet.get("containedInDashboards")[0].get("path", "")
                 sheet_external_url = f"{self.config.connect_uri}/t/{self.config.site}/authoring/{dashboard_path}/{sheet.get('name', '')}"
+            else:
+                # hidden or viz-in-tooltip sheet
+                sheet_external_url = f"{self.config.connect_uri}"
 
             fields = {}
             for field in sheet.get("datasourceFields", ""):

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -652,7 +652,7 @@ class TableauSource(Source):
                 sheet_external_url = f"{self.config.connect_uri}/t/{self.config.site}/authoring/{dashboard_path}/{sheet.get('name', '')}"
             else:
                 # hidden or viz-in-tooltip sheet
-                sheet_external_url = f"{self.config.connect_uri}"
+                sheet_external_url = None
 
             fields = {}
             for field in sheet.get("datasourceFields", ""):

--- a/metadata-ingestion/tests/integration/tableau/setup/workbooksConnection_8.json
+++ b/metadata-ingestion/tests/integration/tableau/setup/workbooksConnection_8.json
@@ -36329,12 +36329,7 @@
                             "createdAt": "2021-12-17T21:08:26Z",
                             "updatedAt": "2021-12-17T21:08:27Z",
                             "tags": [],
-                            "containedInDashboards": [
-                                {
-                                    "name": "Obesity",
-                                    "path": "Regional_16397753068010/Obesity"
-                                }
-                            ],
+                            "containedInDashboards": [],
                             "upstreamDatasources": [
                                 {
                                     "id": "8eb071bf-364e-262b-c761-1ab465b2f214",


### PR DESCRIPTION
As reported in  slack [1](https://datahubspace.slack.com/archives/C02GBGG90CU/p1645040303160589?thread_ts=1644881402.488669&cid=C02GBGG90CU) [2](https://datahubspace.slack.com/archives/C02GBGG90CU/p1645204203359639) there is an issue with the ingestion of certain sheets that do not have either a `path` or `containedInDashboards`.

This might happen if the sheet is hidden (i.e. published but not exposed via web interface) or its a viz-in-tooltip (only accessible by hovering over marks in another sheet). As a workaround we can just fallback to the tableau URL

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)

