### PR TITLE
feat(tableau): emit workbook as container entity in tableau source, some minor fixes in tableau source

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/types/dataset/mappers/DatasetMapper.java
@@ -108,7 +108,12 @@ public class DatasetMapper implements ModelMapper<EntityResponse, Dataset> {
             properties.setExternalUrl(gmsProperties.getExternalUrl().toString());
         }
         properties.setCustomProperties(StringMapMapper.map(gmsProperties.getCustomProperties()));
-        properties.setName(dataset.getName()); // TODO: Move to using a display name produced by ingestion soures
+        if (gmsProperties.getName() != null) {
+            properties.setName(gmsProperties.getName());
+        } else {
+            properties.setName(dataset.getName());
+        }
+        properties.setQualifiedName(gmsProperties.getQualifiedName());
         dataset.setProperties(properties);
         dataset.setDescription(properties.getDescription());
         if (gmsProperties.getUri() != null) {

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -567,7 +567,8 @@ type Dataset implements EntityWithRelationships & Entity {
     container: Container
 
     """
-    The Dataset display name
+    Unique guid for dataset
+    No longer to be used as the Dataset display name. Use properties.name instead
     """
     name: String!
 
@@ -767,7 +768,12 @@ type DatasetProperties {
     """
     The name of the dataset used in display
     """
-    name: String
+    name: String!
+
+    """
+    Fully-qualified name of the Dataset
+    """
+    qualifiedName: String
 
     """
     Environment in which the dataset belongs to or where it was generated

--- a/datahub-web-react/src/Mocks.tsx
+++ b/datahub-web-react/src/Mocks.tsx
@@ -135,6 +135,7 @@ const dataset1 = {
     tags: ['Private', 'PII'],
     uri: 'www.google.com',
     properties: {
+        name: 'The Great Test Dataset',
         description: 'This is the greatest dataset in the world, youre gonna love it!',
         customProperties: [
             {
@@ -222,6 +223,7 @@ const dataset2 = {
     tags: ['Outdated'],
     uri: 'www.google.com',
     properties: {
+        name: 'Some Other Dataset',
         description: 'This is some other dataset, so who cares!',
         customProperties: [],
     },
@@ -294,6 +296,7 @@ export const dataset3 = {
     origin: 'PROD',
     uri: 'www.google.com',
     properties: {
+        name: 'Yet Another Dataset',
         description: 'This and here we have yet another Dataset (YAN). Are there more?',
         origin: 'PROD',
         customProperties: [{ key: 'propertyAKey', value: 'propertyAValue' }],
@@ -473,24 +476,52 @@ export const dataset4 = {
     ...dataset3,
     name: 'Fourth Test Dataset',
     urn: 'urn:li:dataset:4',
+    properties: {
+        name: 'Fourth Test Dataset',
+        description: 'This and here we have yet another Dataset (YAN). Are there more?',
+        origin: 'PROD',
+        customProperties: [{ key: 'propertyAKey', value: 'propertyAValue' }],
+        externalUrl: 'https://data.hub',
+    },
 };
 
 export const dataset5 = {
     ...dataset3,
     name: 'Fifth Test Dataset',
     urn: 'urn:li:dataset:5',
+    properties: {
+        name: 'Fifth Test Dataset',
+        description: 'This and here we have yet another Dataset (YAN). Are there more?',
+        origin: 'PROD',
+        customProperties: [{ key: 'propertyAKey', value: 'propertyAValue' }],
+        externalUrl: 'https://data.hub',
+    },
 };
 
 export const dataset6 = {
     ...dataset3,
     name: 'Sixth Test Dataset',
     urn: 'urn:li:dataset:6',
+    properties: {
+        name: 'Sixth Test Dataset',
+        description: 'This and here we have yet another Dataset (YAN). Are there more?',
+        origin: 'PROD',
+        customProperties: [{ key: 'propertyAKey', value: 'propertyAValue' }],
+        externalUrl: 'https://data.hub',
+    },
 };
 
 export const dataset7 = {
     ...dataset3,
     name: 'Seventh Test Dataset',
     urn: 'urn:li:dataset:7',
+    properties: {
+        name: 'Seventh Test Dataset',
+        description: 'This and here we have yet another Dataset (YAN). Are there more?',
+        origin: 'PROD',
+        customProperties: [{ key: 'propertyAKey', value: 'propertyAValue' }],
+        externalUrl: 'https://data.hub',
+    },
 };
 
 export const dataset3WithLineage = {

--- a/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entity/dataset/DatasetEntity.tsx
@@ -179,6 +179,7 @@ export class DatasetEntity implements Entity<Dataset> {
         // if dataset has subTypes filled out, pick the most specific subtype and return it
         const subTypes = dataset?.subTypes;
         return {
+            name: dataset?.properties?.name || dataset?.name,
             externalUrl: dataset?.properties?.externalUrl,
             entityTypeOverride: subTypes ? capitalizeFirstLetter(subTypes.typeNames?.[0]) : '',
         };
@@ -188,7 +189,7 @@ export class DatasetEntity implements Entity<Dataset> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.name}
+                name={data.properties?.name || data.name}
                 origin={data.origin}
                 subtype={data.subTypes?.typeNames?.[0]}
                 description={data.editableProperties?.description || data.properties?.description}
@@ -208,7 +209,7 @@ export class DatasetEntity implements Entity<Dataset> {
         return (
             <Preview
                 urn={data.urn}
-                name={data.name}
+                name={data.properties?.name || data.name}
                 origin={data.origin}
                 description={data.editableProperties?.description || data.properties?.description}
                 platformName={data.platform.properties?.displayName || data.platform.name}
@@ -237,7 +238,7 @@ export class DatasetEntity implements Entity<Dataset> {
     getLineageVizConfig = (entity: Dataset) => {
         return {
             urn: entity?.urn,
-            name: entity?.name,
+            name: entity.properties?.name || entity.name,
             type: EntityType.Dataset,
             subtype: entity.subTypes?.typeNames?.[0] || undefined,
             downstreamChildren: getChildrenFromRelationships({
@@ -260,7 +261,7 @@ export class DatasetEntity implements Entity<Dataset> {
     };
 
     displayName = (data: Dataset) => {
-        return data?.name;
+        return data?.properties?.name || data.name;
     };
 
     platformLogoUrl = (data: Dataset) => {

--- a/datahub-web-react/src/graphql/browse.graphql
+++ b/datahub-web-react/src/graphql/browse.graphql
@@ -13,6 +13,7 @@ query getBrowseResults($input: BrowseInput!) {
                 name
                 origin
                 properties {
+                    name
                     description
                 }
                 editableProperties {

--- a/datahub-web-react/src/graphql/fragments.graphql
+++ b/datahub-web-react/src/graphql/fragments.graphql
@@ -125,6 +125,7 @@ fragment nonRecursiveDatasetFields on Dataset {
     }
     platformNativeType
     properties {
+        name
         description
         customProperties {
             key

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -13,6 +13,7 @@ fragment entityPreview on Entity {
         }
         platformNativeType
         properties {
+            name
             description
             customProperties {
                 key

--- a/datahub-web-react/src/graphql/relationships.graphql
+++ b/datahub-web-react/src/graphql/relationships.graphql
@@ -64,6 +64,7 @@ fragment relationshipFields on Entity {
     ... on Dataset {
         name
         properties {
+            name
             description
         }
         editableProperties {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -35,6 +35,7 @@ fragment searchResults on SearchResults {
                 }
                 platformNativeType
                 properties {
+                    name
                     description
                     customProperties {
                         key

--- a/metadata-ingestion/source_docs/tableau.md
+++ b/metadata-ingestion/source_docs/tableau.md
@@ -18,22 +18,25 @@ on Tableau online.
 Tableau's GraphQL interface is used to extract metadata information. Queries used to extract metadata are located
 in `metadata-ingestion/src/datahub/ingestion/source/tableau_common.py`
 
+- [Workbook](#Workbook)
 - [Dashboard](#Dashboard)
 - [Sheet](#Sheet)
 - [Embedded Data source](#Embedded-Data-Source)
 - [Published Data source](#Published-Data-Source)
 - [Custom SQL Data source](#Custom-SQL-Data-Source)
 
-### Dashboard
-Dashboards from Tableau are ingested as Dashboard in datahub. <br/>
+
+### Workbook
+Workbooks from Tableau are ingested as Container in datahub. <br/>
 - GraphQL query <br/>
-```
+```graphql
 {
   workbooksConnection(first: 15, offset: 0, filter: {projectNameWithin: ["default", "Project 2"]}) {
     nodes {
       id
       name
       luid
+      uri
       projectName
       owner {
         username
@@ -42,6 +45,24 @@ Dashboards from Tableau are ingested as Dashboard in datahub. <br/>
       uri
       createdAt
       updatedAt
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    totalCount
+  }
+}
+```
+
+### Dashboard
+Dashboards from Tableau are ingested as Dashboard in datahub. <br/>
+- GraphQL query <br/>
+```graphql
+{
+  workbooksConnection(first: 15, offset: 0, filter: {projectNameWithin: ["default", "Project 2"]}) {
+    nodes {
+      .....
       dashboards {
         id
         name
@@ -67,7 +88,7 @@ Dashboards from Tableau are ingested as Dashboard in datahub. <br/>
 ### Sheet
 Sheets from Tableau are ingested as charts in datahub. <br/>
 - GraphQL query <br/>
-```
+```graphql
 {
   workbooksConnection(first: 10, offset: 0, filter: {projectNameWithin: ["default"]}) {
     .....
@@ -149,7 +170,7 @@ Sheets from Tableau are ingested as charts in datahub. <br/>
 Embedded Data source from Tableau is ingested as a Dataset in datahub.
 
 - GraphQL query <br/>
-```
+```graphql
 {
   workbooksConnection(first: 15, offset: 0, filter: {projectNameWithin: ["default"]}) {
     nodes {
@@ -228,7 +249,7 @@ Embedded Data source from Tableau is ingested as a Dataset in datahub.
 Published Data source from Tableau is ingested as a Dataset in datahub.
 
 - GraphQL query <br/>
-```
+```graphql
 {
   publishedDatasourcesConnection(filter: {idWithin: ["00cce29f-b561-bb41-3557-8e19660bb5dd", "618c87db-5959-338b-bcc7-6f5f4cc0b6c6"]}) {
     nodes {
@@ -306,7 +327,7 @@ Published Data source from Tableau is ingested as a Dataset in datahub.
 ### Custom SQL Data Source
 For custom sql data sources, the query is viewable in UI under View Definition tab. <br/>
 - GraphQL query <br/>
-```
+```graphql
 {
   customSQLTablesConnection(filter: {idWithin: ["22b0b4c3-6b85-713d-a161-5a87fdd78f40"]}) {
     nodes {
@@ -397,8 +418,8 @@ sink:
 | `env`                 |          | `"PROD"`  | Environment to use in namespace when constructing URNs.                  |
 | `username`            |          |           | Tableau username, must be set if authenticating using username/password.    |
 | `password`            |          |           | Tableau password, must be set if authenticating using username/password.    |
-| `token_name`          |          |           | Tableau token name, must be set if authenticating using a personal token.  |
-| `token_value`         |          |           | Tableau token value, must be set if authenticating using a personal token. |
+| `token_name`          |          |           | Tableau token name, must be set if authenticating using a personal access token.  |
+| `token_value`         |          |           | Tableau token value, must be set if authenticating using a personal access token. |
 | `projects`            |          | `default` | List of projects                                                         |
 | `workbooks_page_size`            |          | 10 | Number of workbooks to query at a time using Tableau api.                                              |
 | `default_schema_map`* |          |           | Default schema to use when schema is not found.                          |
@@ -417,8 +438,7 @@ and personal token. For more information on Tableau authentication, refer to [Ho
 
 ## Compatibility
 
-Tableau Server Version: 2021.4.0 (20214.22.0114.0959) 64-bit Linux <br/>
-Tableau Pod: prod-ca-a
+Tableau Server Version: 2021.4.0 (20214.22.0114.0959) 64-bit Linux 
 
 
 ## Questions

--- a/metadata-ingestion/source_docs/tableau.md
+++ b/metadata-ingestion/source_docs/tableau.md
@@ -393,7 +393,7 @@ sink:
 | Field                 | Required | Default   | Description                                                              |
 |-----------------------|----------|-----------|--------------------------------------------------------------------------|
 | `connect_uri`         | ✅        |           | Tableau host URL.                                                        |
-| `site`                | ✅        |           | Tableau Site. Use emptystring "" to connect with Default site on Tableau Server  |
+| `site`                |          |  `""`    | Tableau Site. Always required for Tableau Online. Use emptystring "" to connect with Default site on Tableau Server.   |
 | `env`                 |          | `"PROD"`  | Environment to use in namespace when constructing URNs.                  |
 | `username`            |          |           | Tableau username, must be set if authenticating using username/password.    |
 | `password`            |          |           | Tableau password, must be set if authenticating using username/password.    |

--- a/metadata-ingestion/source_docs/tableau.md
+++ b/metadata-ingestion/source_docs/tableau.md
@@ -1,5 +1,4 @@
 # Tableau
-
 For context on getting started with ingestion, check out our [metadata ingestion guide](../README.md).
 
 Note that this connector is currently considered in `BETA`, and has not been validated for production use. 
@@ -377,9 +376,7 @@ source:
     # Credentials
     username: username@acrylio.com
     password: pass
-    token_name: Acryl
-    token_value: token_generated_from_tableau
-    
+
     # Options
     ingest_tags: True
     ingest_owner: True
@@ -396,24 +393,25 @@ sink:
 | Field                 | Required | Default   | Description                                                              |
 |-----------------------|----------|-----------|--------------------------------------------------------------------------|
 | `connect_uri`         | ✅        |           | Tableau host URL.                                                        |
-| `site`                | ✅        |           | Tableau Online Site                                                      |
+| `site`                | ✅        |           | Tableau Site. Use emptystring "" to connect with Default site on Tableau Server  |
 | `env`                 |          | `"PROD"`  | Environment to use in namespace when constructing URNs.                  |
-| `username`            |          |           | Tableau user name.                                                       |
-| `password`            |          |           | Tableau password for authentication.                                     |
-| `token_name`          |          |           | Tableau token name if authenticating using a personal token.             |
-| `token_value`         |          |           | Tableau token value if authenticating using a personal token.            |
+| `username`            |          |           | Tableau username, must be set if authenticating using username/password.    |
+| `password`            |          |           | Tableau password, must be set if authenticating using username/password.    |
+| `token_name`          |          |           | Tableau token name, must be set if authenticating using a personal token.  |
+| `token_value`         |          |           | Tableau token value, must be set if authenticating using a personal token. |
 | `projects`            |          | `default` | List of projects                                                         |
+| `workbooks_page_size`            |          | 10 | Number of workbooks to query at a time using Tableau api.                                              |
 | `default_schema_map`* |          |           | Default schema to use when schema is not found.                          |
 | `ingest_tags`         |          | `False`   | Ingest Tags from source. This will override Tags entered from UI         |
 | `ingest_owners`       |          | `False`   | Ingest Owner from source. This will override Owner info entered from UI  |
 
-
 *Tableau may not provide schema name when ingesting Custom SQL data source. Use `default_schema_map` to provide a default
 schema name to use when constructing a table URN.
 
+
 ### Authentication
 
-Currently, authentication is supported on Tableau Online using username and password
+Currently, authentication is supported on Tableau using username and password
 and personal token. For more information on Tableau authentication, refer to [How to Authenticate](https://help.tableau.com/current/api/metadata_api/en-us/docs/meta_api_auth.html) guide.
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -338,6 +338,12 @@ class TableauSource(Source):
                 )
                 dataset_snapshot.aspects.append(browse_paths)
 
+                dataset_properties = DatasetPropertiesClass(
+                    name=csql.get("name"), description=csql.get("description")
+                )
+
+                dataset_snapshot.aspects.append(dataset_properties)
+
                 view_properties = ViewPropertiesClass(
                     materialized=False,
                     viewLanguage="SQL",

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -541,7 +541,8 @@ class TableauSource(Source):
 
         # Dataset properties
         dataset_props = DatasetPropertiesClass(
-            description=datasource.get("name", ""),
+            name=datasource.get("name"),
+            description=datasource.get("description"),
             customProperties={
                 "hasExtracts": str(datasource.get("hasExtracts", "")),
                 "extractLastRefreshTime": datasource.get("extractLastRefreshTime", "")

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau.py
@@ -82,7 +82,7 @@ class TableauConfig(ConfigModel):
     token_name: Optional[str] = None
     token_value: Optional[str] = None
 
-    site: str
+    site: str = ""
     projects: Optional[List] = ["default"]
     default_schema_map: dict = {}
     ingest_tags: Optional[bool] = False

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -420,9 +420,9 @@ def make_description_from_params(description, formula):
 
 def get_field_value_in_sheet(field, field_name):
     if field.get("__typename", "") == "DatasourceField":
-        field_value = field.get("remoteField", {}).get(field_name, "")
-    else:
-        field_value = field.get(field_name, "")
+        field = field.get("remoteField") if field.get("remoteField") else {}
+
+    field_value = field.get(field_name, "")
     return field_value
 
 
@@ -477,8 +477,4 @@ def query_metadata(server, main_query, connection_name, first, offset, qry_filte
     )
     query_result = server.metadata.query(query)
 
-    if "errors" in query_result:
-        raise MetadataQueryException(
-            f"Connection: {connection_name} Error: {query_result['errors']}"
-        )
     return query_result

--- a/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/tableau_common.py
@@ -28,6 +28,7 @@ workbook_graphql_query = """
       id
       name
       luid
+      uri
       projectName
       owner {
         username

--- a/metadata-ingestion/tests/integration/tableau/setup/publishedDatasourcesConnection_2.json
+++ b/metadata-ingestion/tests/integration/tableau/setup/publishedDatasourcesConnection_2.json
@@ -213,7 +213,7 @@
                     "owner": {
                         "username": "jawadqu@gmail.com"
                     },
-                    "description": "",
+                    "description": "description for test publish datasource",
                     "uri": "sites/4989/datasources/155429",
                     "projectName": "default"
                 },
@@ -814,7 +814,7 @@
                     "owner": {
                         "username": "jawadqu@gmail.com"
                     },
-                    "description": "",
+                    "description": "Description for Superstore dataset",
                     "uri": "sites/4989/datasources/136096",
                     "projectName": "Samples"
                 }

--- a/metadata-ingestion/tests/integration/tableau/setup/workbooksConnection_8.json
+++ b/metadata-ingestion/tests/integration/tableau/setup/workbooksConnection_8.json
@@ -10,7 +10,7 @@
                     "owner": {
                         "username": "jawadqu@gmail.com"
                     },
-                    "description": "",
+                    "description": "Description for Email Performance by Campaign",
                     "uri": "sites/4989/workbooks/15995",
                     "createdAt": "2021-12-22T19:10:34Z",
                     "updatedAt": "2021-12-22T19:10:34Z",

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
@@ -26,11 +26,13 @@ record DatasetProperties includes CustomProperties, ExternalReference {
    * Fully-qualified name of the Dataset
    */
   @Searchable = {
-    "fieldType": "TEXT_PARTIAL",
+    "fieldType": "TEXT",
+    "addToFilters": false,
     "enableAutocomplete": true,
     "boostScore": 10.0
   }
   qualifiedName: optional string
+
   /**
    * Documentation of the dataset
    */

--- a/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/dataset/DatasetProperties.pdl
@@ -13,6 +13,25 @@ import com.linkedin.common.ExternalReference
 record DatasetProperties includes CustomProperties, ExternalReference {
 
   /**
+   * Display name of the Dataset
+   */
+  @Searchable = {
+    "fieldType": "TEXT_PARTIAL",
+    "enableAutocomplete": true,
+    "boostScore": 10.0
+  }
+  name: optional string
+
+  /**
+   * Fully-qualified name of the Dataset
+   */
+  @Searchable = {
+    "fieldType": "TEXT_PARTIAL",
+    "enableAutocomplete": true,
+    "boostScore": 10.0
+  }
+  qualifiedName: optional string
+  /**
    * Documentation of the dataset
    */
   @Searchable = {

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DatasetKey.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DatasetKey.pdl
@@ -16,8 +16,9 @@ record DatasetKey {
   platform: Urn
 
   /**
-  * Dataset native name e.g. <db>.<table>, /dir/subdir/<name>, or <name>
+  * Unique guid for dataset
   */
+  //This is no longer to be used for Dataset native name. Use name, qualifiedName from DatasetProperties instead.
   @Searchable = {
     "fieldType": "TEXT_PARTIAL",
     "enableAutocomplete": true,

--- a/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DatasetKey.pdl
+++ b/metadata-models/src/main/pegasus/com/linkedin/metadata/key/DatasetKey.pdl
@@ -20,6 +20,7 @@ record DatasetKey {
   */
   //This is no longer to be used for Dataset native name. Use name, qualifiedName from DatasetProperties instead.
   @Searchable = {
+    "fieldName": "id"
     "fieldType": "TEXT_PARTIAL",
     "enableAutocomplete": true,
     "boostScore": 10.0

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.aspects.snapshot.json
@@ -1359,8 +1359,14 @@
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
-      "doc" : "Fields of the input datasets used by this job.",
+      "doc" : "Fields of the input datasets used by this job",
       "optional" : true,
+      "Relationship" : {
+        "/*" : {
+          "entityTypes" : [ "schemaField" ],
+          "name" : "Consumes"
+        }
+      },
       "Searchable" : {
         "/*" : {
           "fieldName" : "inputFields",
@@ -1375,8 +1381,14 @@
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
-      "doc" : "Fields of the output datasets this job writes to.",
+      "doc" : "Fields of the output datasets this job writes to",
       "optional" : true,
+      "Relationship" : {
+        "/*" : {
+          "entityTypes" : [ "schemaField" ],
+          "name" : "Produces"
+        }
+      },
       "Searchable" : {
         "/*" : {
           "fieldName" : "outputFields",
@@ -1393,18 +1405,18 @@
           "type" : "record",
           "name" : "FineGrainedLineage",
           "namespace" : "com.linkedin.dataset",
-          "doc" : "A fine-grained lineage from upstream fields/datasets to downstream field(s).",
+          "doc" : "A fine-grained lineage from upstream fields/datasets to downstream field(s)",
           "fields" : [ {
             "name" : "upstreamType",
             "type" : {
               "type" : "enum",
               "name" : "FineGrainedLineageUpstreamType",
-              "doc" : "The type of upstream entity in a fine-grained lineage.",
+              "doc" : "The type of upstream entity in a fine-grained lineage",
               "symbols" : [ "FIELD_SET", "DATASET", "NONE" ],
               "symbolDocs" : {
-                "DATASET" : " Indicates that this lineage is originating from upstream dataset(s).",
-                "FIELD_SET" : " Indicates that this lineage is originating from upstream field(s).",
-                "NONE" : " Indicates that there is no upstream lineage i.e. the downstream field is not a derived field."
+                "DATASET" : " Indicates that this lineage is originating from upstream dataset(s)",
+                "FIELD_SET" : " Indicates that this lineage is originating from upstream field(s)",
+                "NONE" : " Indicates that there is no upstream lineage i.e. the downstream field is not a derived field"
               }
             },
             "doc" : "The type of upstream entity"
@@ -1421,11 +1433,11 @@
             "type" : {
               "type" : "enum",
               "name" : "FineGrainedLineageDownstreamType",
-              "doc" : "The type of downstream field(s) in a fine-grained lineage.",
+              "doc" : "The type of downstream field(s) in a fine-grained lineage",
               "symbols" : [ "FIELD", "FIELD_SET" ],
               "symbolDocs" : {
-                "FIELD" : " Indicates that the lineage is for a single, specific, downstream field.",
-                "FIELD_SET" : " Indicates that the lineage is for a set of downstream fields."
+                "FIELD" : " Indicates that the lineage is for a single, specific, downstream field",
+                "FIELD_SET" : " Indicates that the lineage is for a set of downstream fields"
               }
             },
             "doc" : "The type of downstream field(s)"
@@ -1440,17 +1452,17 @@
           }, {
             "name" : "transformOperation",
             "type" : "string",
-            "doc" : "The transform operation applied to the upstream entities to produce the downstream field(s).",
+            "doc" : "The transform operation applied to the upstream entities to produce the downstream field(s)",
             "optional" : true
           }, {
             "name" : "confidenceScore",
             "type" : "float",
-            "doc" : "The confidence in this lineage between 0 (low confidence) and 1 (high confidence).",
+            "doc" : "The confidence in this lineage between 0 (low confidence) and 1 (high confidence)",
             "default" : 1.0
           } ]
         }
       },
-      "doc" : "Fine-grained column-level lineages.",
+      "doc" : "Fine-grained column-level lineages",
       "optional" : true
     } ],
     "Aspect" : {
@@ -1508,6 +1520,26 @@
     "doc" : "Properties associated with a Dataset",
     "include" : [ "com.linkedin.common.CustomProperties", "com.linkedin.common.ExternalReference" ],
     "fields" : [ {
+      "name" : "name",
+      "type" : "string",
+      "doc" : "Display name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "boostScore" : 10.0,
+        "enableAutocomplete" : true,
+        "fieldType" : "TEXT_PARTIAL"
+      }
+    }, {
+      "name" : "qualifiedName",
+      "type" : "string",
+      "doc" : "Fully-qualified name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "boostScore" : 10.0,
+        "enableAutocomplete" : true,
+        "fieldType" : "TEXT_PARTIAL"
+      }
+    }, {
       "name" : "description",
       "type" : "string",
       "doc" : "Documentation of the dataset",
@@ -1590,7 +1622,13 @@
         "items" : "FineGrainedLineage"
       },
       "doc" : " List of fine-grained lineage information, including field-level lineage",
-      "optional" : true
+      "optional" : true,
+      "Relationship" : {
+        "/*/upstreams/*" : {
+          "entityTypes" : [ "dataset", "schemaField" ],
+          "name" : "DownstreamOf"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "upstreamLineage"

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.entities.snapshot.json
@@ -1405,8 +1405,14 @@
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
-      "doc" : "Fields of the input datasets used by this job.",
+      "doc" : "Fields of the input datasets used by this job",
       "optional" : true,
+      "Relationship" : {
+        "/*" : {
+          "entityTypes" : [ "schemaField" ],
+          "name" : "Consumes"
+        }
+      },
       "Searchable" : {
         "/*" : {
           "fieldName" : "inputFields",
@@ -1421,8 +1427,14 @@
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
-      "doc" : "Fields of the output datasets this job writes to.",
+      "doc" : "Fields of the output datasets this job writes to",
       "optional" : true,
+      "Relationship" : {
+        "/*" : {
+          "entityTypes" : [ "schemaField" ],
+          "name" : "Produces"
+        }
+      },
       "Searchable" : {
         "/*" : {
           "fieldName" : "outputFields",
@@ -1439,18 +1451,18 @@
           "type" : "record",
           "name" : "FineGrainedLineage",
           "namespace" : "com.linkedin.dataset",
-          "doc" : "A fine-grained lineage from upstream fields/datasets to downstream field(s).",
+          "doc" : "A fine-grained lineage from upstream fields/datasets to downstream field(s)",
           "fields" : [ {
             "name" : "upstreamType",
             "type" : {
               "type" : "enum",
               "name" : "FineGrainedLineageUpstreamType",
-              "doc" : "The type of upstream entity in a fine-grained lineage.",
+              "doc" : "The type of upstream entity in a fine-grained lineage",
               "symbols" : [ "FIELD_SET", "DATASET", "NONE" ],
               "symbolDocs" : {
-                "DATASET" : " Indicates that this lineage is originating from upstream dataset(s).",
-                "FIELD_SET" : " Indicates that this lineage is originating from upstream field(s).",
-                "NONE" : " Indicates that there is no upstream lineage i.e. the downstream field is not a derived field."
+                "DATASET" : " Indicates that this lineage is originating from upstream dataset(s)",
+                "FIELD_SET" : " Indicates that this lineage is originating from upstream field(s)",
+                "NONE" : " Indicates that there is no upstream lineage i.e. the downstream field is not a derived field"
               }
             },
             "doc" : "The type of upstream entity"
@@ -1467,11 +1479,11 @@
             "type" : {
               "type" : "enum",
               "name" : "FineGrainedLineageDownstreamType",
-              "doc" : "The type of downstream field(s) in a fine-grained lineage.",
+              "doc" : "The type of downstream field(s) in a fine-grained lineage",
               "symbols" : [ "FIELD", "FIELD_SET" ],
               "symbolDocs" : {
-                "FIELD" : " Indicates that the lineage is for a single, specific, downstream field.",
-                "FIELD_SET" : " Indicates that the lineage is for a set of downstream fields."
+                "FIELD" : " Indicates that the lineage is for a single, specific, downstream field",
+                "FIELD_SET" : " Indicates that the lineage is for a set of downstream fields"
               }
             },
             "doc" : "The type of downstream field(s)"
@@ -1486,17 +1498,17 @@
           }, {
             "name" : "transformOperation",
             "type" : "string",
-            "doc" : "The transform operation applied to the upstream entities to produce the downstream field(s).",
+            "doc" : "The transform operation applied to the upstream entities to produce the downstream field(s)",
             "optional" : true
           }, {
             "name" : "confidenceScore",
             "type" : "float",
-            "doc" : "The confidence in this lineage between 0 (low confidence) and 1 (high confidence).",
+            "doc" : "The confidence in this lineage between 0 (low confidence) and 1 (high confidence)",
             "default" : 1.0
           } ]
         }
       },
-      "doc" : "Fine-grained column-level lineages.",
+      "doc" : "Fine-grained column-level lineages",
       "optional" : true
     } ],
     "Aspect" : {
@@ -1722,6 +1734,26 @@
     "doc" : "Properties associated with a Dataset",
     "include" : [ "com.linkedin.common.CustomProperties", "com.linkedin.common.ExternalReference" ],
     "fields" : [ {
+      "name" : "name",
+      "type" : "string",
+      "doc" : "Display name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "boostScore" : 10.0,
+        "enableAutocomplete" : true,
+        "fieldType" : "TEXT_PARTIAL"
+      }
+    }, {
+      "name" : "qualifiedName",
+      "type" : "string",
+      "doc" : "Fully-qualified name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "boostScore" : 10.0,
+        "enableAutocomplete" : true,
+        "fieldType" : "TEXT_PARTIAL"
+      }
+    }, {
       "name" : "description",
       "type" : "string",
       "doc" : "Documentation of the dataset",
@@ -1840,7 +1872,13 @@
         "items" : "FineGrainedLineage"
       },
       "doc" : " List of fine-grained lineage information, including field-level lineage",
-      "optional" : true
+      "optional" : true,
+      "Relationship" : {
+        "/*/upstreams/*" : {
+          "entityTypes" : [ "dataset", "schemaField" ],
+          "name" : "DownstreamOf"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "upstreamLineage"
@@ -2490,7 +2528,7 @@
                   }, {
                     "name" : "name",
                     "type" : "string",
-                    "doc" : "Dataset native name e.g. <db>.<table>, /dir/subdir/<name>, or <name>",
+                    "doc" : "Unique guid for dataset",
                     "Searchable" : {
                       "boostScore" : 10.0,
                       "enableAutocomplete" : true,
@@ -3943,6 +3981,12 @@
                         "entityTypes" : [ "mlFeature" ],
                         "name" : "Contains"
                       }
+                    },
+                    "Searchable" : {
+                      "/*" : {
+                        "fieldName" : "features",
+                        "fieldType" : "URN"
+                      }
                     }
                   }, {
                     "name" : "mlPrimaryKeys",
@@ -3956,6 +4000,12 @@
                       "/*" : {
                         "entityTypes" : [ "mlPrimaryKey" ],
                         "name" : "KeyedBy"
+                      }
+                    },
+                    "Searchable" : {
+                      "/*" : {
+                        "fieldName" : "primaryKeys",
+                        "fieldType" : "URN"
                       }
                     }
                   } ],

--- a/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
+++ b/metadata-service/restli-api/src/main/snapshot/com.linkedin.entity.runs.snapshot.json
@@ -1129,8 +1129,14 @@
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
-      "doc" : "Fields of the input datasets used by this job.",
+      "doc" : "Fields of the input datasets used by this job",
       "optional" : true,
+      "Relationship" : {
+        "/*" : {
+          "entityTypes" : [ "schemaField" ],
+          "name" : "Consumes"
+        }
+      },
       "Searchable" : {
         "/*" : {
           "fieldName" : "inputFields",
@@ -1145,8 +1151,14 @@
         "type" : "array",
         "items" : "com.linkedin.common.Urn"
       },
-      "doc" : "Fields of the output datasets this job writes to.",
+      "doc" : "Fields of the output datasets this job writes to",
       "optional" : true,
+      "Relationship" : {
+        "/*" : {
+          "entityTypes" : [ "schemaField" ],
+          "name" : "Produces"
+        }
+      },
       "Searchable" : {
         "/*" : {
           "fieldName" : "outputFields",
@@ -1163,18 +1175,18 @@
           "type" : "record",
           "name" : "FineGrainedLineage",
           "namespace" : "com.linkedin.dataset",
-          "doc" : "A fine-grained lineage from upstream fields/datasets to downstream field(s).",
+          "doc" : "A fine-grained lineage from upstream fields/datasets to downstream field(s)",
           "fields" : [ {
             "name" : "upstreamType",
             "type" : {
               "type" : "enum",
               "name" : "FineGrainedLineageUpstreamType",
-              "doc" : "The type of upstream entity in a fine-grained lineage.",
+              "doc" : "The type of upstream entity in a fine-grained lineage",
               "symbols" : [ "FIELD_SET", "DATASET", "NONE" ],
               "symbolDocs" : {
-                "DATASET" : " Indicates that this lineage is originating from upstream dataset(s).",
-                "FIELD_SET" : " Indicates that this lineage is originating from upstream field(s).",
-                "NONE" : " Indicates that there is no upstream lineage i.e. the downstream field is not a derived field."
+                "DATASET" : " Indicates that this lineage is originating from upstream dataset(s)",
+                "FIELD_SET" : " Indicates that this lineage is originating from upstream field(s)",
+                "NONE" : " Indicates that there is no upstream lineage i.e. the downstream field is not a derived field"
               }
             },
             "doc" : "The type of upstream entity"
@@ -1191,11 +1203,11 @@
             "type" : {
               "type" : "enum",
               "name" : "FineGrainedLineageDownstreamType",
-              "doc" : "The type of downstream field(s) in a fine-grained lineage.",
+              "doc" : "The type of downstream field(s) in a fine-grained lineage",
               "symbols" : [ "FIELD", "FIELD_SET" ],
               "symbolDocs" : {
-                "FIELD" : " Indicates that the lineage is for a single, specific, downstream field.",
-                "FIELD_SET" : " Indicates that the lineage is for a set of downstream fields."
+                "FIELD" : " Indicates that the lineage is for a single, specific, downstream field",
+                "FIELD_SET" : " Indicates that the lineage is for a set of downstream fields"
               }
             },
             "doc" : "The type of downstream field(s)"
@@ -1210,17 +1222,17 @@
           }, {
             "name" : "transformOperation",
             "type" : "string",
-            "doc" : "The transform operation applied to the upstream entities to produce the downstream field(s).",
+            "doc" : "The transform operation applied to the upstream entities to produce the downstream field(s)",
             "optional" : true
           }, {
             "name" : "confidenceScore",
             "type" : "float",
-            "doc" : "The confidence in this lineage between 0 (low confidence) and 1 (high confidence).",
+            "doc" : "The confidence in this lineage between 0 (low confidence) and 1 (high confidence)",
             "default" : 1.0
           } ]
         }
       },
-      "doc" : "Fine-grained column-level lineages.",
+      "doc" : "Fine-grained column-level lineages",
       "optional" : true
     } ],
     "Aspect" : {
@@ -1278,6 +1290,26 @@
     "doc" : "Properties associated with a Dataset",
     "include" : [ "com.linkedin.common.CustomProperties", "com.linkedin.common.ExternalReference" ],
     "fields" : [ {
+      "name" : "name",
+      "type" : "string",
+      "doc" : "Display name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "boostScore" : 10.0,
+        "enableAutocomplete" : true,
+        "fieldType" : "TEXT_PARTIAL"
+      }
+    }, {
+      "name" : "qualifiedName",
+      "type" : "string",
+      "doc" : "Fully-qualified name of the Dataset",
+      "optional" : true,
+      "Searchable" : {
+        "boostScore" : 10.0,
+        "enableAutocomplete" : true,
+        "fieldType" : "TEXT_PARTIAL"
+      }
+    }, {
       "name" : "description",
       "type" : "string",
       "doc" : "Documentation of the dataset",
@@ -1360,7 +1392,13 @@
         "items" : "FineGrainedLineage"
       },
       "doc" : " List of fine-grained lineage information, including field-level lineage",
-      "optional" : true
+      "optional" : true,
+      "Relationship" : {
+        "/*/upstreams/*" : {
+          "entityTypes" : [ "dataset", "schemaField" ],
+          "name" : "DownstreamOf"
+        }
+      }
     } ],
     "Aspect" : {
       "name" : "upstreamLineage"


### PR DESCRIPTION
This PR
- emits Tableau workbook as Container entity and adds charts, dashboards to container
- fixes `View in Tableau` URL for empty/default site in tableau server
- adds workbooks_page_size config parameter which can be tuned to get rid of NODE_LIMIT_EXCEEDED error when querying workbooks

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
