### PR TITLE
bug(schema_version_history): fix semantic version ordering

### DIFF
--- a/metadata-ingestion/src/datahub/cli/timeline_cli.py
+++ b/metadata-ingestion/src/datahub/cli/timeline_cli.py
@@ -49,15 +49,15 @@ def pretty_id(id: Optional[str]) -> str:
                 assert schema_field_key is not None
                 field_path = schema_field_key.fieldPath
 
-                return f"{colored('field','blue')}:{colored(pretty_field_path(field_path),'white')}"
+                return f"{colored('field','cyan')}:{colored(pretty_field_path(field_path),'white')}"
         if id.startswith("[version=2.0]"):
-            return f"{colored('field','blue')}:{colored(pretty_field_path(id),'white')}"
+            return f"{colored('field','cyan')}:{colored(pretty_field_path(id),'white')}"
 
         if id.startswith("urn:li:dataset"):
             # parse dataset urn
             dataset_key = dataset_urn_to_key(id)
             if dataset_key:
-                return f"{colored('dataset','blue')}:{colored(dataset_key.platform,'white')}:{colored(dataset_key.name,'white')}"
+                return f"{colored('dataset','cyan')}:{colored(dataset_key.platform,'white')}:{colored(dataset_key.name,'white')}"
     # failed to prettify, return original
     return id
 
@@ -193,10 +193,11 @@ def timeline(
                 datetime.fromtimestamp(change_txn["timestamp"] // 1000)
             )
             change_color = (
-                "green" if change_txn.get("semVerChange") == "MINOR" else "red"
+                "green" if change_txn.get("semVerChange") == "MINOR" or change_txn.get("semVerChange") == "PATCH"
+                else "red"
             )
             print(
-                f"{colored(change_instant,'blue')} - {colored(change_txn['semVer'],change_color)}"
+                f"{colored(change_instant,'cyan')} - {colored(change_txn['semVer'],change_color)}"
             )
             if change_txn["changeEvents"] is not None:
                 for change_event in change_txn["changeEvents"]:

--- a/metadata-ingestion/src/datahub/cli/timeline_cli.py
+++ b/metadata-ingestion/src/datahub/cli/timeline_cli.py
@@ -193,7 +193,9 @@ def timeline(
                 datetime.fromtimestamp(change_txn["timestamp"] // 1000)
             )
             change_color = (
-                "green" if change_txn.get("semVerChange") == "MINOR" or change_txn.get("semVerChange") == "PATCH"
+                "green"
+                if change_txn.get("semVerChange") == "MINOR"
+                or change_txn.get("semVerChange") == "PATCH"
                 else "red"
             )
             print(

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/differ/GlobalTagsDiffer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/differ/GlobalTagsDiffer.java
@@ -118,7 +118,7 @@ public class GlobalTagsDiffer implements Differ {
         .equals(GLOBAL_TAGS_ASPECT_NAME)) {
       throw new IllegalArgumentException("Aspect is not " + GLOBAL_TAGS_ASPECT_NAME);
     }
-    assert (currentValue != null);
+
     GlobalTags baseGlobalTags = getGlobalTagsFromAspect(previousValue);
     GlobalTags targetGlobalTags = getGlobalTagsFromAspect(currentValue);
     List<ChangeEvent> changeEvents = new ArrayList<>();

--- a/metadata-io/src/main/java/com/linkedin/metadata/timeline/differ/SchemaDiffer.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/timeline/differ/SchemaDiffer.java
@@ -3,6 +3,7 @@ package com.linkedin.metadata.timeline.differ;
 import com.datahub.util.RecordUtils;
 import com.github.fge.jsonpatch.JsonPatch;
 import com.linkedin.common.urn.DatasetUrn;
+import com.linkedin.common.urn.Urn;
 import com.linkedin.metadata.entity.ebean.EbeanAspectV2;
 import com.linkedin.metadata.timeline.data.ChangeCategory;
 import com.linkedin.metadata.timeline.data.ChangeEvent;
@@ -20,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 
 public class SchemaDiffer implements Differ {
@@ -34,21 +36,18 @@ public class SchemaDiffer implements Differ {
   private static final String FIELD_DESCRIPTION_MODIFIED_FORMAT =
       "The description for the field '%s' has been changed from '%s' to '%s'.";
 
-  private static String getFieldPathV1(SchemaField field) {
-    assert (field != null);
+  private static String getFieldPathV1(@Nonnull SchemaField field) {
     String[] v1PathTokens = Arrays.stream(field.getFieldPath().split("\\."))
         .filter(x -> !(x.startsWith("[") || x.endsWith("]")))
         .toArray(String[]::new);
     return String.join(".", v1PathTokens);
   }
 
-  private static String getSchemaFieldUrn(DatasetUrn datasetUrn, SchemaField schemaField) {
-    assert (datasetUrn != null && schemaField != null);
+  private static String getSchemaFieldUrn(@Nonnull Urn datasetUrn, @Nonnull SchemaField schemaField) {
     return String.format("urn:li:schemaField:(%s,%s)", datasetUrn, getFieldPathV1(schemaField));
   }
 
-  private static String getSchemaFieldUrn(DatasetUrn datasetUrn, String schemaFieldPath) {
-    assert (datasetUrn != null && schemaFieldPath != null);
+  private static String getSchemaFieldUrn(@Nonnull Urn datasetUrn, @Nonnull String schemaFieldPath) {
     return String.format("urn:li:schemaField:(%s,%s)", datasetUrn, schemaFieldPath);
   }
 
@@ -76,7 +75,7 @@ public class SchemaDiffer implements Differ {
           .description(String.format(FIELD_DESCRIPTION_REMOVED_FORMAT, baseDesciption, baseField.getFieldPath()))
           .build();
     }
-    if (baseDesciption != null && targetDescription != null && !baseDesciption.equals(targetDescription)) {
+    if (baseDesciption != null && !baseDesciption.equals(targetDescription)) {
       // Description Change
       return ChangeEvent.builder()
           .changeType(ChangeOperation.MODIFY)
@@ -103,27 +102,39 @@ public class SchemaDiffer implements Differ {
   }
 
   private static List<ChangeEvent> getFieldPropertyChangeEvents(SchemaField baseField, SchemaField targetField,
-      DatasetUrn datasetUrn) {
+      Urn datasetUrn, ChangeCategory changeCategory) {
     List<ChangeEvent> propChangeEvents = new ArrayList<>();
-    String datasetFieldUrn = getSchemaFieldUrn(datasetUrn, targetField);
+    String datasetFieldUrn;
+    if (targetField != null) {
+      datasetFieldUrn = getSchemaFieldUrn(datasetUrn, targetField);
+    } else {
+      datasetFieldUrn = getSchemaFieldUrn(datasetUrn, baseField);
+    }
 
     // Description Change.
-    ChangeEvent descriptionChangeEvent = getDescriptionChange(baseField, targetField, datasetFieldUrn);
-    if (descriptionChangeEvent != null) {
-      propChangeEvents.add(descriptionChangeEvent);
+    if (ChangeCategory.DOCUMENTATION.equals(changeCategory)) {
+      ChangeEvent descriptionChangeEvent = getDescriptionChange(baseField, targetField, datasetFieldUrn);
+      if (descriptionChangeEvent != null) {
+        propChangeEvents.add(descriptionChangeEvent);
+      }
     }
 
     // Global Tags
-    propChangeEvents.addAll(getGlobalTagChangeEvents(baseField, targetField, datasetFieldUrn));
+    if (ChangeCategory.TAG.equals(changeCategory)) {
+      propChangeEvents.addAll(getGlobalTagChangeEvents(baseField, targetField, datasetFieldUrn));
+    }
 
     // Glossary terms.
-    propChangeEvents.addAll(getGlossaryTermsChangeEvents(baseField, targetField, datasetFieldUrn));
+    if (ChangeCategory.GLOSSARY_TERM.equals(changeCategory)) {
+      propChangeEvents.addAll(getGlossaryTermsChangeEvents(baseField, targetField, datasetFieldUrn));
+    }
 
     return propChangeEvents;
   }
 
-  private static List<ChangeEvent> computeSchemaDiff(SchemaMetadata baseSchema, SchemaMetadata targetSchema,
-      DatasetUrn datasetUrn) {
+  // TODO: This could use some cleanup, lots of repeated logic and tenuous conditionals
+  private static List<ChangeEvent> computeDiffs(SchemaMetadata baseSchema, SchemaMetadata targetSchema,
+      Urn datasetUrn, ChangeCategory changeCategory) {
     boolean isOrdinalBasedSchema = isSchemaOrdinalBased(targetSchema);
     if (!isOrdinalBasedSchema) {
       // Sort the fields by their field path.
@@ -145,21 +156,27 @@ public class SchemaDiffer implements Differ {
       if (isOrdinalBasedSchema) {
         if (!curBaseField.getNativeDataType().equals(curTargetField.getNativeDataType())) {
           // Non-backward compatible change + Major version bump
-          changeEvents.add(ChangeEvent.builder()
-              .category(ChangeCategory.TECHNICAL_SCHEMA)
-              .elementId(getSchemaFieldUrn(datasetUrn, curBaseField))
-              .target(datasetUrn.toString())
-              .changeType(ChangeOperation.MODIFY)
-              .semVerChange(SemanticChangeType.MAJOR)
-              .description(String.format("%s native datatype of the field '%s' changed from '%s' to '%s'.",
-                  BACKWARDS_INCOMPATIBLE_DESC, getFieldPathV1(curTargetField), curBaseField.getNativeDataType(),
-                  curTargetField.getNativeDataType()))
-              .build());
+          if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+            changeEvents.add(ChangeEvent.builder()
+                .category(ChangeCategory.TECHNICAL_SCHEMA)
+                .elementId(getSchemaFieldUrn(datasetUrn, curBaseField))
+                .target(datasetUrn.toString())
+                .changeType(ChangeOperation.MODIFY)
+                .semVerChange(SemanticChangeType.MAJOR)
+                .description(String.format("%s native datatype of the field '%s' changed from '%s' to '%s'.",
+                    BACKWARDS_INCOMPATIBLE_DESC, getFieldPathV1(curTargetField), curBaseField.getNativeDataType(),
+                    curTargetField.getNativeDataType()))
+                .build());
+          }
+          List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn,
+              changeCategory);
+          changeEvents.addAll(propChangeEvents);
           ++baseFieldIdx;
           ++targetFieldIdx;
           continue;
         }
-        if (baseFieldIdx == targetFieldIdx && !curBaseField.getFieldPath().equals(curTargetField.getFieldPath())) {
+        if (baseFieldIdx == targetFieldIdx && !curBaseField.getFieldPath().equals(curTargetField.getFieldPath())
+            && ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
           // The field got renamed. Forward compatible + Minor version bump.
           changeEvents.add(ChangeEvent.builder()
               .category(ChangeCategory.TECHNICAL_SCHEMA)
@@ -173,7 +190,8 @@ public class SchemaDiffer implements Differ {
               .build());
         }
         // Generate change events from property changes
-        List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn);
+        List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn,
+            changeCategory);
         changeEvents.addAll(propChangeEvents);
         ++baseFieldIdx;
         ++targetFieldIdx;
@@ -182,32 +200,43 @@ public class SchemaDiffer implements Differ {
         int comparison = curBaseField.getFieldPath().compareTo(curTargetField.getFieldPath());
         if (comparison == 0) {
           // This is the same field. Check for change events from property changes.
-          List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn);
+          List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn,
+              changeCategory);
           changeEvents.addAll(propChangeEvents);
           ++baseFieldIdx;
           ++targetFieldIdx;
         } else if (comparison < 0) {
           // BaseFiled got removed. Non-backward compatible change + Major version bump
-          changeEvents.add(ChangeEvent.builder()
-              .category(ChangeCategory.TECHNICAL_SCHEMA)
-              .elementId(getSchemaFieldUrn(datasetUrn, curBaseField))
-              .target(datasetUrn.toString())
-              .changeType(ChangeOperation.REMOVE)
-              .semVerChange(SemanticChangeType.MAJOR)
-              .description(BACKWARDS_INCOMPATIBLE_DESC + "removal of the field'" + getFieldPathV1(curBaseField) + "'.")
-              .build());
+          if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+            changeEvents.add(ChangeEvent.builder()
+                .category(ChangeCategory.TECHNICAL_SCHEMA)
+                .elementId(getSchemaFieldUrn(datasetUrn, curBaseField))
+                .target(datasetUrn.toString())
+                .changeType(ChangeOperation.REMOVE)
+                .semVerChange(SemanticChangeType.MAJOR)
+                .description(BACKWARDS_INCOMPATIBLE_DESC + "removal of the field'" + getFieldPathV1(curBaseField) + "'.")
+                .build());
+          }
+          List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn,
+              changeCategory);
+          changeEvents.addAll(propChangeEvents);
           ++baseFieldIdx;
         } else {
           // The targetField got added. Forward & backwards compatible change + minor version bump.
-          changeEvents.add(ChangeEvent.builder()
-              .category(ChangeCategory.TECHNICAL_SCHEMA)
-              .elementId(getSchemaFieldUrn(datasetUrn, curTargetField))
-              .target(datasetUrn.toString())
-              .changeType(ChangeOperation.ADD)
-              .semVerChange(SemanticChangeType.MINOR)
-              .description(
-                  BACK_AND_FORWARD_COMPATIBLE_DESC + "the newly added field '" + getFieldPathV1(curTargetField) + "'.")
-              .build());
+          if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+            changeEvents.add(ChangeEvent.builder()
+                .category(ChangeCategory.TECHNICAL_SCHEMA)
+                .elementId(getSchemaFieldUrn(datasetUrn, curTargetField))
+                .target(datasetUrn.toString())
+                .changeType(ChangeOperation.ADD)
+                .semVerChange(SemanticChangeType.MINOR)
+                .description(
+                    BACK_AND_FORWARD_COMPATIBLE_DESC + "the newly added field '" + getFieldPathV1(curTargetField) + "'.")
+                .build());
+          }
+          List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(curBaseField, curTargetField, datasetUrn,
+              changeCategory);
+          changeEvents.addAll(propChangeEvents);
           ++targetFieldIdx;
         }
       }
@@ -215,28 +244,37 @@ public class SchemaDiffer implements Differ {
     while (baseFieldIdx < baseFields.size()) {
       // Handle removed fields. Non-backward compatible change + major version bump
       SchemaField baseField = baseFields.get(baseFieldIdx);
-      changeEvents.add(ChangeEvent.builder()
-          .elementId(getSchemaFieldUrn(datasetUrn, baseField))
-          .target(datasetUrn.toString())
-          .category(ChangeCategory.TECHNICAL_SCHEMA)
-          .changeType(ChangeOperation.REMOVE)
-          .semVerChange(SemanticChangeType.MAJOR)
-          .description(BACKWARDS_INCOMPATIBLE_DESC + "removal of field: '" + getFieldPathV1(baseField) + "'.")
-          .build());
+      if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+        changeEvents.add(ChangeEvent.builder()
+            .elementId(getSchemaFieldUrn(datasetUrn, baseField))
+            .target(datasetUrn.toString())
+            .category(ChangeCategory.TECHNICAL_SCHEMA)
+            .changeType(ChangeOperation.REMOVE)
+            .semVerChange(SemanticChangeType.MAJOR)
+            .description(BACKWARDS_INCOMPATIBLE_DESC + "removal of field: '" + getFieldPathV1(baseField) + "'.")
+            .build());
+      }
+      List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(baseField, null, datasetUrn,
+          changeCategory);
+      changeEvents.addAll(propChangeEvents);
       ++baseFieldIdx;
     }
     while (targetFieldIdx < targetFields.size()) {
       // Newly added fields. Forwards & backwards compatible change + minor version bump.
       SchemaField targetField = targetFields.get(targetFieldIdx);
-      changeEvents.add(ChangeEvent.builder()
-          .elementId(getSchemaFieldUrn(datasetUrn, targetField))
-          .target(datasetUrn.toString())
-          .category(ChangeCategory.TECHNICAL_SCHEMA)
-          .changeType(ChangeOperation.ADD)
-          .semVerChange(SemanticChangeType.MINOR)
-          .description(
-              BACK_AND_FORWARD_COMPATIBLE_DESC + "the newly added field '" + getFieldPathV1(targetField) + "'.")
-          .build());
+      if (ChangeCategory.TECHNICAL_SCHEMA.equals(changeCategory)) {
+        changeEvents.add(ChangeEvent.builder()
+            .elementId(getSchemaFieldUrn(datasetUrn, targetField))
+            .target(datasetUrn.toString())
+            .category(ChangeCategory.TECHNICAL_SCHEMA)
+            .changeType(ChangeOperation.ADD)
+            .semVerChange(SemanticChangeType.MINOR)
+            .description(BACK_AND_FORWARD_COMPATIBLE_DESC + "the newly added field '" + getFieldPathV1(targetField) + "'.")
+            .build());
+      }
+      List<ChangeEvent> propChangeEvents = getFieldPropertyChangeEvents(null, targetField, datasetUrn,
+          changeCategory);
+      changeEvents.addAll(propChangeEvents);
       ++targetFieldIdx;
     }
 
@@ -285,6 +323,7 @@ public class SchemaDiffer implements Differ {
     return null;
   }
 
+  @SuppressWarnings("ConstantConditions")
   private static SchemaMetadata getSchemaMetadataFromAspect(EbeanAspectV2 ebeanAspectV2) {
     if (ebeanAspectV2 != null && ebeanAspectV2.getMetadata() != null) {
       return RecordUtils.toRecordTemplate(SchemaMetadata.class, ebeanAspectV2.getMetadata());
@@ -292,6 +331,7 @@ public class SchemaDiffer implements Differ {
     return null;
   }
 
+  @SuppressWarnings("UnnecessaryLocalVariable")
   private static List<ChangeEvent> getForeignKeyChangeEvents(SchemaMetadata baseSchema, SchemaMetadata targetSchema) {
     List<ChangeEvent> foreignKeyChangeEvents = new ArrayList<>();
     // TODO: Implement the diffing logic.
@@ -299,7 +339,7 @@ public class SchemaDiffer implements Differ {
   }
 
   private static List<ChangeEvent> getPrimaryKeyChangeEvents(SchemaMetadata baseSchema, SchemaMetadata targetSchema,
-      DatasetUrn datasetUrn) {
+      Urn datasetUrn) {
     List<ChangeEvent> primaryKeyChangeEvents = new ArrayList<>();
     Set<String> basePrimaryKeys =
         (baseSchema != null && baseSchema.getPrimaryKeys() != null) ? new HashSet<>(baseSchema.getPrimaryKeys())
@@ -336,7 +376,7 @@ public class SchemaDiffer implements Differ {
 
   @Override
   public ChangeTransaction getSemanticDiff(EbeanAspectV2 previousValue, EbeanAspectV2 currentValue,
-      ChangeCategory element, JsonPatch rawDiff, boolean rawDiffRequested) {
+      ChangeCategory changeCategory, JsonPatch rawDiff, boolean rawDiffRequested) {
     if (!previousValue.getAspect().equals(SCHEMA_METADATA_ASPECT_NAME) || !currentValue.getAspect()
         .equals(SCHEMA_METADATA_ASPECT_NAME)) {
       throw new IllegalArgumentException("Aspect is not " + SCHEMA_METADATA_ASPECT_NAME);
@@ -352,7 +392,7 @@ public class SchemaDiffer implements Differ {
     } else {
       try {
         changeEvents.addAll(
-            computeSchemaDiff(baseSchema, targetSchema, DatasetUrn.createFromString(currentValue.getUrn())));
+            computeDiffs(baseSchema, targetSchema, DatasetUrn.createFromString(currentValue.getUrn()), changeCategory));
       } catch (URISyntaxException e) {
         throw new IllegalArgumentException("Malformed DatasetUrn " + currentValue.getUrn());
       }
@@ -361,7 +401,7 @@ public class SchemaDiffer implements Differ {
     // Assess the highest change at the transaction(schema) level.
     SemanticChangeType highestSematicChange = SemanticChangeType.NONE;
     changeEvents =
-        changeEvents.stream().filter(changeEvent -> changeEvent.getCategory() == element).collect(Collectors.toList());
+        changeEvents.stream().filter(changeEvent -> changeEvent.getCategory() == changeCategory).collect(Collectors.toList());
     ChangeEvent highestChangeEvent =
         changeEvents.stream().max(Comparator.comparing(ChangeEvent::getSemVerChange)).orElse(null);
     if (highestChangeEvent != null) {

--- a/smoke-test/tests/timeline/timeline_test.py
+++ b/smoke-test/tests/timeline/timeline_test.py
@@ -27,7 +27,7 @@ def test_all():
     assert res_data[0]["semVerChange"] == "MINOR"
     assert len(res_data[0]["changeEvents"]) == 10
     assert res_data[1]["semVerChange"] == "MAJOR"
-    assert len(res_data[1]["changeEvents"]) == 6
+    assert len(res_data[1]["changeEvents"]) == 9
     assert res_data[2]["semVerChange"] == "MAJOR"
     assert len(res_data[2]["changeEvents"]) == 5
     assert res_data[2]["semVer"] == "2.0.0-computed"

--- a/smoke-test/tests/timeline/timeline_test.py
+++ b/smoke-test/tests/timeline/timeline_test.py
@@ -25,7 +25,7 @@ def test_all():
     assert res_data
     assert len(res_data) == 3
     assert res_data[0]["semVerChange"] == "MINOR"
-    assert len(res_data[0]["changeEvents"]) == 6
+    assert len(res_data[0]["changeEvents"]) == 10
     assert res_data[1]["semVerChange"] == "MAJOR"
     assert len(res_data[1]["changeEvents"]) == 6
     assert res_data[2]["semVerChange"] == "MAJOR"


### PR DESCRIPTION
Fixes issues with semantic versioning
* When multiple categories requested version was per category and looked weird
* Differs per category did not roll up either
* No more empty results w/ None semverchange
* Better colors

## Checklist
- [X] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [X] Tests for the changes have been added/updated (if applicable)
- [X] Docs related to the changes have been added/updated (if applicable)
