### PR TITLE
fix(docs): Error in running airflow locally

### DIFF
--- a/docker/airflow/local_airflow.md
+++ b/docker/airflow/local_airflow.md
@@ -38,6 +38,21 @@ curl -L 'https://raw.githubusercontent.com/linkedin/datahub/master/metadata-inge
 - This docker-compose file also sets up the ENV variables to configure Airflow's Lineage Backend to talk to DataHub. (Look for the `AIRFLOW__LINEAGE__BACKEND` and `AIRFLOW__LINEAGE__DATAHUB_KWARGS` variables) 
 
 ## Step 2: Bring up Airflow
+
+First you need to initialize airflow in order to create initial database tables and the initial airflow user.
+```
+docker-compose up airflow-init
+```
+You should see the following final initialization message
+
+```
+airflow-init_1       | Admin user airflow created
+airflow-init_1       | 2.1.3
+airflow_install_airflow-init_1 exited with code 0
+
+```
+Afterwards you need to start the airflow docker-compose
+
 ```
 docker-compose up
 ```
@@ -79,18 +94,8 @@ flower_1             | DB_PORT=6379
 flower_1             | 
 ```
 
-Finally, Airflow should be healthy and up on port 58080. 
-
-```
-airflow-webserver_1  | 172.22.0.1 - - [31/Aug/2021:20:30:52 +0000] "GET /static/appbuilder/fonts/fontawesome-webfont.woff2?v=4.7.0 HTTP/1.1" 304 0 "http://localhost:58080/static/appbuilder/css/font-awesome.min.css" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.159 Safari/537.36"
-airflow-init_1       | Admin user airflow created
-airflow-init_1       | 2.1.3
-airflow_install_airflow-init_1 exited with code 0
-
-```
-
-Navigate to http://localhost:58080 to confirm and find your Airflow webserver. 
-Default username and password is:
+Finally, Airflow should be healthy and up on port 58080. Navigate to http://localhost:58080 to confirm and find your Airflow webserver. 
+The default username and password is:
 ```
 airflow:airflow
 ```


### PR DESCRIPTION
There is an Error in the "Running airflow locally" documentation: 

As described in the [official airflow documentation](https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html#initialize-the-database), the doc is missing the airflow-init statement. The result is that the container won´t start properly as the initial database tables and the initial user are missing.

The fix is to add the missing line to the documentation and rearrange the paragraphs.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
