### PR TITLE
fix(ingestion): Fix mypy error stateful committable & restore mypy version.

### DIFF
--- a/metadata-ingestion/setup.py
+++ b/metadata-ingestion/setup.py
@@ -225,7 +225,7 @@ base_dev_requirements = {
     "flake8>=3.8.3",
     "flake8-tidy-imports>=4.3.0",
     "isort>=5.7.0",
-    "mypy>=0.920,<0.940",
+    "mypy>=0.920",
     # pydantic 1.8.2 is incompatible with mypy 0.910.
     # See https://github.com/samuelcolvin/pydantic/pull/3175#issuecomment-995382910.
     "pydantic>=1.9.0",

--- a/metadata-ingestion/src/datahub/ingestion/api/committable.py
+++ b/metadata-ingestion/src/datahub/ingestion/api/committable.py
@@ -34,9 +34,9 @@ StateType = TypeVar("StateType")
 FilterType = TypeVar("FilterType")
 
 
-@dataclass
 class _StatefulCommittableConcrete(Generic[StateType]):
-    state_to_commit: StateType
+    def __init__(self, state_to_commit: StateType):
+        self.state_to_commit: StateType = state_to_commit
 
 
 class StatefulCommittable(


### PR DESCRIPTION
Fixes the following mypy error and restores the mypy version back.
```
src/datahub/ingestion/api/committable.py:42: error: Cannot override final attribute "__match_args__" (previously declared in base class "_StatefulCommittableConcrete")
src/datahub/ingestion/api/committable.py:42: error: Cannot override writable attribute "__match_args__" with a final one
src/datahub/ingestion/api/committable.py:42: error: Definition of "__match_args__" in base class "_CommittableConcrete" is incompatible with definition in base class "_StatefulCommittableConcrete"
```
## Checklist
- [x] The PR conforms to DataHub's [Contributing Guideline](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/linkedin/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
