### PR TITLE
fix(ingest): handle endpoints without 200 response in openapi

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/openapi_parser.py
@@ -120,10 +120,14 @@ def get_endpoints(sw_dict: dict) -> dict:  # noqa: C901
         # will track only the "get" methods, which are the ones that give us data
         if "get" in p_o.keys():
 
-            try:
+            if "200" in p_o["get"]["responses"].keys():
                 base_res = p_o["get"]["responses"]["200"]
-            except KeyError:  # if you read a plain yml file the 200 will be an integer
+            elif 200 in p_o["get"]["responses"].keys():
+                # if you read a plain yml file the 200 will be an integer
                 base_res = p_o["get"]["responses"][200]
+            else:
+                # the endpoint does not have a 200 response
+                continue
 
             if "description" in p_o["get"].keys():
                 desc = p_o["get"]["description"]

--- a/metadata-ingestion/tests/unit/test_openapi.py
+++ b/metadata-ingestion/tests/unit/test_openapi.py
@@ -261,6 +261,13 @@ paths:
                         }
                     ]
                    }
+  /redirect:
+    get:
+      operationId: redirectSomewhere
+      summary: Redirect to a different endpoint
+      responses:
+        '302':
+          description: 302 response
   /v2:
     get:
       operationId: getVersionDetailsv2


### PR DESCRIPTION
This PR prevents a crash on openapi documents that have GET endpoints without a `200` response. For example endpoints that are intended for redirects and only contain `302` responses.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)
