### PR TITLE
Fixed Bug: Alpha slider doesn’t move, only the color slider is movabe in tag color picker

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -78,6 +78,7 @@
         "react-syntax-highlighter": "^15.4.4",
         "react-timezone-select": "^1.1.15",
         "react-visibility-sensor": "^5.1.1",
+        "rgb-hex": "^4.0.0",
         "sinon": "^11.1.1",
         "start-server-and-test": "1.12.2",
         "styled-components": "^5.2.1",

--- a/datahub-web-react/src/app/shared/TagStyleEntity.tsx
+++ b/datahub-web-react/src/app/shared/TagStyleEntity.tsx
@@ -6,6 +6,8 @@ import { ApolloError } from '@apollo/client';
 import styled from 'styled-components';
 import { ChromePicker } from 'react-color';
 import ColorHash from 'color-hash';
+import rgbHex from 'rgb-hex';
+
 import { PlusOutlined } from '@ant-design/icons';
 import { useGetTagQuery } from '../../graphql/tag.generated';
 import { EntityType, FacetMetadata, Maybe, Scalars } from '../../types.generated';
@@ -256,10 +258,6 @@ export default function TagStyleEntity({ urn, useGetSearchResults = useWrappedSe
         saveColor();
     };
 
-    const handleColorChange = (color: any) => {
-        setColorValue(color?.hex);
-    };
-
     // Update Description
     const updateDescriptionValue = (desc: string) => {
         setUpdatedDescription(desc);
@@ -314,7 +312,10 @@ export default function TagStyleEntity({ urn, useGetSearchResults = useWrappedSe
                 </TagName>
                 {displayColorPicker && (
                     <ColorPickerPopOver ref={colorPickerRef}>
-                        <ChromePicker color={colorValue} onChange={handleColorChange} />
+                        <ChromePicker
+                            color={colorValue}
+                            onChange={(c) => setColorValue(`#${rgbHex(c.rgb.r, c.rgb.g, c.rgb.b, c.rgb.a)}`)}
+                        />
                     </ColorPickerPopOver>
                 )}
             </div>

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -14722,6 +14722,11 @@ rework@1.0.1:
     convert-source-map "^0.3.3"
     css "^2.0.0"
 
+rgb-hex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/rgb-hex/-/rgb-hex-4.0.0.tgz#02fb1e215e3fe5d070501579a3d2e4fa3c0acec8"
+  integrity sha512-Eg2ev5CiMBnQ9Gpflmqbwbso0CCdISqtVIow7OpYSLN1ULUv2jTB9YieS1DSSn/17AD7KkPWDPzSFzI4GSuu/Q==
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"


### PR DESCRIPTION
Resolved the alpha slider issue in the tag slider color picker.

## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
