### PR TITLE
fix(query_combiner): add try block to handle queries of type str

### DIFF
--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -215,7 +215,7 @@ class SQLAlchemyQueryCombiner:
         # This also implicitly ensures that the typing is generally correct.
         try:
             assert len(get_query_columns(query)) > 0
-        except Exception as e:
+        except AttributeError as e:
             logger.exception(
                 f"Failed to assert count of columns returned by query: {str(query)}"
             )

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -213,7 +213,16 @@ class SQLAlchemyQueryCombiner:
 
         # Figure out how many columns this query returns.
         # This also implicitly ensures that the typing is generally correct.
-        assert len(get_query_columns(query)) > 0
+        try:
+            assert len(get_query_columns(query)) > 0
+        except Exception as e:
+            logger.exception(
+                f"Failed to assert count of columns returned by query: {str(query)}"
+            )
+            logger.debug(
+                f"Query of type: '{type(query)}' does not contain attributes required by 'get_query_columns()'."
+            )
+            return False, None
 
         # Add query to the queue.
         queue = self._get_queue(main_greenlet)

--- a/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
+++ b/metadata-ingestion/src/datahub/utilities/sqlalchemy_query_combiner.py
@@ -216,11 +216,8 @@ class SQLAlchemyQueryCombiner:
         try:
             assert len(get_query_columns(query)) > 0
         except AttributeError as e:
-            logger.exception(
-                f"Failed to assert count of columns returned by query: {str(query)}"
-            )
             logger.debug(
-                f"Query of type: '{type(query)}' does not contain attributes required by 'get_query_columns()'."
+                f"Query of type: '{type(query)}' does not contain attributes required by 'get_query_columns()'. AttributeError: {e}"
             )
             return False, None
 


### PR DESCRIPTION
Add try block for query_combiner early return in case a query does not contain attributes (inner_columns | columns) as defined by function get_query_columns().

See discussion in #4389 

Previous code had an early return in case that query did not contain attribute columns. With the new assertion, there is no fallback in the new get_query_columns() function. Hence, some queries fail without a functional fallback. Current work around is to disable the query combiner via: profiling.query_combiner_enabled.



## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
