### PR TITLE
fix(ingestion): Fix bigquery stateful ingestion checkpoint reconstruction.

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/bigquery.py
@@ -292,9 +292,10 @@ class BigQueryConfig(BaseTimeWindowConfig, SQLAlchemyConfig):
 
     @pydantic.validator("platform_instance")
     def bigquery_doesnt_need_platform_instance(cls, v):
-        raise ConfigurationError(
-            "BigQuery project ids are globally unique. You do not need to specify a platform instance."
-        )
+        if v is not None:
+            raise ConfigurationError(
+                "BigQuery project ids are globally unique. You do not need to specify a platform instance."
+            )
 
     @pydantic.validator("platform")
     def platform_is_always_bigquery(cls, v):


### PR DESCRIPTION
The checkpointing state stores the config as well. In the case of BigQuery, the `platform_instance` will have a value of `None`. The BigQueryConfig validator currently raises an exception unconditionally if this member is present, as opposed to it having  a non `None` value. The fix addresses this issue.
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
