### PR TITLE
Remove <> from add-users.md doc

### DIFF
--- a/docs/how/auth/add-users.md
+++ b/docs/how/auth/add-users.md
@@ -90,7 +90,7 @@ URNs are identifiers that uniquely identify an Entity on DataHub. The usernames 
 the user on DataHub. The urn is computed as:
 
 ```
-urn:li:corpuser:<username>
+urn:li:corpuser:{username}
 ```
 
 ## Caveats
@@ -99,7 +99,7 @@ If you add a new username / password to the `user.props` file, no other informat
 about the user in DataHub (full name, email, bio, etc). This means that you will not be able to search to find the user.
 
 In order to add information about the user in DataHub, you can use our Python Emitter SDK to produce aspects for the CorpUser,
-where the URN will be computed as `urn:li:corpuser:<username>`, where `<username>` is the identifier defined in the user.props file.
+where the URN will be computed as `urn:li:corpuser:{username}`, where `username` is the identifier defined in the user.props file.
 
 For a more comprehensive overview of how users & groups are managed within DataHub, check out [this video](https://www.youtube.com/watch?v=8Osw6p9vDYY).
 


### PR DESCRIPTION
Small change. <> seems to make docs build complain.


## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
