### PR TITLE
feat(ingestion): Add  memory leak detection capability to the datahub cli command.

### DIFF
--- a/metadata-ingestion/src/datahub/cli/ingest_cli.py
+++ b/metadata-ingestion/src/datahub/cli/ingest_cli.py
@@ -1,10 +1,7 @@
-import fnmatch
-import gc
 import json
 import logging
 import pathlib
 import sys
-import tracemalloc
 from datetime import datetime
 
 import click
@@ -23,6 +20,7 @@ from datahub.configuration import SensitiveError
 from datahub.configuration.config_loader import load_config_file
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.telemetry import telemetry
+from datahub.utilities import memory_leak_detector
 
 logger = logging.getLogger(__name__)
 
@@ -66,21 +64,11 @@ def ingest() -> None:
     default=False,
     help="If enabled, ingestion runs with warnings will yield a non-zero error code",
 )
-@click.option(
-    "-ml",
-    "--detect-memory-leaks",
-    type=bool,
-    is_flag=True,
-    default=False,
-    help="Run memory leak detection using tracemalloc.",
-)
+@click.pass_context
 @telemetry.with_telemetry
+@memory_leak_detector.with_leak_detection
 def run(
-    config: str,
-    dry_run: bool,
-    preview: bool,
-    strict_warnings: bool,
-    detect_memory_leaks: bool,
+    ctx: click.Context, config: str, dry_run: bool, preview: bool, strict_warnings: bool
 ) -> None:
     """Ingest metadata into DataHub."""
 
@@ -100,80 +88,11 @@ def run(
         # in a SensitiveError to prevent detailed variable-level information from being logged.
         raise SensitiveError() from e
 
-    if detect_memory_leaks:
-        tracemalloc.start(25)
-        if sys.version_info[0] >= 3 and sys.version_info[1] >= 9:
-            tracemalloc.reset_peak()
-        # snapshot_before_run = tracemalloc.take_snapshot()
-        gc.set_debug(gc.DEBUG_LEAK)
     logger.info("Starting metadata ingestion")
     pipeline.run()
     logger.info("Finished metadata ingestion")
     ret = pipeline.pretty_print_summary(warnings_as_failure=strict_warnings)
     pipeline.log_ingestion_stats()
-
-    def trace_has_file(trace: tracemalloc.Traceback, file_pattern: str) -> bool:
-        for frame_index in range(0, len(trace)):
-            cur_frame = trace[frame_index]
-            if fnmatch.fnmatch(cur_frame.filename, file_pattern):
-                return True
-        return False
-
-    if detect_memory_leaks:
-        del pipeline
-        logger.info(f"GC count before collect {gc.get_count()}")
-        num_unreacheable_objects = gc.collect()
-        logger.info(f"Number of unreachable objects = {num_unreacheable_objects}")
-        logger.info(f"GC count after collect {gc.get_count()}")
-        logger.info("Potentially leaking objects start")
-        traces_seen = set()
-        for obj in gc.garbage:
-            obj_trace = tracemalloc.get_object_traceback(obj)
-            if (obj_trace is not None) and (obj_trace not in traces_seen):
-                traces_seen.add(obj_trace)
-                if trace_has_file(obj_trace, "*lookml.py"):
-                    referrers = gc.get_referrers(obj)
-                    logger.info(
-                        f"#Referrers:{len(referrers)}; Allocation Trace:\n\t"
-                        + "\n\t".join(
-                            obj_trace.format(limit=25, most_recent_first=True)
-                        )
-                    )
-                    for ref_index, referrer in enumerate(referrers):
-                        ref_trace = tracemalloc.get_object_traceback(referrer)
-                        logger.info(
-                            f"Referrer[{ref_index}] Object:{str(referrer)}, Trace:\n\t"
-                            + "\n\t".join(
-                                ref_trace.format(limit=5, most_recent_first=True)
-                                if ref_trace
-                                else []
-                            )
-                        )
-
-        logger.info("Potentially leaking objects end")
-
-        traced_memory_size, traced_memory_peak = tracemalloc.get_traced_memory()
-        logger.info(
-            f"Traced Memory: size={traced_memory_size}, peak={traced_memory_peak}"
-        )
-        # filter = tracemalloc.Filter(
-        #    inclusive=True, filename_pattern="*datahub/ingestion*.py"
-        # )
-        snapshot_after_run = tracemalloc.take_snapshot()
-        # snapshot_before_run = snapshot_before_run.filter_traces([filter])
-        # snapshot_after_run = snapshot_after_run.filter_traces([filter])
-        logger.info("After run stats")
-        for stat in snapshot_after_run.statistics("lineno", cumulative=True):
-            logger.info(
-                f"size={stat.size}, count={stat.count}Trace=\n\t"
-                + "\n\t".join(stat.traceback.format(limit=25, most_recent_first=True))
-                + "\n\n"
-            )
-        # logger.info("Diff report")
-        # for diff in snapshot_after_run.compare_to(snapshot_before_run, "lineno")[:10]:
-        #    logger.info(f"{diff}\n{diff.traceback.format(limit=25, most_recent_first=True)}")
-        # logger.info(diff)
-        tracemalloc.stop()
     sys.exit(ret)
 
 

--- a/metadata-ingestion/src/datahub/entrypoints.py
+++ b/metadata-ingestion/src/datahub/entrypoints.py
@@ -48,7 +48,16 @@ MAX_CONTENT_WIDTH = 120
     version=datahub_package.nice_version_name(),
     prog_name=datahub_package.__package_name__,
 )
-def datahub(debug: bool) -> None:
+@click.option(
+    "-dl",
+    "--detect-memory-leaks",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Run memory leak detection.",
+)
+@click.pass_context
+def datahub(ctx: click.Context, debug: bool, detect_memory_leaks: bool) -> None:
     # Insulate 'datahub' and all child loggers from inadvertent changes to the
     # root logger by the external site packages that we import.
     # (Eg: https://github.com/reata/sqllineage/commit/2df027c77ea0a8ea4909e471dcd1ecbf4b8aeb2f#diff-30685ea717322cd1e79c33ed8d37903eea388e1750aa00833c33c0c5b89448b3R11
@@ -74,6 +83,9 @@ def datahub(debug: bool) -> None:
         datahub_logger.setLevel(logging.INFO)
     # loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
     # print(loggers)
+    # Setup the context for the memory_leak_detector decorator.
+    ctx.ensure_object(dict)
+    ctx.obj["detect_memory_leaks"] = detect_memory_leaks
 
 
 @datahub.command()

--- a/metadata-ingestion/src/datahub/utilities/memory_leak_detector.py
+++ b/metadata-ingestion/src/datahub/utilities/memory_leak_detector.py
@@ -1,0 +1,123 @@
+import fnmatch
+import gc
+import logging
+import sys
+import tracemalloc
+from collections import defaultdict
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
+
+logger = logging.getLogger(__name__)
+T = TypeVar("T")
+
+
+def _trace_has_file(trace: tracemalloc.Traceback, file_pattern: str) -> bool:
+    for frame_index in range(0, len(trace)):
+        cur_frame = trace[frame_index]
+        if fnmatch.fnmatch(cur_frame.filename, file_pattern):
+            return True
+    return False
+
+
+def _init_leak_detection() -> None:
+    # Initialize trace malloc to track up to 25 stack frames.
+    tracemalloc.start(25)
+    if sys.version_info[0] >= 3 and sys.version_info[1] >= 9:
+        # Nice to reset peak to 0. Available for versions >= 3.9.
+        tracemalloc.reset_peak()
+    # Enable leak debugging in the garbage collector.
+    gc.set_debug(gc.DEBUG_LEAK)
+
+
+def _perform_leak_detection() -> None:
+    # Log potentially useful memory usage metrics
+    logger.info(f"GC count before collect {gc.get_count()}")
+    traced_memory_size, traced_memory_peak = tracemalloc.get_traced_memory()
+    logger.info(f"Traced Memory: size={traced_memory_size}, peak={traced_memory_peak}")
+    num_unreacheable_objects = gc.collect()
+    logger.info(f"Number of unreachable objects = {num_unreacheable_objects}")
+    logger.info(f"GC count after collect {gc.get_count()}")
+
+    # Collect unique traces of all live objects in the garbage - these have potential leaks.
+    unique_traces_to_objects: Dict[
+        Union[tracemalloc.Traceback, int], List[object]
+    ] = defaultdict(list)
+    for obj in gc.garbage:
+        obj_trace = tracemalloc.get_object_traceback(obj)
+        if obj_trace is not None:
+            if _trace_has_file(obj_trace, "*datahub/*.py"):
+                # Leaking object
+                unique_traces_to_objects[obj_trace].append(obj)
+            else:
+                unique_traces_to_objects[id(obj)].append(obj)
+    logger.info("Potentially leaking objects start")
+    for key, obj_list in sorted(
+        unique_traces_to_objects.items(),
+        key=lambda item: sum([sys.getsizeof(o) for o in item[1]]),
+        reverse=True,
+    ):
+        if isinstance(key, tracemalloc.Traceback):
+            obj_traceback: tracemalloc.Traceback = cast(tracemalloc.Traceback, key)
+            logger.info(
+                f"#Objects:{len(obj_list)}; Total memory:{sum([sys.getsizeof(obj) for obj in obj_list])};"
+                + " Allocation Trace:\n\t"
+                + "\n\t".join(obj_traceback.format(limit=25, most_recent_first=True))
+            )
+        else:
+            logger.info(
+                f"#Objects:{len(obj_list)}; Total memory:{sum([sys.getsizeof(obj) for obj in obj_list])};"
+                + " No Allocation Trace available!"
+            )
+        # Print details about the live referrers of each object in the obj_list (same trace).
+        for obj in obj_list:
+            referrers = [r for r in gc.get_referrers(obj) if r in gc.garbage]
+            logger.info(
+                f"Referrers[{len(referrers)}] for object(addr={hex(id(obj))}):'{obj}':"
+            )
+            for ref_index, referrer in enumerate(referrers):
+                ref_trace = tracemalloc.get_object_traceback(referrer)
+                logger.info(
+                    f"Referrer[{ref_index}] referrer_obj(addr={hex(id(referrer))}):{referrer}, RefTrace:\n\t\t"
+                    + "\n\t\t".join(
+                        ref_trace.format(limit=5, most_recent_first=True)
+                        if ref_trace
+                        else []
+                    )
+                    + "\n"
+                )
+    logger.info("Potentially leaking objects end")
+
+    tracemalloc.stop()
+
+
+def with_leak_detection(func: Callable[..., T]) -> Callable[..., T]:
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        detect_leaks: bool = args[0].obj.get("detect_memory_leaks", False)
+        exception: Optional[BaseException] = None
+        if detect_leaks:
+            logger.info(
+                f"Initializing memory leak detection on command: {func.__module__}.{func.__name__}"
+            )
+            _init_leak_detection()
+
+        try:
+            res = func(*args, **kwargs)
+        # Catch all exceptions, including SystemExit that some of the commands raise via sys.exit()
+        except BaseException as e:
+            exception = e
+
+        if detect_leaks:
+            _perform_leak_detection()
+            logger.info(
+                f"Finished memory leak detection on command: {func.__module__}.{func.__name__}"
+            )
+
+        if exception is None:
+            return res
+        elif isinstance(exception, SystemExit):
+            sys.exit(exception.code)
+        else:
+            raise exception
+
+    return wrapper


### PR DESCRIPTION
This change implements `memory_leak_detector.with_leak_detection` decorator that performs memory leak detection when the `--detect-memory-leaks` argument is passed to the `datahub` command. This design allows for decorating any `datahub` command to detect the memory leaks originating from the command. It currently decorates only the `ingest run` command. 

Eg usage: `datahub --detect-memory-leaks ingest -c <path_to_recipe>`.

### Approach
When `--detect-memory-leaks` is set, the decorator uses python's garbage collector's `DEBUG_LEAK` capability to collect all live objects after a datahub command finishes. Then it collects unique stack traces corresponding to the allocation of these objects if any of the stack frame in the trace originates from a `datahub/*.py` file using tracemalloc. Then it writes the analysis summary report of these traces along with the live referrers of these objects for further analysis to the logger.

### Future enhancements:
1.  Extend it to rest of the rest of the datahub commands.
2. Implement circular reference detection.

## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
