### PR TITLE
fix(docs): fix frontend docs to replace port 9001 -> 9002

### DIFF
--- a/datahub-frontend/README.md
+++ b/datahub-frontend/README.md
@@ -40,7 +40,7 @@ cd datahub-frontend/run && ./run-local-frontend
 After starting your application in one of the two ways mentioned above, you can connect to it by typing below
 into your favorite web browser:
 ```
-http://localhost:9001
+http://localhost:9002
 ```
 
 To be able to sign in, you need to provide your user name. The default account is `datahub`, password `datahub`.
@@ -69,7 +69,7 @@ see the [OIDC in React](../docs/how/auth/sso/configure-oidc-react.md) document.
 Most DataHub frontend API endpoints are protected using [Play Authentication](https://www.playframework.com/documentation/2.1.0/JavaGuide4), which means it requires authentication information stored in the cookie for the request to go through. This makes debugging using curl difficult. One option is to first make a curl call against the `/authenticate` endpoint and stores the authentication info in a cookie file like this
 
 ```
-curl -c cookie.txt -d '{"username":"datahub", "password":"datahub"}' -H 'Content-Type: application/json' http://localhost:9001/authenticate
+curl -c cookie.txt -d '{"username":"datahub", "password":"datahub"}' -H 'Content-Type: application/json' http://localhost:9002/authenticate
 ```
 
 You can then make all subsequent calls using the same cookie file to pass the authentication check.


### PR DESCRIPTION
The frontend runs on port 9002 by default

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
