### PR TITLE
Allow elasticsearch to authenticate without `username` and `password`

### DIFF
--- a/metadata-ingestion/source_docs/elastic_search.md
+++ b/metadata-ingestion/source_docs/elastic_search.md
@@ -30,18 +30,20 @@ source:
   config:
     # Coordinates
     host: 'localhost:9200'
+
     # Credentials
-    username: ""
-    password: ""
+    username: user # optional
+    password: pass # optional
+
     # Options
     url_prefix: "" # optional url_prefix
     env: "PROD"
     index_pattern:
-        allow: [".*some_index_name_pattern*"]
-        deny: [".*skip_index_name_pattern*"]
+      allow: [".*some_index_name_pattern*"]
+      deny: [".*skip_index_name_pattern*"]
 
 sink:
-  # sink configs
+# sink configs
 ```
 
 ## Config details
@@ -49,17 +51,17 @@ sink:
 Note that a `.` is used to denote nested fields in the YAML recipe.
 
 
-| Field                       | Required | Default          | Description                                                   |
-| --------------------------- | -------- | ---------------- |---------------------------------------------------------------|
-| `host`                      |          | "localhost:9092" | The elastic search host URI.                                  |
-| `username`                  |          | ""               | The username credential.                                      |
-| `password`                  |          | ""               | The password credential.                                      |
-| `url_prefix`                |          | ""               | There are cases where an enterprise would have multiple elastic search clusters. One way for them to manage is to have a single endpoint for all the elastic search clusters and use url_prefix for routing requests to different clusters.                            |
-| `env`                       |          | `"PROD"`         | Environment to use in namespace when constructing URNs.       |
-| `platform_instance`         |          | None             | The Platform instance to use while constructing URNs.         |
-| `index_pattern.allow`       |          |                  | List of regex patterns for indexes to include in ingestion.   |
-| `index_pattern.deny`        |          |                  | List of regex patterns for indexes to exclude from ingestion. |
-| `index_pattern.ignoreCase`  |          | `True`           | Whether regex matching should ignore case or not              |
+| Field                       | Required | Default            | Description                                                   |
+| --------------------------- | -------- |--------------------|---------------------------------------------------------------|
+| `host`                      | ✅       | `"localhost:9092"` | The elastic search host URI.                                  |
+| `username`                  |          | None               | The username credential.                                      |
+| `password`                  |          | None               | The password credential.                                      |
+| `url_prefix`                |          | ""                 | There are cases where an enterprise would have multiple elastic search clusters. One way for them to manage is to have a single endpoint for all the elastic search clusters and use url_prefix for routing requests to different clusters.                            |
+| `env`                       |          | `"PROD"`           | Environment to use in namespace when constructing URNs.       |
+| `platform_instance`         |          | None               | The Platform instance to use while constructing URNs.         |
+| `index_pattern.allow`       |          |                    | List of regex patterns for indexes to include in ingestion.   |
+| `index_pattern.deny`        |          |                    | List of regex patterns for indexes to exclude from ingestion. |
+| `index_pattern.ignoreCase`  |          | `True`             | Whether regex matching should ignore case or not              |
 
 ## Compatibility
 

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from hashlib import md5
-from typing import Any, Dict, Generator, Iterable, List, Tuple, Optional, Type
+from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Type
 
 from elasticsearch import Elasticsearch
 from pydantic import validator
@@ -205,7 +205,7 @@ class ElasticsearchSourceConfig(DatasetSourceConfigBase):
     def http_auth(self) -> Optional[Tuple[str, str]]:
         if self.username is None:
             return None
-        return self.username, self.password
+        return self.username, self.password or ""
 
 
 class ElasticsearchSource(Source):

--- a/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/elastic_search.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from hashlib import md5
-from typing import Any, Dict, Generator, Iterable, List, Optional, Type
+from typing import Any, Dict, Generator, Iterable, List, Tuple, Optional, Type
 
 from elasticsearch import Elasticsearch
 from pydantic import validator
@@ -166,8 +166,8 @@ class ElasticsearchSourceReport(SourceReport):
 
 class ElasticsearchSourceConfig(DatasetSourceConfigBase):
     host: str = "localhost:9200"
-    username: str = ""
-    password: str = ""
+    username: Optional[str] = None
+    password: Optional[str] = None
     url_prefix: str = ""
     index_pattern: AllowDenyPattern = AllowDenyPattern(
         allow=[".*"], deny=["^_.*", "^ilm-history.*"]
@@ -201,6 +201,12 @@ class ElasticsearchSourceConfig(DatasetSourceConfigBase):
                 raise ConfigurationError(f"port must be all digits, found {port}")
         return host_val
 
+    @property
+    def http_auth(self) -> Optional[Tuple[str, str]]:
+        if self.username is None:
+            return None
+        return self.username, self.password
+
 
 class ElasticsearchSource(Source):
     def __init__(self, config: ElasticsearchSourceConfig, ctx: PipelineContext):
@@ -208,7 +214,7 @@ class ElasticsearchSource(Source):
         self.source_config = config
         self.client = Elasticsearch(
             self.source_config.host,
-            http_auth=(self.source_config.username, self.source_config.password),
+            http_auth=self.source_config.http_auth,
             url_prefix=self.source_config.url_prefix,
         )
         self.report = ElasticsearchSourceReport()


### PR DESCRIPTION
## What
![image](https://user-images.githubusercontent.com/19890112/156944177-941a0b1f-2a01-4abc-9996-f12746f3d88e.png)

Currently, there is no way to ingest **Elasticsearch** with the default `username=""` and `password=""`, which raises the exception above. This PR fixes the issue by making them optional.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
