### PR TITLE
fix(ingestion): read all tables from redshift

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -471,7 +471,7 @@ class RedshiftSource(SQLAlchemySource):
             table_schema as schemaname,
             table_name as tablename
         from
-            information_schema.tables
+            svv_tables
         where
             table_type = 'BASE TABLE'
             and table_schema not in ('information_schema', 'pg_catalog', 'pg_internal')

--- a/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/sql/redshift.py
@@ -471,7 +471,7 @@ class RedshiftSource(SQLAlchemySource):
             table_schema as schemaname,
             table_name as tablename
         from
-            svv_tables
+            pg_catalog.svv_tables
         where
             table_type = 'BASE TABLE'
             and table_schema not in ('information_schema', 'pg_catalog', 'pg_internal')


### PR DESCRIPTION
Query svv_tables instead of information_schema.

If a user with metadata access, no data access queries information_schema,
nothing is returned. Querying svv_tables returns all tables in the database.


## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
