### PR TITLE
fix(containers): query for custom properties on containers

### DIFF
--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -1391,12 +1391,12 @@ type ContainerProperties {
   description: String
 
   """
-  Custom properties of the Dataset
+  Custom properties of the Container
   """
   customProperties: [StringMapEntry!]
 
   """
-  Native platform URL of the dashboard
+  Native platform URL of the Container
   """
   externalUrl: String
 }

--- a/datahub-web-react/src/graphql/container.graphql
+++ b/datahub-web-react/src/graphql/container.graphql
@@ -7,6 +7,10 @@ query getContainer($urn: String!) {
         properties {
             name
             description
+            customProperties {
+                key
+                value
+            }
         }
         editableProperties {
             description


### PR DESCRIPTION
Graphql query wasn't fetching custom properties so they werent showing up in the UI

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
