### PR TITLE
fix(ingestion): Insulate 'datahub' and child loggers from external modules.

### DIFF
--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -49,12 +49,29 @@ MAX_CONTENT_WIDTH = 120
     prog_name=datahub_package.__package_name__,
 )
 def datahub(debug: bool) -> None:
+    # Insulate 'datahub' and all child loggers from inadvertent changes to the
+    # root logger by the external site packages that we import.
+    # (Eg: https://github.com/reata/sqllineage/commit/2df027c77ea0a8ea4909e471dcd1ecbf4b8aeb2f#diff-30685ea717322cd1e79c33ed8d37903eea388e1750aa00833c33c0c5b89448b3R11
+    #  changes the root logger's handler level to WARNING, causing any message below
+    #  WARNING level to be dropped  after this module is imported, irrespective
+    #  of the logger's logging level! The lookml source was affected by this).
+
+    # 1. Create 'datahub' parent logger.
+    datahub_logger = logging.getLogger("datahub")
+    # 2. Setup the stream handler with formatter.
+    stream_handler = logging.StreamHandler()
+    formatter = logging.Formatter(BASE_LOGGING_FORMAT)
+    stream_handler.setFormatter(formatter)
+    datahub_logger.addHandler(stream_handler)
+    # 3. Turn off propagation to the root handler.
+    datahub_logger.propagate = False
+    # 4. Adjust log-levels.
     if debug or os.getenv("DATAHUB_DEBUG", False):
         logging.getLogger().setLevel(logging.INFO)
-        logging.getLogger("datahub").setLevel(logging.DEBUG)
+        datahub_logger.setLevel(logging.DEBUG)
     else:
         logging.getLogger().setLevel(logging.WARNING)
-        logging.getLogger("datahub").setLevel(logging.INFO)
+        datahub_logger.setLevel(logging.INFO)
     # loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
     # print(loggers)
 


### PR DESCRIPTION
This change isolates the `datahub` logger and it's child loggers from inadvertent changes to the root logger by the external modules(site-packages) that we import. This also fixes the current issue with the `INFO` and `DEBUG` log messages of lookml source getting dropped.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
