### PR TITLE
fix(docker): use exec form to start container main process

### DIFF
--- a/docker/datahub-gms/start.sh
+++ b/docker/datahub-gms/start.sh
@@ -60,9 +60,9 @@ COMMON="
     /datahub/datahub-gms/bin/war.war"
 
 if [[ $SKIP_ELASTICSEARCH_CHECK != true ]]; then
-  dockerize \
+  exec dockerize \
     -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
     $COMMON
 else
-  dockerize $COMMON
+  exec dockerize $COMMON
 fi

--- a/docker/datahub-mae-consumer/start.sh
+++ b/docker/datahub-mae-consumer/start.sh
@@ -53,9 +53,9 @@ COMMON="
     java $JAVA_OPTS $JMX_OPTS $OTEL_AGENT $PROMETHEUS_AGENT -jar /datahub/datahub-mae-consumer/bin/mae-consumer-job.jar
 "
 if [[ $SKIP_ELASTICSEARCH_CHECK != true ]]; then
-  dockerize \
+  exec dockerize \
     -wait $ELASTICSEARCH_PROTOCOL://$ELASTICSEARCH_HOST:$ELASTICSEARCH_PORT -wait-http-header "$ELASTICSEARCH_AUTH_HEADER" \
     $COMMON
 else
-  dockerize $COMMON
+  exec dockerize $COMMON
 fi

--- a/docker/datahub-mce-consumer/start.sh
+++ b/docker/datahub-mce-consumer/start.sh
@@ -15,7 +15,7 @@ if [[ $ENABLE_PROMETHEUS == true ]]; then
   PROMETHEUS_AGENT="-javaagent:jmx_prometheus_javaagent.jar=4318:/datahub/datahub-mce-consumer/scripts/prometheus-config.yaml "
 fi
 
-dockerize \
+exec dockerize \
   $WAIT_FOR_KAFKA \
   -timeout 240s \
   java $JAVA_OPTS $JMX_OPTS $OTEL_AGENT $PROMETHEUS_AGENT -jar /datahub/datahub-mce-consumer/bin/mce-consumer-job.jar


### PR DESCRIPTION
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))

Docker containers of mae, mce and gms uses shell form, so the main process will be the start script, which can't handle signals sent to it. This fixes changes the scripts to use exec form. 
