### PR TITLE
fix(ingest) kafka-connect: Pass the env variable as part of making dataset

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -891,6 +891,7 @@ class KafkaConnectSource(Source):
                             source_platform,
                             source_dataset,
                             platform_instance=source_platform_instance,
+                            env=self.config.env
                         )
                     ]
                     if source_dataset
@@ -901,6 +902,7 @@ class KafkaConnectSource(Source):
                         target_platform,
                         target_dataset,
                         platform_instance=target_platform_instance,
+                        env=self.config.env
                     )
                 ]
 

--- a/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/kafka_connect.py
@@ -891,7 +891,7 @@ class KafkaConnectSource(Source):
                             source_platform,
                             source_dataset,
                             platform_instance=source_platform_instance,
-                            env=self.config.env
+                            env=self.config.env,
                         )
                     ]
                     if source_dataset
@@ -902,7 +902,7 @@ class KafkaConnectSource(Source):
                         target_platform,
                         target_dataset,
                         platform_instance=target_platform_instance,
-                        env=self.config.env
+                        env=self.config.env,
                     )
                 ]
 


### PR DESCRIPTION

## Checklist
- [ X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

Datasets created as part of kafka connect ingestion are created with default `PROD` env. This fix is to pass the env variable from the recipe.
