### PR TITLE
fix(ingest): clarify s3/s3a requirements and platform defaults

### DIFF
--- a/metadata-ingestion/source_docs/data_lake.md
+++ b/metadata-ingestion/source_docs/data_lake.md
@@ -10,7 +10,7 @@ This source is in **Beta** and under active development. Not yet considered read
 
 ## Setup
 
-To install this plugin, run `pip install 'acryl-datahub[data-lake]'`. Note that because the profiling is run with PySpark, we require Spark 3.0.3 with Hadoop 3.2 to be installed (see [compatibility](#compatibility) for more details).
+To install this plugin, run `pip install 'acryl-datahub[data-lake]'`. Note that because the profiling is run with PySpark, we require Spark 3.0.3 with Hadoop 3.2 to be installed (see [compatibility](#compatibility) for more details). If ingesting S3 files with Spark, make sure that permissions for **s3a://** access are set as well because Spark and Hadoop use the s3a:// protocol to interface with AWS.
 
 The data lake connector extracts schemas and profiles from a variety of file formats (see below for an exhaustive list).
 Individual files are ingested as tables, and profiles are computed similar to the [SQL profiler](./sql_profiles.md).
@@ -94,7 +94,7 @@ Note that a `.` is used to denote nested fields in the YAML recipe.
 | Field                                                | Required                 | Default      | Description                                                                                                                                                                                                    |
 | ---------------------------------------------------- | ------------------------ | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `env`                                                |                          | `PROD`       | Environment to use in namespace when constructing URNs.                                                                                                                                                        |
-| `platform`                                           | ✅                       |              | Platform to use in namespace when constructing URNs.                                                                                                                                                           |
+| `platform`                                           |                          | Autodetected | Platform to use in namespace when constructing URNs. If left blank, local paths will correspond to `file` and S3 paths will correspond to `s3`.                                                                |
 | `base_path`                                          | ✅                       |              | Path of the base folder to crawl. Unless `schema_patterns` and `profile_patterns` are set, the connector will ingest all files in this folder.                                                                 |
 | `path_spec`                                          |                          |              | Format string for constructing table identifiers from the relative path. See the above [setup section](#setup) for details.                                                                                    |
 | `use_relative_path`                                  |                          | `False`      | Whether to use the relative path when constructing URNs. Has no effect when a `path_spec` is provided.                                                                                                         |

--- a/metadata-ingestion/source_docs/data_lake.md
+++ b/metadata-ingestion/source_docs/data_lake.md
@@ -10,7 +10,7 @@ This source is in **Beta** and under active development. Not yet considered read
 
 ## Setup
 
-To install this plugin, run `pip install 'acryl-datahub[data-lake]'`. Note that because the profiling is run with PySpark, we require Spark 3.0.3 with Hadoop 3.2 to be installed (see [compatibility](#compatibility) for more details). If ingesting S3 files with Spark, make sure that permissions for **s3a://** access are set as well because Spark and Hadoop use the s3a:// protocol to interface with AWS.
+To install this plugin, run `pip install 'acryl-datahub[data-lake]'`. Note that because the profiling is run with PySpark, we require Spark 3.0.3 with Hadoop 3.2 to be installed (see [compatibility](#compatibility) for more details). If profiling, make sure that permissions for **s3a://** access are set because Spark and Hadoop use the s3a:// protocol to interface with AWS (schema inference outside of profiling requires s3:// access).
 
 The data lake connector extracts schemas and profiles from a variety of file formats (see below for an exhaustive list).
 Individual files are ingested as tables, and profiles are computed similar to the [SQL profiler](./sql_profiles.md).

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake/config.py
@@ -6,14 +6,15 @@ import pydantic
 from datahub.configuration.common import AllowDenyPattern, ConfigModel
 from datahub.emitter.mce_builder import DEFAULT_ENV
 from datahub.ingestion.source.aws.aws_common import AwsSourceConfig
+from datahub.ingestion.source.aws.s3_util import is_s3_uri
 from datahub.ingestion.source.data_lake.profiling import DataLakeProfilerConfig
 
 
 class DataLakeSourceConfig(ConfigModel):
 
     env: str = DEFAULT_ENV
-    platform: str
     base_path: str
+    platform: str = "file"  # overwritten by validator below
 
     use_relative_path: bool = False
     ignore_dotfiles: bool = True
@@ -39,6 +40,15 @@ class DataLakeSourceConfig(ConfigModel):
         if profiling is not None and profiling.enabled:
             profiling.allow_deny_patterns = values["profile_patterns"]
         return values
+
+    @pydantic.validator("platform", always=True)
+    def validate_platform(cls, value: str, values: Dict[str, Any]) -> Optional[str]:
+        if value is not None:
+            return value
+
+        if is_s3_uri(values["base_path"]):
+            return "s3"
+        return "file"
 
     @pydantic.validator("path_spec", always=True)
     def validate_path_spec(

--- a/metadata-ingestion/src/datahub/ingestion/source/data_lake/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/data_lake/config.py
@@ -14,7 +14,7 @@ class DataLakeSourceConfig(ConfigModel):
 
     env: str = DEFAULT_ENV
     base_path: str
-    platform: str = "file"  # overwritten by validator below
+    platform: str = ""  # overwritten by validator below
 
     use_relative_path: bool = False
     ignore_dotfiles: bool = True
@@ -43,7 +43,7 @@ class DataLakeSourceConfig(ConfigModel):
 
     @pydantic.validator("platform", always=True)
     def validate_platform(cls, value: str, values: Dict[str, Any]) -> Optional[str]:
-        if value is not None:
+        if value != "":
             return value
 
         if is_s3_uri(values["base_path"]):


### PR DESCRIPTION
Adds a few sentences to the docs clarifying the need to grant S3A permissions when running profiling on files in AWS S3. Also sets the `platform` to `s3` or `file` depending on the `base_path` if `platform` is unspecified.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
