### PR TITLE
feat(quickstart): restart actions pod in case of failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ metadata-ingestion/generated/**
 # docs
 docs/generated/
 tmp*
+temp*

--- a/docker/docker-compose-without-neo4j.yml
+++ b/docker/docker-compose-without-neo4j.yml
@@ -110,6 +110,7 @@ services:
     image: public.ecr.aws/datahub/acryl-datahub-actions:${ACTIONS_VERSION:-v0.0.1-beta.11}
     hostname: actions
     env_file: datahub-actions/env/docker.env
+    restart: on-failure:5
     depends_on:
       - datahub-gms
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,6 +123,7 @@ services:
     image: public.ecr.aws/datahub/acryl-datahub-actions:${ACTIONS_VERSION:-v0.0.1-beta.11}
     hostname: actions
     env_file: datahub-actions/env/docker.env
+    restart: on-failure:5
     depends_on:
       - datahub-gms
 

--- a/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j-m1.quickstart.yml
@@ -34,6 +34,7 @@ services:
       - KAFKA_PROPERTIES_SECURITY_PROTOCOL=PLAINTEXT
     hostname: actions
     image: public.ecr.aws/datahub/acryl-datahub-actions:${ACTIONS_VERSION:-v0.0.1-beta.11}
+    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:

--- a/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
+++ b/docker/quickstart/docker-compose-without-neo4j.quickstart.yml
@@ -34,6 +34,7 @@ services:
     - KAFKA_PROPERTIES_SECURITY_PROTOCOL=PLAINTEXT
     hostname: actions
     image: public.ecr.aws/datahub/acryl-datahub-actions:${ACTIONS_VERSION:-v0.0.1-beta.11}
+    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:

--- a/docker/quickstart/docker-compose.quickstart.yml
+++ b/docker/quickstart/docker-compose.quickstart.yml
@@ -36,6 +36,7 @@ services:
     - KAFKA_PROPERTIES_SECURITY_PROTOCOL=PLAINTEXT
     hostname: actions
     image: public.ecr.aws/datahub/acryl-datahub-actions:${ACTIONS_VERSION:-v0.0.1-beta.11}
+    restart: on-failure:5
   datahub-frontend-react:
     container_name: datahub-frontend-react
     depends_on:


### PR DESCRIPTION
Sometimes actions pod fails. We should restart it a few times to improve user experience.

The format used is undocumented but works as per https://stackoverflow.com/questions/42216017/docker-compose-restart-policy#comment100592024_43006595

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
